### PR TITLE
v2.0: Config-driven routing with role-based skill orchestration

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-claude-skills",
   "description": "Intelligent skill activation hook with phase-aware routing for the design-plan-implement-review-ship pipeline",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "author": {
     "name": "auto-claude-skills contributors"
   },

--- a/config/default-triggers.json
+++ b/config/default-triggers.json
@@ -1,0 +1,271 @@
+{
+  "version": "2.0.0",
+  "skills": [
+    {
+      "name": "systematic-debugging",
+      "role": "process",
+      "phase": "DEBUG",
+      "triggers": [
+        "(debug|bug|fix|broken|fail|error|crash|wrong|unexpected|not.work|regression|issue|problem|doesn.t|won.t|can.t|stuck|hang|freeze|timeout|leak|corrupt|invalid|missing)",
+        "(explain|understand|what.is|what.does|how.does|where.is|find|search|look.at|show.me|trace|investigate|analyze|profile|benchmark|measure|count|list|summarize|describe|walk.me|dig.into)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 10,
+      "precedes": [],
+      "requires": [],
+      "description": "Structured debugging: reproduce, hypothesise, isolate, fix, verify. Returns to the current phase after resolution."
+    },
+    {
+      "name": "test-driven-development",
+      "role": "process",
+      "phase": "IMPLEMENT",
+      "triggers": [
+        "(debug|bug|fix|broken|fail|error|crash|wrong|unexpected|not.work|regression|issue|problem|doesn.t|won.t|can.t|stuck|hang|freeze|timeout|leak|corrupt|invalid|missing)",
+        "(build|create|implement|develop|scaffold|init|bootstrap|brainstorm|design|architect|strateg|scope|outline|approach|add|write|make|generate|set.?up|install|configure|wire.up|connect|integrate|extend|new|start|introduce|enable|support|how.(should|would|could))",
+        "(update|change|modify|edit|alter|adjust|tweak|move|rename|replace|swap|switch|convert|transform|migrate|upgrade|downgrade|bump|patch|optimize|improve|enhance|speed.up|performance|refactor|restructure|reorganize|simplify|consolidate|extract|inline|split|combine)",
+        "(remove|delete|drop|clean|prune|strip|deprecate|disable|turn.off|get.rid|eliminate|unused|dead.code)",
+        "(run|test|execute|verify|validate|check|ensure|confirm|try|attempt|evaluate|assert|expect|coverage|pass|green)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 20,
+      "precedes": [],
+      "requires": [],
+      "description": "Write failing test first, then implement until green. Applied during Fix, Build, Modify, Remove, and Run/Test intents."
+    },
+    {
+      "name": "brainstorming",
+      "role": "process",
+      "phase": "DESIGN",
+      "triggers": [
+        "(build|create|implement|develop|scaffold|init|bootstrap|brainstorm|design|architect|strateg|scope|outline|approach|add|write|make|generate|set.?up|install|configure|wire.up|connect|integrate|extend|new|start|introduce|enable|support|how.(should|would|could))",
+        "(update|change|modify|edit|alter|adjust|tweak|move|rename|replace|swap|switch|convert|transform|migrate|upgrade|downgrade|bump|patch|optimize|improve|enhance|speed.up|performance|refactor|restructure|reorganize|simplify|consolidate|extract|inline|split|combine)",
+        "(remove|delete|drop|clean|prune|strip|deprecate|disable|turn.off|get.rid|eliminate|unused|dead.code)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 30,
+      "precedes": ["writing-plans"],
+      "requires": [],
+      "description": "Ask clarifying questions, explore options, and get user approval before planning. Activated for Build, Modify, and Remove intents."
+    },
+    {
+      "name": "writing-plans",
+      "role": "process",
+      "phase": "PLAN",
+      "triggers": [],
+      "trigger_mode": "regex",
+      "priority": 40,
+      "precedes": ["executing-plans"],
+      "requires": ["brainstorming"],
+      "description": "Break work into discrete tasks and confirm the plan with the user before execution begins."
+    },
+    {
+      "name": "executing-plans",
+      "role": "process",
+      "phase": "IMPLEMENT",
+      "triggers": [
+        "(execute.*plan|run.the.plan|implement.the.plan|implement.*(rest|remaining)|continue|follow.the.plan|pick.up|resume|next.task|next.step|carry.on|keep.going|where.were.we|what.s.next)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 15,
+      "precedes": [],
+      "requires": ["writing-plans"],
+      "description": "Step-by-step execution of an approved plan. Triggered by explicit plan-continuation language."
+    },
+    {
+      "name": "subagent-driven-development",
+      "role": "process",
+      "phase": "IMPLEMENT",
+      "triggers": [
+        "(execute.*plan|run.the.plan|implement.the.plan|implement.*(rest|remaining)|continue|follow.the.plan|pick.up|resume|next.task|next.step|carry.on|keep.going|where.were.we|what.s.next)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 14,
+      "precedes": [],
+      "requires": [],
+      "description": "Delegate plan tasks to sub-agents for parallel implementation. Co-triggered with executing-plans."
+    },
+    {
+      "name": "requesting-code-review",
+      "role": "process",
+      "phase": "REVIEW",
+      "triggers": [
+        "(review|pull.?request|code.?review|check.*(code|changes|diff)|code.?quality|lint|smell|tech.?debt|(^|[^a-z])pr($|[^a-z]))"
+      ],
+      "trigger_mode": "regex",
+      "priority": 50,
+      "precedes": [],
+      "requires": [],
+      "description": "Prepare and request a code review: summarise changes, highlight risks, open a PR."
+    },
+    {
+      "name": "receiving-code-review",
+      "role": "process",
+      "phase": "REVIEW",
+      "triggers": [
+        "(review|pull.?request|code.?review|check.*(code|changes|diff)|code.?quality|lint|smell|tech.?debt|(^|[^a-z])pr($|[^a-z]))"
+      ],
+      "trigger_mode": "regex",
+      "priority": 51,
+      "precedes": [],
+      "requires": [],
+      "description": "Process incoming review feedback: address comments, push fixes, re-request review."
+    },
+    {
+      "name": "verification-before-completion",
+      "role": "workflow",
+      "triggers": [
+        "(ship|merge|deploy|push|release|tag|publish|pr.ready|ready.to|wrap.?up|all.(done|good|green|passing)|lgtm|finalize|complete|finish)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 60,
+      "precedes": ["finishing-a-development-branch"],
+      "requires": [],
+      "description": "Final verification checklist before shipping: tests pass, lint clean, no TODOs, docs updated."
+    },
+    {
+      "name": "finishing-a-development-branch",
+      "role": "workflow",
+      "triggers": [
+        "(ship|merge|deploy|push|release|tag|publish|pr.ready|ready.to|wrap.?up|all.(done|good|green|passing)|lgtm|finalize|complete|finish)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 61,
+      "precedes": [],
+      "requires": ["verification-before-completion"],
+      "description": "Branch cleanup and merge: squash commits, update changelog, merge to main."
+    },
+    {
+      "name": "dispatching-parallel-agents",
+      "role": "workflow",
+      "triggers": [
+        "(parallel|concurrent|multiple.*(failure|bug|issue|error|test)|independent.*(task|failure|bug|issue|test)|worktree)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 70,
+      "precedes": [],
+      "requires": [],
+      "description": "Fan out independent tasks to parallel sub-agents and collect results."
+    },
+    {
+      "name": "using-git-worktrees",
+      "role": "workflow",
+      "triggers": [
+        "(parallel|concurrent|multiple.*(failure|bug|issue|error|test)|independent.*(task|failure|bug|issue|test)|worktree)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 71,
+      "precedes": [],
+      "requires": [],
+      "description": "Use git worktrees to enable parallel work on multiple branches without stashing."
+    },
+    {
+      "name": "writing-skills",
+      "role": "domain",
+      "triggers": [
+        "(claude\\.md|claude.md|\\.claude|skill|hook|mcp|plugin)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 100,
+      "precedes": [],
+      "requires": [],
+      "description": "Author and maintain Claude Code skill files (SKILL.md). Meta-overlay for Claude tooling prompts."
+    },
+    {
+      "name": "frontend-design",
+      "role": "domain",
+      "triggers": [
+        "(^|[^a-z])(ui|frontend|component|layout|style|css|tailwind|responsive|dashboard|landing.?page|mockup|wireframe)($|[^a-z])"
+      ],
+      "trigger_mode": "regex",
+      "priority": 101,
+      "precedes": [],
+      "requires": [],
+      "description": "UI/UX design guidance: component structure, responsive layout, styling, and visual prototyping."
+    },
+    {
+      "name": "security-scanner",
+      "role": "domain",
+      "triggers": [
+        "(secur(e|ity)|vulnerab|owasp|pentest|attack|exploit|compliance|hipaa|gdpr|encrypt|auth(entication|orization)|inject|xss|csrf|sanitiz|supply.?chain)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 102,
+      "precedes": [],
+      "requires": [],
+      "description": "Security analysis overlay: scan for vulnerabilities, OWASP risks, compliance issues, and supply-chain threats."
+    },
+    {
+      "name": "webapp-testing",
+      "role": "domain",
+      "triggers": [
+        "(^|[^a-z])(ui|frontend|component|layout|style|css|tailwind|responsive|dashboard|landing.?page|mockup|wireframe)($|[^a-z])"
+      ],
+      "trigger_mode": "regex",
+      "priority": 103,
+      "precedes": [],
+      "requires": [],
+      "description": "Web application testing: browser automation, accessibility checks, visual regression, and E2E flows."
+    },
+    {
+      "name": "doc-coauthoring",
+      "role": "domain",
+      "triggers": [
+        "(proposal|spec[^a-z]|rfc|write.?up|technical.?doc|architecture.?doc|documentation)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 104,
+      "precedes": [],
+      "requires": [],
+      "description": "Co-author technical documents: proposals, specs, RFCs, and architecture docs."
+    },
+    {
+      "name": "claude-automation-recommender",
+      "role": "domain",
+      "triggers": [
+        "(claude\\.md|claude.md|\\.claude|skill|hook|mcp|plugin)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 105,
+      "precedes": [],
+      "requires": [],
+      "description": "Recommend Claude Code automation setups: hooks, MCP servers, plugins, and workflow optimisations."
+    },
+    {
+      "name": "claude-md-improver",
+      "role": "domain",
+      "triggers": [
+        "(claude\\.md|claude.md|\\.claude|skill|hook|mcp|plugin)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 106,
+      "precedes": [],
+      "requires": [],
+      "description": "Improve CLAUDE.md project files: structure, clarity, and completeness of project instructions."
+    }
+  ],
+  "methodology_hints": [
+    {
+      "name": "ralph-loop",
+      "triggers": [
+        "(migrate|refactor.all|fix.all|batch|overnight|autonom|iterate|keep.(going|trying|fixing)|until.*(pass|work|complet|succeed)|make.*tests?.pass|run.*until|loop|coverage|greenfield)"
+      ],
+      "trigger_mode": "regex",
+      "hint": "RALPH LOOP: Consider /ralph-loop for autonomous iteration."
+    },
+    {
+      "name": "pr-review",
+      "triggers": [
+        "(review|pull.?request|code.?review|(^|[^a-z])pr($|[^a-z]))"
+      ],
+      "trigger_mode": "regex",
+      "hint": "PR REVIEW: Consider /pr-review for structured review."
+    }
+  ],
+  "blocklist_patterns": [
+    {
+      "pattern": "^(hi|hello|hey|thanks|thank.you|good.(morning|afternoon|evening)|bye|goodbye|ok|okay|yes|no|sure|yep|nope|got.it|sounds.good|cool|nice|great|perfect|awesome|understood)([[:space:]!.,]+.{0,20})?$",
+      "description": "Greeting or short acknowledgement -- not a dev task. Allow short trailing words but not full sentences.",
+      "max_tail_length": 20
+    }
+  ]
+}

--- a/config/fallback-registry.json
+++ b/config/fallback-registry.json
@@ -1,0 +1,73 @@
+{
+  "version": "2.0.0-fallback",
+  "description": "Static fallback registry for degraded environments (no jq, missing plugin dirs)",
+  "warnings": [
+    "Using static fallback registry — dynamic discovery unavailable"
+  ],
+  "skills": [
+    {
+      "name": "brainstorming",
+      "role": "Explore ideas, ask clarifying questions, get design approval before building",
+      "invoke": "Skill(superpowers:brainstorming)",
+      "phase": "DESIGN",
+      "triggers": ["brainstorm", "design", "architect", "scope", "outline", "approach", "how should"],
+      "priority": 10
+    },
+    {
+      "name": "writing-plans",
+      "role": "Break work into structured tasks and confirm the plan before execution",
+      "invoke": "Skill(superpowers:writing-plans)",
+      "phase": "PLAN",
+      "triggers": ["plan", "break down", "task list", "steps", "outline tasks", "spec"],
+      "priority": 20
+    },
+    {
+      "name": "executing-plans",
+      "role": "Systematically implement a confirmed plan, task by task",
+      "invoke": "Skill(superpowers:executing-plans)",
+      "phase": "IMPLEMENT",
+      "triggers": ["execute plan", "implement plan", "follow the plan", "next task", "continue", "pick up"],
+      "priority": 30
+    },
+    {
+      "name": "test-driven-development",
+      "role": "Write tests first, then implement to make them pass",
+      "invoke": "Skill(superpowers:test-driven-development)",
+      "phase": "IMPLEMENT",
+      "triggers": ["tdd", "test first", "write tests", "test driven", "red green refactor"],
+      "priority": 31
+    },
+    {
+      "name": "systematic-debugging",
+      "role": "Methodically isolate and fix bugs using structured investigation",
+      "invoke": "Skill(superpowers:systematic-debugging)",
+      "phase": "DEBUG",
+      "triggers": ["debug", "bug", "fix", "broken", "error", "crash", "failing", "not working", "regression"],
+      "priority": 5
+    },
+    {
+      "name": "requesting-code-review",
+      "role": "Prepare and request a structured code review",
+      "invoke": "Skill(superpowers:requesting-code-review)",
+      "phase": "REVIEW",
+      "triggers": ["review", "code review", "pull request", "pr", "check changes", "diff"],
+      "priority": 40
+    },
+    {
+      "name": "verification-before-completion",
+      "role": "Run final checks before declaring work complete",
+      "invoke": "Skill(superpowers:verification-before-completion)",
+      "phase": "SHIP",
+      "triggers": ["verify", "final check", "ready to ship", "all green", "all passing", "lgtm"],
+      "priority": 50
+    },
+    {
+      "name": "finishing-a-development-branch",
+      "role": "Clean up, squash, and prepare a branch for merge",
+      "invoke": "Skill(superpowers:finishing-a-development-branch)",
+      "phase": "SHIP",
+      "triggers": ["finish", "ship", "merge", "wrap up", "finalize", "complete branch", "push"],
+      "priority": 51
+    }
+  ]
+}

--- a/docs/plans/2026-02-15-v2-architecture-design.md
+++ b/docs/plans/2026-02-15-v2-architecture-design.md
@@ -1,0 +1,315 @@
+# auto-claude-skills v2.0 Architecture Design
+
+**Date**: 2026-02-15
+**Status**: Approved
+**Scope**: Full rethink — config-driven core with smart defaults
+**Audience**: Broad developer audience
+
+## Philosophy
+
+"Claude IS the classifier" — the hook is a fast pre-filter that narrows possibilities, then Claude makes the final routing decision with full conversation context. No separate LLM calls, no external APIs.
+
+## 1. Skill Registry & Dynamic Discovery
+
+Replace the hardcoded `skill_path()` case statement with an auto-generated `skills-registry.json`.
+
+### SessionStart scan sources
+
+1. `~/.claude/plugins/cache/*/` — all installed plugins with skills
+2. `~/.claude/skills/*/SKILL.md` — user-installed standalone skills
+3. Built-in defaults shipped with auto-claude-skills
+
+### Registry entry format
+
+```json
+{
+  "name": "brainstorming",
+  "source": "superpowers",
+  "role": "process",
+  "invoke": "Skill(superpowers:brainstorming)",
+  "phase": ["DESIGN"],
+  "triggers": ["build", "create", "add", "design", "new"],
+  "precedes": ["writing-plans"],
+  "description": "Explore requirements before implementation"
+}
+```
+
+### Trigger definitions
+
+Ship as `config/default-triggers.json` — the curated starter pack. Users can override with `~/.claude/skill-config.json`.
+
+### Caching
+
+Registry cached to `~/.claude/.skill-registry-cache.json` so UserPromptSubmit reads a file, not re-scans.
+
+## 2. Routing Engine Redesign
+
+Replace 8 hardcoded regex blocks with a generic matcher that reads trigger patterns from the registry.
+
+### Matching
+
+1. Iterate registry entries, test each skill's triggers against the lowercased prompt.
+2. Collect all matches with priority scores.
+
+### Scoring
+
+- Exact keyword match: score 3
+- Partial/substring match: score 1
+- Phase-aligned: +2 bonus
+- Result: ranked list, not first-match-wins
+
+### Skill roles & category caps
+
+| Role | Behavior | Cap | Examples |
+|------|----------|-----|---------|
+| **Process** | Drives the current phase. Sequenced by phase order. | 1 | brainstorming, writing-plans, TDD, debugging |
+| **Domain** | Specialized knowledge. Active alongside any process skill. Phase-independent. | 2 | frontend-design, security-scanner, doc-coauthoring |
+| **Workflow** | Lifecycle actions. Triggered by specific moments. | 1 | finishing-branch, dispatching-parallel-agents |
+
+Maximum 3 skills suggested per prompt (configurable).
+
+### Blocklist stays
+
+Greeting/chat detection short-circuits before any matching. Simple, fast, proven.
+
+## 3. Context Injection
+
+Adaptive output scaled to match confidence and count.
+
+### Three injection tiers
+
+**Zero skills matched** (dev prompt, no triggers):
+```
+SKILL ACTIVATION (0 skills | phase checkpoint only)
+
+Phase: assess current phase (DESIGN/PLAN/IMPLEMENT/REVIEW/SHIP/DEBUG)
+and consider whether any installed skill applies.
+```
+
+**1-2 skills, strong match**:
+```
+SKILL ACTIVATION (2 skills | Fix Bug)
+
+Strong: systematic-debugging -> Skill(superpowers:systematic-debugging)
+Weak: test-driven-development -> Skill(superpowers:test-driven-development)
+
+Evaluate each: **Phase: [PHASE]** | skill1 YES/NO, skill2 YES/NO
+```
+
+**3 skills or mixed confidence**: Full format with skills grouped by confidence tier.
+
+### Phase map at session start
+
+Inject the DESIGN->PLAN->IMPLEMENT->REVIEW->SHIP->DEBUG map once at SessionStart. Per-prompt injection only references "assess current phase."
+
+### Invocation hints inline
+
+Include the exact `Skill(...)` or `Read ...` call in the context. Claude doesn't have to figure out how to invoke.
+
+### Visible evaluation line stays mandatory
+
+`**Phase: X** | skill1 YES/NO` format from v1.2.0 is retained.
+
+## 4. Test Harness
+
+Lightweight bash test framework validating all deterministic parts of the system.
+
+### Test runner
+
+`tests/run-tests.sh` — no dependencies beyond bash and jq. Target: <5 seconds.
+
+### Test categories
+
+**Registry tests** (`tests/test-registry.sh`):
+- Scan finds skills from all three sources
+- Cache file is valid JSON
+- Missing plugin dirs don't cause errors
+- Duplicate skills handled
+
+**Routing tests** (`tests/test-routing.sh`):
+- Feed prompts, assert expected skill selections:
+  ```bash
+  assert_matches "fix the login bug"        "systematic-debugging"
+  assert_matches "build a new API endpoint"  "brainstorming"
+  assert_matches "hey how are you"           ""
+  ```
+- Test scoring: "build a React component" ranks frontend-design higher
+- Test category caps: never more than 3 skills
+
+**Context injection tests** (`tests/test-context.sh`):
+- 0 skills -> minimal output
+- 1-2 strong matches -> compact format
+- 3+ matches -> full format
+- Invocation hints syntactically correct
+
+**Install/uninstall tests** (`tests/test-install.sh`):
+- Install into temp dir, verify files
+- Uninstall, verify clean removal
+- Idempotent install
+
+### Test isolation
+
+Each test creates a temp directory with mock plugin caches. No dependency on actual installed skills.
+
+## 5. Multi-Skill Orchestration
+
+Skills declare relationships. Context injection includes a sequenced execution plan, not a flat list.
+
+### Composition model
+
+**Process skills drive.** One active at a time. Selected by phase + trigger match.
+
+**Domain skills inform.** Active alongside whatever process skill is running. Phase-independent. Multiple can be co-active.
+
+**Workflow skills are standalone.** Fire on specific trigger conditions.
+
+### Orchestrated context output
+
+```
+SKILL ACTIVATION (3 skills | Build Dashboard)
+
+Process: brainstorming -> Skill(superpowers:brainstorming)
+  INFORMED BY: frontend-design -> Skill(frontend-design:frontend-design)
+  INFORMED BY: security-scanner -> Read ~/.claude/skills/security-scanner/SKILL.md
+
+Invoke brainstorming as the driving skill.
+Invoke frontend-design and security-scanner to provide domain guidance.
+
+Evaluate: **Phase: [PHASE]** | brainstorming YES/NO, frontend-design YES/NO, security-scanner YES/NO
+```
+
+### Composition keywords
+
+- `INFORMED BY` — domain skill provides context within the process skill's workflow
+- `THEN` — sequential process skill handoff (e.g., brainstorming THEN writing-plans)
+- `WITH` — co-active skills in the same phase
+
+### Relationship metadata
+
+```json
+{
+  "precedes": ["writing-plans"],
+  "requires": ["writing-plans"],
+  "alongside": ["frontend-design"]
+}
+```
+
+- `precedes` — invoke me before these
+- `requires` — these should have run earlier in the session
+- `alongside` — can run in parallel/same phase
+
+### Phase-skip detection
+
+Applies to process skills only. If session is past DESIGN phase, brainstorming gets skipped. Domain skills are never skipped by phase.
+
+## 6. Error Handling & Graceful Degradation
+
+Principle: never silently swallow a problem, but never block the user either.
+
+### Registry build failures (SessionStart)
+
+| Failure | Behavior |
+|---------|----------|
+| Plugin cache dir missing | Skip source, log warning in registry |
+| jq not installed | Fall back to bundled static registry |
+| Malformed plugin manifest | Skip that plugin, include warning |
+| Timeout (>10s) | Use stale cache or static fallback |
+
+Registry includes `"warnings": []` array. Empty = clean.
+
+### Routing failures (UserPromptSubmit)
+
+| Failure | Behavior |
+|---------|----------|
+| Registry cache missing | Rebuild on the fly (~200ms), or static fallback |
+| Invalid JSON cache | Delete, rebuild, or static fallback |
+| Hook timeout approaching | Emit matches found so far |
+
+### Missing skills surfaced
+
+```
+INFORMED BY: security-scanner -> Read ~/.claude/skills/security-scanner/SKILL.md
+  (not installed — run /setup to install, or skip)
+```
+
+### Startup health check
+
+```
+SessionStart: skill registry built (14 skills from 3 sources, 0 warnings)
+```
+
+### Static fallback registry
+
+`config/fallback-registry.json` — hardcoded minimal registry with core skills. Used when dynamic discovery completely fails.
+
+## 7. User Configuration
+
+Single optional config file: `~/.claude/skill-config.json`.
+
+### Format
+
+```json
+{
+  "overrides": {
+    "brainstorming": {
+      "triggers": ["+prototype", "+spike", "-design"],
+      "enabled": true
+    },
+    "security-scanner": {
+      "enabled": false
+    }
+  },
+  "custom_skills": [
+    {
+      "name": "my-team-conventions",
+      "role": "domain",
+      "invoke": "Read ~/.claude/skills/team-conventions/SKILL.md",
+      "triggers": ["review", "refactor", "new file"],
+      "description": "Team-specific coding standards"
+    }
+  ],
+  "settings": {
+    "max_suggestions": 3,
+    "verbosity": "normal"
+  }
+}
+```
+
+### Trigger override syntax
+
+- `"+keyword"` — add to existing defaults
+- `"-keyword"` — remove from defaults
+- `"keyword"` (no prefix) — replace all defaults
+
+### Settings
+
+- `max_suggestions` — cap on total skills per prompt (default 3)
+- `verbosity` — `"minimal"` | `"normal"` | `"verbose"`
+
+### Merge order
+
+static fallback -> dynamic discovery -> starter pack triggers -> user config overrides
+
+### Zero-config by default
+
+The entire config file is optional. No config = full curated experience.
+
+## Key Files in v2.0
+
+| File | Purpose |
+|------|---------|
+| `hooks/skill-activation-hook.sh` | Generic routing engine (reads registry) |
+| `hooks/session-start-hook.sh` | Registry builder + health check |
+| `config/default-triggers.json` | Starter pack trigger definitions |
+| `config/fallback-registry.json` | Static fallback for degraded environments |
+| `tests/run-tests.sh` | Test runner |
+| `tests/test-registry.sh` | Registry build tests |
+| `tests/test-routing.sh` | Prompt->skill matching tests |
+| `tests/test-context.sh` | Context injection format tests |
+| `tests/test-install.sh` | Install/uninstall tests |
+| `~/.claude/skill-config.json` | Optional user overrides (not shipped) |
+| `~/.claude/.skill-registry-cache.json` | Generated at session start |
+
+## Backwards Compatibility
+
+v1.x users get the new behavior automatically on update. No migration needed — the registry builder discovers the same skills the hardcoded paths did.

--- a/docs/plans/2026-02-15-v2-implementation-plan.md
+++ b/docs/plans/2026-02-15-v2-implementation-plan.md
@@ -1,0 +1,1503 @@
+# auto-claude-skills v2.0 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Rewrite auto-claude-skills as a config-driven, role-based skill activation system with tests, adaptive context injection, and multi-skill orchestration.
+
+**Architecture:** Replace hardcoded regex/skill mappings with a JSON registry built at session start from dynamic discovery. The routing engine reads the registry, scores matches by trigger+phase, selects skills by role (process/domain/workflow), and emits orchestrated context. A test harness validates all deterministic behavior.
+
+**Tech Stack:** Bash 3.2+ (macOS compatible), jq, JSON config files
+
+---
+
+### Task 1: Create default-triggers.json (starter pack)
+
+**Files:**
+- Create: `config/default-triggers.json`
+
+This is the curated trigger/role/relationship definitions for all known skills. The routing engine and registry builder both consume this file.
+
+**Step 1: Create config directory and default-triggers.json**
+
+```json
+{
+  "skills": [
+    {
+      "name": "brainstorming",
+      "role": "process",
+      "phase": ["DESIGN"],
+      "triggers": ["build", "create", "implement", "develop", "scaffold", "init", "bootstrap", "brainstorm", "design", "architect", "strateg", "scope", "outline", "approach", "add", "write", "make", "generate", "set.?up", "install", "configure", "wire.up", "connect", "integrate", "extend", "new", "start", "introduce", "enable", "support", "how.(should|would|could)"],
+      "trigger_mode": "regex",
+      "priority": 30,
+      "precedes": ["writing-plans"],
+      "description": "Explore intent and requirements before implementation"
+    },
+    {
+      "name": "writing-plans",
+      "role": "process",
+      "phase": ["PLAN"],
+      "triggers": ["plan", "break.down", "outline.steps", "task.list", "implementation.plan"],
+      "trigger_mode": "regex",
+      "priority": 25,
+      "precedes": ["executing-plans", "subagent-driven-development"],
+      "requires": ["brainstorming"],
+      "description": "Break spec into bite-sized implementation tasks"
+    },
+    {
+      "name": "executing-plans",
+      "role": "process",
+      "phase": ["IMPLEMENT"],
+      "triggers": ["execute.*plan", "run.the.plan", "implement.the.plan", "implement.*(rest|remaining)", "follow.the.plan", "pick.up", "resume", "next.task", "next.step", "carry.on", "keep.going", "where.were.we", "what.s.next", "continue"],
+      "trigger_mode": "regex",
+      "priority": 20,
+      "requires": ["writing-plans"],
+      "description": "Execute implementation plan task-by-task"
+    },
+    {
+      "name": "subagent-driven-development",
+      "role": "process",
+      "phase": ["IMPLEMENT"],
+      "triggers": ["execute.*plan", "run.the.plan", "implement.the.plan", "implement.*(rest|remaining)", "follow.the.plan", "pick.up", "resume", "next.task", "next.step", "carry.on", "keep.going", "where.were.we", "what.s.next", "continue"],
+      "trigger_mode": "regex",
+      "priority": 20,
+      "requires": ["writing-plans"],
+      "description": "Execute plan with fresh subagent per task"
+    },
+    {
+      "name": "test-driven-development",
+      "role": "process",
+      "phase": ["IMPLEMENT"],
+      "triggers": ["test", "tdd", "run", "execute", "verify", "validate", "check", "ensure", "confirm", "try", "attempt", "evaluate", "assert", "expect", "coverage", "pass", "green"],
+      "trigger_mode": "regex",
+      "priority": 15,
+      "description": "Write failing test first, then implement"
+    },
+    {
+      "name": "systematic-debugging",
+      "role": "process",
+      "phase": ["DEBUG"],
+      "triggers": ["debug", "bug", "fix", "broken", "fail", "error", "crash", "wrong", "unexpected", "not.work", "regression", "issue", "problem", "doesn.t", "won.t", "can.t", "stuck", "hang", "freeze", "timeout", "leak", "corrupt", "invalid", "missing", "explain", "understand", "what.is", "what.does", "how.does", "where.is", "find", "search", "look.at", "show.me", "trace", "investigate", "analyze", "profile", "benchmark"],
+      "trigger_mode": "regex",
+      "priority": 40,
+      "description": "Systematic root-cause analysis before fixing"
+    },
+    {
+      "name": "requesting-code-review",
+      "role": "process",
+      "phase": ["REVIEW"],
+      "triggers": ["review", "pull.?request", "code.?review", "check.*(code|changes|diff)", "code.?quality", "lint", "smell", "tech.?debt", "pr($|[^a-z])"],
+      "trigger_mode": "regex",
+      "priority": 20,
+      "description": "Request structured code review"
+    },
+    {
+      "name": "receiving-code-review",
+      "role": "process",
+      "phase": ["REVIEW"],
+      "triggers": ["review", "pull.?request", "code.?review", "pr($|[^a-z])"],
+      "trigger_mode": "regex",
+      "priority": 19,
+      "description": "Process code review feedback with technical rigor"
+    },
+    {
+      "name": "verification-before-completion",
+      "role": "workflow",
+      "triggers": ["ship", "merge", "deploy", "push", "release", "tag", "publish", "pr.ready", "ready.to", "wrap.?up", "all.(done|good|green|passing)", "lgtm", "finalize", "complete", "finish"],
+      "trigger_mode": "regex",
+      "priority": 20,
+      "description": "Run verification before claiming work is done"
+    },
+    {
+      "name": "finishing-a-development-branch",
+      "role": "workflow",
+      "triggers": ["ship", "merge", "deploy", "push", "release", "tag", "publish", "pr.ready", "ready.to", "wrap.?up", "finalize", "complete", "finish"],
+      "trigger_mode": "regex",
+      "priority": 19,
+      "description": "Guide branch completion — merge, PR, or cleanup"
+    },
+    {
+      "name": "dispatching-parallel-agents",
+      "role": "workflow",
+      "triggers": ["parallel", "concurrent", "multiple.*(failure|bug|issue|error|test)", "independent.*(task|failure|bug|issue|test)"],
+      "trigger_mode": "regex",
+      "priority": 15,
+      "description": "Dispatch independent tasks to parallel agents"
+    },
+    {
+      "name": "using-git-worktrees",
+      "role": "workflow",
+      "triggers": ["worktree", "parallel", "isolat"],
+      "trigger_mode": "regex",
+      "priority": 10,
+      "description": "Create isolated git worktrees for feature work"
+    },
+    {
+      "name": "writing-skills",
+      "role": "domain",
+      "triggers": ["skill", "hook", "plugin"],
+      "trigger_mode": "regex",
+      "priority": 10,
+      "description": "Create or edit Claude Code skills"
+    },
+    {
+      "name": "frontend-design",
+      "role": "domain",
+      "triggers": ["ui", "frontend", "component", "layout", "style", "css", "tailwind", "responsive", "dashboard", "landing.?page", "mockup", "wireframe", "modal", "form", "button", "page"],
+      "trigger_mode": "regex",
+      "priority": 15,
+      "description": "Specialized frontend design guidance"
+    },
+    {
+      "name": "security-scanner",
+      "role": "domain",
+      "triggers": ["secur(e|ity)", "vulnerab", "owasp", "pentest", "attack", "exploit", "compliance", "hipaa", "gdpr", "encrypt", "auth(entication|orization)", "inject", "xss", "csrf", "sanitiz", "supply.?chain"],
+      "trigger_mode": "regex",
+      "priority": 15,
+      "description": "Scan for security vulnerabilities"
+    },
+    {
+      "name": "webapp-testing",
+      "role": "domain",
+      "triggers": ["ui", "frontend", "component", "browser", "playwright", "screenshot", "visual"],
+      "trigger_mode": "regex",
+      "priority": 10,
+      "description": "Test web apps with Playwright"
+    },
+    {
+      "name": "doc-coauthoring",
+      "role": "domain",
+      "triggers": ["proposal", "spec[^a-z]", "rfc", "write.?up", "technical.?doc", "architecture.?doc", "documentation"],
+      "trigger_mode": "regex",
+      "priority": 15,
+      "description": "Co-author structured documentation"
+    },
+    {
+      "name": "claude-automation-recommender",
+      "role": "domain",
+      "triggers": ["claude\\.md", "claude.md", "\\.claude", "skill", "hook", "mcp", "plugin", "automation"],
+      "trigger_mode": "regex",
+      "priority": 10,
+      "description": "Recommend Claude Code automations"
+    },
+    {
+      "name": "claude-md-improver",
+      "role": "domain",
+      "triggers": ["claude\\.md", "claude.md", "project.memory"],
+      "trigger_mode": "regex",
+      "priority": 10,
+      "description": "Audit and improve CLAUDE.md files"
+    }
+  ],
+  "methodology_hints": [
+    {
+      "name": "ralph-loop",
+      "plugin": "ralph-loop",
+      "triggers": ["migrate", "refactor.all", "fix.all", "batch", "overnight", "autonom", "iterate", "keep.(going|trying|fixing)", "until.*(pass|work|complet|succeed)", "make.*tests?.pass", "run.*until", "loop", "coverage", "greenfield"],
+      "hint": "RALPH LOOP: Consider /ralph-loop for autonomous iteration."
+    },
+    {
+      "name": "pr-review",
+      "plugin": "pr-review-toolkit",
+      "triggers": ["review", "pull.?request", "code.?review", "pr($|[^a-z])"],
+      "hint": "PR REVIEW: Consider /pr-review for structured review."
+    }
+  ],
+  "blocklist_patterns": [
+    "^(hi|hello|hey|thanks|thank.you|good.(morning|afternoon|evening)|bye|goodbye|ok|okay|yes|no|sure|yep|nope|got.it|sounds.good|cool|nice|great|perfect|awesome|understood)([[:space:]!.,]+.{0,20})?$"
+  ],
+  "version": "2.0.0"
+}
+```
+
+**Step 2: Verify JSON is valid**
+
+Run: `jq . config/default-triggers.json`
+Expected: Pretty-printed JSON, no errors
+
+**Step 3: Commit**
+
+```bash
+git add config/default-triggers.json
+git commit -m "feat: add default-triggers.json starter pack config"
+```
+
+---
+
+### Task 2: Create fallback-registry.json (static fallback)
+
+**Files:**
+- Create: `config/fallback-registry.json`
+
+This is the minimal static registry used when dynamic discovery fails (no jq, missing plugin dirs, etc). Contains core superpowers skills with `Skill()` invocation paths.
+
+**Step 1: Create fallback-registry.json**
+
+```json
+{
+  "skills": [
+    {
+      "name": "brainstorming",
+      "role": "process",
+      "invoke": "Skill(superpowers:brainstorming)",
+      "phase": ["DESIGN"],
+      "triggers": ["build", "create", "add", "design", "new", "implement"],
+      "priority": 30,
+      "precedes": ["writing-plans"]
+    },
+    {
+      "name": "writing-plans",
+      "role": "process",
+      "invoke": "Skill(superpowers:writing-plans)",
+      "phase": ["PLAN"],
+      "triggers": ["plan", "break.down", "outline.steps"],
+      "priority": 25,
+      "precedes": ["executing-plans"]
+    },
+    {
+      "name": "executing-plans",
+      "role": "process",
+      "invoke": "Skill(superpowers:executing-plans)",
+      "phase": ["IMPLEMENT"],
+      "triggers": ["execute.*plan", "continue", "next.task", "resume"],
+      "priority": 20
+    },
+    {
+      "name": "test-driven-development",
+      "role": "process",
+      "invoke": "Skill(superpowers:test-driven-development)",
+      "phase": ["IMPLEMENT"],
+      "triggers": ["test", "tdd", "verify", "validate"],
+      "priority": 15
+    },
+    {
+      "name": "systematic-debugging",
+      "role": "process",
+      "invoke": "Skill(superpowers:systematic-debugging)",
+      "phase": ["DEBUG"],
+      "triggers": ["debug", "bug", "fix", "broken", "error", "crash"],
+      "priority": 40
+    },
+    {
+      "name": "requesting-code-review",
+      "role": "process",
+      "invoke": "Skill(superpowers:requesting-code-review)",
+      "phase": ["REVIEW"],
+      "triggers": ["review", "code.?review"],
+      "priority": 20
+    },
+    {
+      "name": "verification-before-completion",
+      "role": "workflow",
+      "invoke": "Skill(superpowers:verification-before-completion)",
+      "triggers": ["ship", "merge", "deploy", "finish", "complete"],
+      "priority": 20
+    },
+    {
+      "name": "finishing-a-development-branch",
+      "role": "workflow",
+      "invoke": "Skill(superpowers:finishing-a-development-branch)",
+      "triggers": ["ship", "merge", "finish", "complete", "pr.ready"],
+      "priority": 19
+    }
+  ],
+  "warnings": ["Using static fallback registry — dynamic discovery unavailable"],
+  "version": "2.0.0-fallback"
+}
+```
+
+**Step 2: Verify JSON is valid**
+
+Run: `jq . config/fallback-registry.json`
+Expected: Pretty-printed JSON, no errors
+
+**Step 3: Commit**
+
+```bash
+git add config/fallback-registry.json
+git commit -m "feat: add fallback-registry.json for degraded environments"
+```
+
+---
+
+### Task 3: Create test harness framework
+
+**Files:**
+- Create: `tests/test-helpers.sh`
+- Create: `tests/run-tests.sh`
+
+The test framework provides assert functions and a runner that discovers and executes test files. No external dependencies beyond bash.
+
+**Step 1: Create tests/test-helpers.sh**
+
+```bash
+#!/bin/bash
+# --- Test helpers for auto-claude-skills ---
+# Source this file in each test script.
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+FAIL_MESSAGES=""
+
+# Create isolated temp environment
+setup_test_env() {
+  TEST_HOME=$(mktemp -d)
+  TEST_PLUGIN_CACHE="$TEST_HOME/.claude/plugins/cache/claude-plugins-official"
+  TEST_USER_SKILLS="$TEST_HOME/.claude/skills"
+  TEST_REGISTRY_CACHE="$TEST_HOME/.claude/.skill-registry-cache.json"
+  TEST_USER_CONFIG="$TEST_HOME/.claude/skill-config.json"
+  mkdir -p "$TEST_PLUGIN_CACHE" "$TEST_USER_SKILLS"
+
+  # Point hooks at test environment
+  export HOME="$TEST_HOME"
+  export CLAUDE_PLUGIN_ROOT="${SCRIPT_DIR}/.."
+}
+
+teardown_test_env() {
+  [[ -n "${TEST_HOME:-}" ]] && rm -rf "$TEST_HOME"
+}
+
+assert_equals() {
+  local description="$1"
+  local expected="$2"
+  local actual="$3"
+  ((TESTS_RUN++))
+  if [[ "$expected" == "$actual" ]]; then
+    ((TESTS_PASSED++))
+    echo "  PASS: $description"
+  else
+    ((TESTS_FAILED++))
+    FAIL_MESSAGES+="  FAIL: $description\n    expected: $expected\n    actual:   $actual\n"
+    echo "  FAIL: $description"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+assert_contains() {
+  local description="$1"
+  local needle="$2"
+  local haystack="$3"
+  ((TESTS_RUN++))
+  if echo "$haystack" | grep -q "$needle"; then
+    ((TESTS_PASSED++))
+    echo "  PASS: $description"
+  else
+    ((TESTS_FAILED++))
+    FAIL_MESSAGES+="  FAIL: $description\n    expected to contain: $needle\n    actual: ${haystack:0:200}\n"
+    echo "  FAIL: $description"
+    echo "    expected to contain: $needle"
+    echo "    actual: ${haystack:0:200}"
+  fi
+}
+
+assert_not_contains() {
+  local description="$1"
+  local needle="$2"
+  local haystack="$3"
+  ((TESTS_RUN++))
+  if ! echo "$haystack" | grep -q "$needle"; then
+    ((TESTS_PASSED++))
+    echo "  PASS: $description"
+  else
+    ((TESTS_FAILED++))
+    FAIL_MESSAGES+="  FAIL: $description\n    expected NOT to contain: $needle\n"
+    echo "  FAIL: $description"
+    echo "    expected NOT to contain: $needle"
+  fi
+}
+
+assert_json_valid() {
+  local description="$1"
+  local file="$2"
+  ((TESTS_RUN++))
+  if jq . "$file" > /dev/null 2>&1; then
+    ((TESTS_PASSED++))
+    echo "  PASS: $description"
+  else
+    ((TESTS_FAILED++))
+    FAIL_MESSAGES+="  FAIL: $description\n    $file is not valid JSON\n"
+    echo "  FAIL: $description"
+    echo "    $file is not valid JSON"
+  fi
+}
+
+assert_file_exists() {
+  local description="$1"
+  local file="$2"
+  ((TESTS_RUN++))
+  if [[ -f "$file" ]]; then
+    ((TESTS_PASSED++))
+    echo "  PASS: $description"
+  else
+    ((TESTS_FAILED++))
+    FAIL_MESSAGES+="  FAIL: $description\n    file not found: $file\n"
+    echo "  FAIL: $description"
+    echo "    file not found: $file"
+  fi
+}
+
+print_summary() {
+  echo ""
+  echo "--- Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed ---"
+  if ((TESTS_FAILED > 0)); then
+    echo ""
+    printf '%b' "$FAIL_MESSAGES"
+    return 1
+  fi
+  return 0
+}
+```
+
+**Step 2: Create tests/run-tests.sh**
+
+```bash
+#!/bin/bash
+# --- Test runner for auto-claude-skills ---
+# Discovers and runs all tests/test-*.sh files.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TOTAL_PASSED=0
+TOTAL_FAILED=0
+TOTAL_RUN=0
+
+echo "========================================="
+echo " auto-claude-skills test suite"
+echo "========================================="
+echo ""
+
+for test_file in "$SCRIPT_DIR"/test-*.sh; do
+  [[ ! -f "$test_file" ]] && continue
+  test_name=$(basename "$test_file" .sh)
+  echo "--- $test_name ---"
+
+  output=$(bash "$test_file" 2>&1)
+  exit_code=$?
+  echo "$output"
+
+  # Extract counts from output
+  passed=$(echo "$output" | grep -c "PASS:" || true)
+  failed=$(echo "$output" | grep -c "FAIL:" || true)
+  run=$((passed + failed))
+
+  TOTAL_PASSED=$((TOTAL_PASSED + passed))
+  TOTAL_FAILED=$((TOTAL_FAILED + failed))
+  TOTAL_RUN=$((TOTAL_RUN + run))
+  echo ""
+done
+
+echo "========================================="
+echo " TOTAL: $TOTAL_PASSED/$TOTAL_RUN passed, $TOTAL_FAILED failed"
+echo "========================================="
+
+if ((TOTAL_FAILED > 0)); then
+  exit 1
+fi
+exit 0
+```
+
+**Step 3: Make scripts executable and verify**
+
+Run: `chmod +x tests/run-tests.sh tests/test-helpers.sh`
+Expected: No errors
+
+**Step 4: Commit**
+
+```bash
+git add tests/test-helpers.sh tests/run-tests.sh
+git commit -m "feat: add test harness framework with assert helpers and runner"
+```
+
+---
+
+### Task 4: Write session-start-hook.sh (registry builder)
+
+**Files:**
+- Create: `hooks/session-start-hook.sh`
+- Modify: `hooks/fix-plugin-manifests.sh` (keep as-is, called from new hook)
+
+The session start hook builds the skill registry by scanning plugin cache + user skills, merging with default triggers, applying user config overrides, and caching the result.
+
+**Step 1: Write the failing test (tests/test-registry.sh)**
+
+```bash
+#!/bin/bash
+# --- Registry builder tests ---
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/test-helpers.sh"
+
+setup_test_env
+
+# --- Test: empty environment produces fallback registry ---
+echo '{"prompt":"test"}' | bash "$CLAUDE_PLUGIN_ROOT/hooks/session-start-hook.sh" > /dev/null 2>&1
+assert_file_exists "registry cache created" "$TEST_REGISTRY_CACHE"
+assert_json_valid "registry cache is valid JSON" "$TEST_REGISTRY_CACHE"
+assert_contains "fallback warning present" "fallback" "$(jq -r '.warnings[]?' "$TEST_REGISTRY_CACHE" 2>/dev/null)"
+
+teardown_test_env
+setup_test_env
+
+# --- Test: discovers superpowers plugin skills ---
+SP_DIR="$TEST_PLUGIN_CACHE/superpowers/1.0.0/skills/brainstorming"
+mkdir -p "$SP_DIR"
+echo "# Brainstorming" > "$SP_DIR/SKILL.md"
+
+bash "$CLAUDE_PLUGIN_ROOT/hooks/session-start-hook.sh" > /dev/null 2>&1
+assert_contains "brainstorming discovered" "brainstorming" "$(jq -r '.skills[].name' "$TEST_REGISTRY_CACHE" 2>/dev/null)"
+
+teardown_test_env
+setup_test_env
+
+# --- Test: discovers user-installed skills ---
+mkdir -p "$TEST_USER_SKILLS/my-custom-skill"
+echo "# My Custom Skill" > "$TEST_USER_SKILLS/my-custom-skill/SKILL.md"
+
+bash "$CLAUDE_PLUGIN_ROOT/hooks/session-start-hook.sh" > /dev/null 2>&1
+assert_contains "custom skill discovered" "my-custom-skill" "$(jq -r '.skills[].name' "$TEST_REGISTRY_CACHE" 2>/dev/null)"
+
+teardown_test_env
+setup_test_env
+
+# --- Test: discovers official plugin skills ---
+mkdir -p "$TEST_PLUGIN_CACHE/frontend-design/.claude-plugin"
+echo '{"name":"frontend-design"}' > "$TEST_PLUGIN_CACHE/frontend-design/.claude-plugin/plugin.json"
+
+bash "$CLAUDE_PLUGIN_ROOT/hooks/session-start-hook.sh" > /dev/null 2>&1
+assert_contains "frontend-design discovered" "frontend-design" "$(jq -r '.skills[].name' "$TEST_REGISTRY_CACHE" 2>/dev/null)"
+
+teardown_test_env
+setup_test_env
+
+# --- Test: missing plugin dir doesn't cause error ---
+rmdir "$TEST_PLUGIN_CACHE" 2>/dev/null || true
+bash "$CLAUDE_PLUGIN_ROOT/hooks/session-start-hook.sh" > /dev/null 2>&1
+exit_code=$?
+assert_equals "missing plugin cache doesn't crash" "0" "$exit_code"
+assert_file_exists "fallback registry still created" "$TEST_REGISTRY_CACHE"
+
+teardown_test_env
+setup_test_env
+
+# --- Test: user config overrides ---
+mkdir -p "$TEST_PLUGIN_CACHE/superpowers/1.0.0/skills/brainstorming"
+echo "# Brainstorming" > "$TEST_PLUGIN_CACHE/superpowers/1.0.0/skills/brainstorming/SKILL.md"
+
+cat > "$TEST_USER_CONFIG" << 'EOF'
+{
+  "overrides": {
+    "brainstorming": { "enabled": false }
+  }
+}
+EOF
+
+bash "$CLAUDE_PLUGIN_ROOT/hooks/session-start-hook.sh" > /dev/null 2>&1
+disabled=$(jq -r '.skills[] | select(.name == "brainstorming") | .enabled' "$TEST_REGISTRY_CACHE" 2>/dev/null)
+assert_equals "brainstorming disabled by user config" "false" "$disabled"
+
+teardown_test_env
+setup_test_env
+
+# --- Test: health check output ---
+output=$(bash "$CLAUDE_PLUGIN_ROOT/hooks/session-start-hook.sh" 2>&1)
+assert_contains "health check in output" "skill registry built" "$output"
+
+teardown_test_env
+
+print_summary
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bash tests/test-registry.sh`
+Expected: FAIL (session-start-hook.sh doesn't exist yet)
+
+**Step 3: Write hooks/session-start-hook.sh**
+
+```bash
+#!/bin/bash
+# --- auto-claude-skills Session Start Hook ---
+# Builds skill registry from dynamic discovery + config defaults.
+# Caches result for the routing engine to read.
+#
+# Sources (merge order):
+#   1. config/fallback-registry.json (static baseline)
+#   2. Dynamic discovery (plugin cache + user skills)
+#   3. config/default-triggers.json (trigger definitions)
+#   4. ~/.claude/skill-config.json (user overrides)
+#
+# Output: ~/.claude/.skill-registry-cache.json
+# Also: runs fix-plugin-manifests.sh for backwards compat
+# -----------------------------------------------------------------
+set -uo pipefail
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+CACHE_FILE="$HOME/.claude/.skill-registry-cache.json"
+DEFAULT_TRIGGERS="$PLUGIN_ROOT/config/default-triggers.json"
+FALLBACK_REGISTRY="$PLUGIN_ROOT/config/fallback-registry.json"
+USER_CONFIG="$HOME/.claude/skill-config.json"
+PLUGIN_CACHE="$HOME/.claude/plugins/cache/claude-plugins-official"
+USER_SKILLS="$HOME/.claude/skills"
+
+WARNINGS='[]'
+DISCOVERED_SKILLS='[]'
+
+# --- Run manifest fixer (backwards compat) -----------------------
+if [[ -x "$PLUGIN_ROOT/hooks/fix-plugin-manifests.sh" ]]; then
+  bash "$PLUGIN_ROOT/hooks/fix-plugin-manifests.sh" 2>/dev/null || true
+fi
+
+# --- Check jq availability --------------------------------------
+if ! command -v jq &>/dev/null; then
+  # No jq — use fallback registry directly
+  if [[ -f "$FALLBACK_REGISTRY" ]]; then
+    cp "$FALLBACK_REGISTRY" "$CACHE_FILE"
+  else
+    echo '{"skills":[],"warnings":["jq not found, no fallback registry"],"version":"2.0.0-degraded"}' > "$CACHE_FILE"
+  fi
+  echo "SessionStart: skill registry built (fallback — jq not found)"
+  exit 0
+fi
+
+# --- Discover superpowers plugin skills --------------------------
+SP_BASE="$PLUGIN_CACHE/superpowers"
+SP_SKILLS=""
+if [[ -d "$SP_BASE" ]]; then
+  SP_VERSION=$(ls -1 "$SP_BASE" 2>/dev/null | sort -V | tail -1)
+  [[ -n "$SP_VERSION" ]] && SP_SKILLS="$SP_BASE/$SP_VERSION/skills"
+fi
+
+if [[ -n "$SP_SKILLS" && -d "$SP_SKILLS" ]]; then
+  for skill_dir in "$SP_SKILLS"/*/; do
+    [[ ! -f "$skill_dir/SKILL.md" ]] && continue
+    skill_name=$(basename "$skill_dir")
+    DISCOVERED_SKILLS=$(echo "$DISCOVERED_SKILLS" | jq --arg name "$skill_name" --arg invoke "Read $skill_dir/SKILL.md" \
+      '. + [{"name": $name, "source": "superpowers", "invoke": $invoke, "discovered": true}]')
+  done
+else
+  WARNINGS=$(echo "$WARNINGS" | jq '. + ["superpowers plugin not found"]')
+fi
+
+# --- Discover official plugin skills -----------------------------
+OFFICIAL_PLUGINS=("frontend-design" "claude-md-management" "claude-code-setup" "ralph-loop" "pr-review-toolkit")
+declare -A PLUGIN_SKILL_MAP
+PLUGIN_SKILL_MAP=(
+  ["frontend-design"]="frontend-design:frontend-design"
+  ["claude-md-management"]="claude-md-management:claude-md-improver"
+  ["claude-code-setup"]="claude-code-setup:claude-automation-recommender"
+)
+
+for plugin in "${OFFICIAL_PLUGINS[@]}"; do
+  if [[ -d "$PLUGIN_CACHE/$plugin" ]]; then
+    skill_ref="${PLUGIN_SKILL_MAP[$plugin]:-}"
+    if [[ -n "$skill_ref" ]]; then
+      skill_name="${skill_ref#*:}"
+      DISCOVERED_SKILLS=$(echo "$DISCOVERED_SKILLS" | jq --arg name "$skill_name" --arg invoke "Call Skill($skill_ref)" --arg source "$plugin" \
+        '. + [{"name": $name, "source": $source, "invoke": $invoke, "discovered": true}]')
+    fi
+  fi
+done
+
+# --- Discover user-installed skills ------------------------------
+if [[ -d "$USER_SKILLS" ]]; then
+  for skill_dir in "$USER_SKILLS"/*/; do
+    [[ ! -f "$skill_dir/SKILL.md" ]] && continue
+    skill_name=$(basename "$skill_dir")
+    DISCOVERED_SKILLS=$(echo "$DISCOVERED_SKILLS" | jq --arg name "$skill_name" --arg invoke "Read ${skill_dir}SKILL.md" \
+      '. + [{"name": $name, "source": "user-skills", "invoke": $invoke, "discovered": true}]')
+  done
+fi
+
+# --- Merge with default triggers ---------------------------------
+if [[ -f "$DEFAULT_TRIGGERS" ]]; then
+  # For each discovered skill, merge trigger/role/phase from defaults
+  MERGED_SKILLS=$(jq -n --argjson discovered "$DISCOVERED_SKILLS" --slurpfile defaults "$DEFAULT_TRIGGERS" '
+    ($defaults[0].skills // []) as $default_skills |
+    # Start with defaults, overlay discovered invoke paths
+    [ $default_skills[] |
+      . as $default |
+      ($discovered | map(select(.name == $default.name)) | first // null) as $disc |
+      if $disc then
+        $default + {"invoke": $disc.invoke, "source": $disc.source, "available": true}
+      else
+        $default + {"available": false}
+      end
+    ] +
+    # Add discovered skills not in defaults (user custom skills)
+    [ $discovered[] |
+      . as $disc |
+      ($default_skills | map(select(.name == $disc.name)) | length) as $in_defaults |
+      if $in_defaults == 0 then
+        $disc + {"role": "domain", "triggers": [], "priority": 5, "available": true}
+      else
+        empty
+      end
+    ]
+  ')
+else
+  WARNINGS=$(echo "$WARNINGS" | jq '. + ["default-triggers.json not found"]')
+  MERGED_SKILLS="$DISCOVERED_SKILLS"
+fi
+
+# --- Apply user config overrides ---------------------------------
+if [[ -f "$USER_CONFIG" ]] && jq . "$USER_CONFIG" > /dev/null 2>&1; then
+  MERGED_SKILLS=$(jq -n --argjson skills "$MERGED_SKILLS" --slurpfile config "$USER_CONFIG" '
+    ($config[0].overrides // {}) as $overrides |
+    ($config[0].custom_skills // []) as $custom |
+    ($config[0].settings // {}) as $settings |
+    [
+      $skills[] |
+      . as $skill |
+      ($overrides[$skill.name] // null) as $override |
+      if $override then
+        # Apply enabled flag
+        (if $override.enabled == false then . + {"enabled": false} elif $override.enabled == true then . + {"enabled": true} else . end) |
+        # Apply trigger overrides
+        if $override.triggers then
+          ($override.triggers | map(select(startswith("+"))) | map(ltrimstr("+"))) as $add |
+          ($override.triggers | map(select(startswith("-"))) | map(ltrimstr("-"))) as $remove |
+          ($override.triggers | map(select(startswith("+") or startswith("-")) | not)) as $replace |
+          if ($replace | length) > 0 then
+            .triggers = $replace
+          else
+            .triggers = ((.triggers // []) + $add | map(select(. as $t | $remove | index($t) | not)))
+          end
+        else
+          .
+        end
+      else
+        .
+      end
+    ] + ($custom | map(. + {"source": "user-config", "available": true}))
+  ')
+elif [[ -f "$USER_CONFIG" ]]; then
+  WARNINGS=$(echo "$WARNINGS" | jq '. + ["skill-config.json is invalid JSON — ignored"]')
+fi
+
+# --- Also extract methodology hints from defaults ----------------
+HINTS='[]'
+if [[ -f "$DEFAULT_TRIGGERS" ]]; then
+  HINTS=$(jq '.methodology_hints // []' "$DEFAULT_TRIGGERS")
+  # Filter to only installed plugins
+  HINTS=$(echo "$HINTS" | jq --arg cache "$PLUGIN_CACHE" '
+    [ .[] | select(.plugin as $p | ($cache + "/" + $p) | test(".*")) ]
+  ')
+fi
+
+# --- Build final registry ----------------------------------------
+SKILL_COUNT=$(echo "$MERGED_SKILLS" | jq '[.[] | select(.available == true or .available == null)] | length')
+SOURCE_COUNT=$(echo "$MERGED_SKILLS" | jq '[.[] | select(.available == true) | .source] | unique | length')
+WARNING_COUNT=$(echo "$WARNINGS" | jq 'length')
+
+REGISTRY=$(jq -n \
+  --argjson skills "$MERGED_SKILLS" \
+  --argjson warnings "$WARNINGS" \
+  --argjson hints "$HINTS" \
+  '{
+    skills: $skills,
+    methodology_hints: $hints,
+    warnings: $warnings,
+    version: "2.0.0"
+  }')
+
+mkdir -p "$(dirname "$CACHE_FILE")"
+echo "$REGISTRY" > "$CACHE_FILE"
+
+# --- Emit phase map for session context --------------------------
+PHASE_CONTEXT="SessionStart: skill registry built ($SKILL_COUNT skills from $SOURCE_COUNT sources, $WARNING_COUNT warnings)"
+
+# Output as hook response
+printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":%s}}\n' \
+  "$(printf '%s' "$PHASE_CONTEXT" | jq -Rs .)"
+```
+
+**Step 4: Make executable**
+
+Run: `chmod +x hooks/session-start-hook.sh`
+
+**Step 5: Run tests to verify they pass**
+
+Run: `bash tests/test-registry.sh`
+Expected: All PASS
+
+**Step 6: Commit**
+
+```bash
+git add hooks/session-start-hook.sh tests/test-registry.sh
+git commit -m "feat: add session-start hook with dynamic registry builder and tests"
+```
+
+---
+
+### Task 5: Rewrite skill-activation-hook.sh (routing engine)
+
+**Files:**
+- Modify: `hooks/skill-activation-hook.sh:1-225` (full rewrite)
+
+The new routing engine reads the cached registry, scores trigger matches, selects skills by role caps, and emits orchestrated context.
+
+**Step 1: Write the failing test (tests/test-routing.sh)**
+
+```bash
+#!/bin/bash
+# --- Routing engine tests ---
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/test-helpers.sh"
+
+# Helper: run the hook with a prompt and capture output
+run_hook() {
+  local prompt="$1"
+  echo "{\"prompt\":\"$prompt\"}" | bash "$CLAUDE_PLUGIN_ROOT/hooks/skill-activation-hook.sh" 2>/dev/null
+}
+
+extract_context() {
+  local output="$1"
+  echo "$output" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null
+}
+
+setup_test_env
+
+# Build a test registry with known skills
+cat > "$TEST_REGISTRY_CACHE" << 'REGISTRY'
+{
+  "skills": [
+    {"name": "systematic-debugging", "role": "process", "invoke": "Skill(superpowers:systematic-debugging)", "phase": ["DEBUG"], "triggers": ["debug", "bug", "fix", "broken", "error"], "priority": 40, "available": true},
+    {"name": "brainstorming", "role": "process", "invoke": "Skill(superpowers:brainstorming)", "phase": ["DESIGN"], "triggers": ["build", "create", "add", "design", "new"], "priority": 30, "available": true, "precedes": ["writing-plans"]},
+    {"name": "test-driven-development", "role": "process", "invoke": "Skill(superpowers:test-driven-development)", "phase": ["IMPLEMENT"], "triggers": ["test", "tdd", "verify"], "priority": 15, "available": true},
+    {"name": "requesting-code-review", "role": "process", "invoke": "Skill(superpowers:requesting-code-review)", "phase": ["REVIEW"], "triggers": ["review", "code.?review"], "priority": 20, "available": true},
+    {"name": "verification-before-completion", "role": "workflow", "invoke": "Skill(superpowers:verification-before-completion)", "triggers": ["ship", "merge", "finish", "complete"], "priority": 20, "available": true},
+    {"name": "frontend-design", "role": "domain", "invoke": "Skill(frontend-design:frontend-design)", "triggers": ["component", "dashboard", "ui", "frontend"], "priority": 15, "available": true},
+    {"name": "security-scanner", "role": "domain", "invoke": "Read ~/.claude/skills/security-scanner/SKILL.md", "triggers": ["security", "vulnerab", "auth"], "priority": 15, "available": true}
+  ],
+  "methodology_hints": [],
+  "warnings": [],
+  "version": "2.0.0"
+}
+REGISTRY
+
+# --- Test: debug prompt matches systematic-debugging ---
+ctx=$(extract_context "$(run_hook "fix the login bug")")
+assert_contains "debug prompt matches debugging" "systematic-debugging" "$ctx"
+
+# --- Test: build prompt matches brainstorming ---
+ctx=$(extract_context "$(run_hook "build a new API endpoint")")
+assert_contains "build prompt matches brainstorming" "brainstorming" "$ctx"
+
+# --- Test: greeting is blocked ---
+output=$(run_hook "hey how are you")
+assert_equals "greeting produces no output" "" "$output"
+
+# --- Test: slash command is blocked ---
+output=$(run_hook "/commit")
+assert_equals "slash command produces no output" "" "$output"
+
+# --- Test: short prompt is blocked ---
+output=$(run_hook "ok")
+assert_equals "short prompt produces no output" "" "$output"
+
+# --- Test: domain skill appears alongside process skill ---
+ctx=$(extract_context "$(run_hook "build a new dashboard component")")
+assert_contains "brainstorming as process" "brainstorming" "$ctx"
+assert_contains "frontend-design as domain" "frontend-design" "$ctx"
+assert_contains "INFORMED BY keyword" "INFORMED BY" "$ctx"
+
+# --- Test: review prompt matches code review ---
+ctx=$(extract_context "$(run_hook "review my latest changes")")
+assert_contains "review matches code review" "requesting-code-review" "$ctx"
+
+# --- Test: ship prompt matches workflow skills ---
+ctx=$(extract_context "$(run_hook "ship it, we are done")")
+assert_contains "ship matches verification" "verification-before-completion" "$ctx"
+
+# --- Test: max 1 process skill ---
+ctx=$(extract_context "$(run_hook "fix and build something new")")
+# Should not have both debugging AND brainstorming as process
+process_count=$(echo "$ctx" | grep -c "^Process:" || true)
+assert_equals "max 1 process skill" "1" "$process_count"
+
+# --- Test: disabled skills are excluded ---
+cat > "$TEST_REGISTRY_CACHE" << 'REGISTRY'
+{
+  "skills": [
+    {"name": "brainstorming", "role": "process", "invoke": "Skill(superpowers:brainstorming)", "phase": ["DESIGN"], "triggers": ["build", "create"], "priority": 30, "available": true, "enabled": false}
+  ],
+  "warnings": [],
+  "version": "2.0.0"
+}
+REGISTRY
+ctx=$(extract_context "$(run_hook "build something new")")
+assert_not_contains "disabled skill excluded" "brainstorming" "$ctx"
+
+# --- Test: missing registry falls back ---
+rm -f "$TEST_REGISTRY_CACHE"
+output=$(run_hook "build something")
+assert_not_contains "no crash without registry" "error" "$output"
+
+teardown_test_env
+
+print_summary
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bash tests/test-routing.sh`
+Expected: FAIL (hook still uses old hardcoded logic)
+
+**Step 3: Rewrite hooks/skill-activation-hook.sh**
+
+```bash
+#!/bin/bash
+# --- auto-claude-skills Routing Engine v2 ---------------------
+# https://github.com/damianpapadopoulos/auto-claude-skills
+#
+# Config-driven routing with role-based skill orchestration.
+# Reads skill registry from cache (built by session-start-hook.sh).
+#
+# DESIGN PRINCIPLE: The registry + scoring is a FAST PRE-FILTER.
+# Claude Code (already running) makes the real intent assessment
+# via the orchestrated context injection.
+# No extra API call needed -- Claude IS the classifier.
+#
+# Roles: Process (drives) | Domain (informs) | Workflow (standalone)
+# The hook suggests; Claude decides; the user overrides.
+# -----------------------------------------------------------------
+set -uo pipefail
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+REGISTRY_CACHE="$HOME/.claude/.skill-registry-cache.json"
+FALLBACK_REGISTRY="$PLUGIN_ROOT/config/fallback-registry.json"
+USER_CONFIG="$HOME/.claude/skill-config.json"
+
+PROMPT=$(cat 2>/dev/null | jq -r '.prompt // empty' 2>/dev/null) || true
+
+# --- Early exits -------------------------------------------------
+[[ -z "$PROMPT" ]] && exit 0
+[[ "$PROMPT" =~ ^[[:space:]]*/  ]] && exit 0
+(( ${#PROMPT} < 8 )) && exit 0
+
+P=$(printf '%s' "$PROMPT" | tr '[:upper:]' '[:lower:]')
+
+# --- Blocklist (non-dev prompts) ---------------------------------
+if [[ "$P" =~ ^(hi|hello|hey|thanks|thank.you|good.(morning|afternoon|evening)|bye|goodbye|ok|okay|yes|no|sure|yep|nope|got.it|sounds.good|cool|nice|great|perfect|awesome|understood)([[:space:]!.,]+.{0,20})?$ ]]; then
+  TAIL="${P#*[[:space:]]}"
+  if [[ "$TAIL" == "$P" ]] || (( ${#TAIL} < 20 )); then
+    exit 0
+  fi
+fi
+
+# --- Load registry -----------------------------------------------
+REGISTRY=""
+if [[ -f "$REGISTRY_CACHE" ]] && jq . "$REGISTRY_CACHE" > /dev/null 2>&1; then
+  REGISTRY=$(cat "$REGISTRY_CACHE")
+elif [[ -f "$FALLBACK_REGISTRY" ]]; then
+  REGISTRY=$(cat "$FALLBACK_REGISTRY")
+else
+  # No registry at all — emit minimal phase checkpoint
+  printf '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":%s}}\n' \
+    "$(printf '%s' "SKILL ACTIVATION (0 skills | no registry)\n\nPhase: assess current phase (DESIGN/PLAN/IMPLEMENT/REVIEW/SHIP/DEBUG)\nand consider whether any installed skill applies." | jq -Rs .)"
+  exit 0
+fi
+
+# --- Load settings from user config ------------------------------
+MAX_SUGGESTIONS=3
+VERBOSITY="normal"
+if [[ -f "$USER_CONFIG" ]] && jq . "$USER_CONFIG" > /dev/null 2>&1; then
+  MAX_SUGGESTIONS=$(jq -r '.settings.max_suggestions // 3' "$USER_CONFIG")
+  VERBOSITY=$(jq -r '.settings.verbosity // "normal"' "$USER_CONFIG")
+fi
+
+# --- Score skills against prompt ----------------------------------
+# For each available, enabled skill: test triggers, compute score
+SCORED_SKILLS=$(echo "$REGISTRY" | jq --arg prompt "$P" '
+  .skills
+  | map(select(.available != false and .enabled != false))
+  | map(
+      . as $skill |
+      ($skill.triggers // []) |
+      map(
+        . as $trigger |
+        if ($prompt | test($trigger; "i")) then
+          # Check exact word boundary match vs substring
+          if ($prompt | test("(^|[^a-z])" + $trigger + "($|[^a-z])"; "i")) then 3
+          else 1
+          end
+        else 0
+        end
+      ) |
+      max // 0 |
+      . as $trigger_score |
+      if $trigger_score > 0 then
+        {
+          name: $skill.name,
+          role: ($skill.role // "domain"),
+          invoke: $skill.invoke,
+          phase: ($skill.phase // []),
+          priority: ($skill.priority // 10),
+          trigger_score: $trigger_score,
+          score: ($trigger_score + $skill.priority),
+          precedes: ($skill.precedes // []),
+          requires: ($skill.requires // []),
+          description: ($skill.description // ""),
+          available: true
+        }
+      else empty
+      end
+    )
+  | sort_by(-.score)
+')
+
+# --- Select by role caps -----------------------------------------
+# 1 process + up to 2 domain + 1 workflow = max ~4, then cap at MAX_SUGGESTIONS
+SELECTED=$(echo "$SCORED_SKILLS" | jq --argjson max "$MAX_SUGGESTIONS" '
+  (map(select(.role == "process")) | first // empty) as $proc |
+  (map(select(.role == "domain")) | .[0:2]) as $doms |
+  (map(select(.role == "workflow")) | first // empty) as $wf |
+  (
+    (if $proc then [$proc] else [] end) +
+    $doms +
+    (if $wf then [$wf] else [] end)
+  ) | .[0:$max]
+')
+
+SKILL_COUNT=$(echo "$SELECTED" | jq 'length')
+
+# --- Determine label ---------------------------------------------
+PROCESS_NAME=$(echo "$SELECTED" | jq -r 'map(select(.role == "process")) | first // empty | .name // empty')
+LABEL=""
+case "$PROCESS_NAME" in
+  systematic-debugging) LABEL="Fix / Debug" ;;
+  brainstorming) LABEL="Build New" ;;
+  executing-plans|subagent-driven-development) LABEL="Plan Execution" ;;
+  test-driven-development) LABEL="Run / Test" ;;
+  requesting-code-review|receiving-code-review) LABEL="Review" ;;
+  *) LABEL="(Claude: assess intent)" ;;
+esac
+
+# Add domain/workflow labels
+DOMAIN_NAMES=$(echo "$SELECTED" | jq -r '[.[] | select(.role == "domain") | .name] | join(" ")')
+WORKFLOW_NAMES=$(echo "$SELECTED" | jq -r '[.[] | select(.role == "workflow") | .name] | join(" ")')
+[[ -n "$DOMAIN_NAMES" ]] && LABEL="$LABEL + Domain"
+[[ -n "$WORKFLOW_NAMES" ]] && LABEL="$LABEL + Workflow"
+
+# --- Build orchestrated context output ----------------------------
+if (( SKILL_COUNT == 0 )); then
+  # Minimal phase checkpoint
+  OUT="SKILL ACTIVATION (0 skills | phase checkpoint only)
+
+Phase: assess current phase (DESIGN/PLAN/IMPLEMENT/REVIEW/SHIP/DEBUG)
+and consider whether any installed skill applies."
+
+elif (( SKILL_COUNT <= 2 )) && [[ "$VERBOSITY" != "verbose" ]]; then
+  # Compact format with orchestration
+  OUT="SKILL ACTIVATION ($SKILL_COUNT skills | $LABEL)"
+  OUT+=$'\n'
+
+  # Process skill
+  PROC=$(echo "$SELECTED" | jq -r '.[] | select(.role == "process") | "\(.name) -> \(.invoke)"')
+  if [[ -n "$PROC" ]]; then
+    OUT+=$'\n'"Process: $PROC"
+    # Domain skills as INFORMED BY
+    while IFS= read -r dom_line; do
+      [[ -n "$dom_line" ]] && OUT+=$'\n'"  INFORMED BY: $dom_line"
+    done < <(echo "$SELECTED" | jq -r '.[] | select(.role == "domain") | "\(.name) -> \(.invoke)"')
+  else
+    # No process skill — list all as standalone
+    while IFS= read -r skill_line; do
+      [[ -n "$skill_line" ]] && OUT+=$'\n'"  $skill_line"
+    done < <(echo "$SELECTED" | jq -r '.[] | "\(.name) -> \(.invoke)"')
+  fi
+
+  # Workflow skills standalone
+  while IFS= read -r wf_line; do
+    [[ -n "$wf_line" ]] && OUT+=$'\n'"Workflow: $wf_line"
+  done < <(echo "$SELECTED" | jq -r '.[] | select(.role == "workflow") | "\(.name) -> \(.invoke)"')
+
+  # Evaluation line
+  SKILL_NAMES=$(echo "$SELECTED" | jq -r '[.[].name] | join(", ")')
+  OUT+=$'\n'
+  OUT+=$'\n'"Evaluate: **Phase: [PHASE]** | $(echo "$SELECTED" | jq -r '[.[].name + " YES/NO"] | join(", ")')"
+
+else
+  # Full format
+  OUT="SKILL ACTIVATION ($SKILL_COUNT skills | $LABEL)"
+  OUT+=$'\n'
+  OUT+=$'\n'"Step 1 -- ASSESS PHASE. Check conversation context:"
+  OUT+=$'\n'"  DESIGN    -> brainstorming (ask questions, get approval)"
+  OUT+=$'\n'"  PLAN      -> writing-plans (break into tasks, confirm before execution)"
+  OUT+=$'\n'"  IMPLEMENT -> executing-plans or subagent-driven-development + TDD"
+  OUT+=$'\n'"  REVIEW    -> requesting-code-review"
+  OUT+=$'\n'"  SHIP      -> verification-before-completion + finishing-a-development-branch"
+  OUT+=$'\n'"  DEBUG     -> systematic-debugging, then return to current phase"
+
+  OUT+=$'\n'
+  OUT+=$'\n'"Step 2 -- EVALUATE skills against your phase assessment."
+
+  # Process skill
+  PROC_NAME=$(echo "$SELECTED" | jq -r '.[] | select(.role == "process") | .name' | head -1)
+  PROC_INVOKE=$(echo "$SELECTED" | jq -r '.[] | select(.role == "process") | .invoke' | head -1)
+  if [[ -n "$PROC_NAME" ]]; then
+    OUT+=$'\n'"  Process: $PROC_NAME -> $PROC_INVOKE"
+    while IFS= read -r dom_line; do
+      [[ -n "$dom_line" ]] && OUT+=$'\n'"    INFORMED BY: $dom_line"
+    done < <(echo "$SELECTED" | jq -r '.[] | select(.role == "domain") | "\(.name) -> \(.invoke)"')
+  fi
+
+  # Standalone domain skills (no process)
+  if [[ -z "$PROC_NAME" ]]; then
+    while IFS= read -r skill_line; do
+      [[ -n "$skill_line" ]] && OUT+=$'\n'"  $skill_line"
+    done < <(echo "$SELECTED" | jq -r '.[] | select(.role == "domain") | "\(.name) -> \(.invoke)"')
+  fi
+
+  # Workflow skills
+  while IFS= read -r wf_line; do
+    [[ -n "$wf_line" ]] && OUT+=$'\n'"  Workflow: $wf_line"
+  done < <(echo "$SELECTED" | jq -r '.[] | select(.role == "workflow") | "\(.name) -> \(.invoke)"')
+
+  OUT+=$'\n'"You MUST print a brief evaluation for each skill above. Format:"
+  OUT+=$'\n'"  **Phase: [PHASE]** | [skill1] YES/NO, [skill2] YES/NO"
+  OUT+=$'\n'"Example: **Phase: IMPLEMENT** | test-driven-development YES, claude-md-improver NO (not editing CLAUDE.md)"
+  OUT+=$'\n'"This line is MANDATORY -- do not skip it."
+
+  OUT+=$'\n'
+  OUT+=$'\n'"Step 3 -- State your plan and proceed. Keep it to 1-2 sentences."
+fi
+
+# --- Methodology hints -------------------------------------------
+HINTS=$(echo "$REGISTRY" | jq --arg prompt "$P" '
+  (.methodology_hints // []) | map(
+    select(.triggers | any(. as $t | $prompt | test($t; "i")))
+  ) | .[].hint // empty
+' 2>/dev/null)
+
+if [[ -n "$HINTS" ]]; then
+  OUT+=$'\n'
+  while IFS= read -r hint; do
+    [[ -n "$hint" ]] && OUT+=$'\n'"- $hint"
+  done <<< "$HINTS"
+fi
+
+# --- Emit ---------------------------------------------------------
+printf '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":%s}}\n' \
+  "$(printf '%s' "$OUT" | jq -Rs .)"
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `bash tests/test-routing.sh`
+Expected: All PASS
+
+**Step 5: Commit**
+
+```bash
+git add hooks/skill-activation-hook.sh tests/test-routing.sh
+git commit -m "feat: rewrite routing engine with config-driven scoring and role-based orchestration"
+```
+
+---
+
+### Task 6: Write context injection tests
+
+**Files:**
+- Create: `tests/test-context.sh`
+
+**Step 1: Write tests/test-context.sh**
+
+```bash
+#!/bin/bash
+# --- Context injection format tests ---
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/test-helpers.sh"
+
+run_hook() {
+  local prompt="$1"
+  echo "{\"prompt\":\"$prompt\"}" | bash "$CLAUDE_PLUGIN_ROOT/hooks/skill-activation-hook.sh" 2>/dev/null
+}
+
+extract_context() {
+  echo "$1" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null
+}
+
+setup_test_env
+
+# --- Registry with varied skills for context format testing ---
+cat > "$TEST_REGISTRY_CACHE" << 'REGISTRY'
+{
+  "skills": [
+    {"name": "systematic-debugging", "role": "process", "invoke": "Skill(superpowers:systematic-debugging)", "phase": ["DEBUG"], "triggers": ["debug", "bug", "fix"], "priority": 40, "available": true},
+    {"name": "brainstorming", "role": "process", "invoke": "Skill(superpowers:brainstorming)", "phase": ["DESIGN"], "triggers": ["build", "create", "add"], "priority": 30, "available": true},
+    {"name": "verification-before-completion", "role": "workflow", "invoke": "Skill(superpowers:verification-before-completion)", "triggers": ["ship", "merge", "finish"], "priority": 20, "available": true},
+    {"name": "finishing-a-development-branch", "role": "workflow", "invoke": "Skill(superpowers:finishing-a-development-branch)", "triggers": ["ship", "merge", "finish"], "priority": 19, "available": true},
+    {"name": "frontend-design", "role": "domain", "invoke": "Skill(frontend-design:frontend-design)", "triggers": ["component", "dashboard", "ui"], "priority": 15, "available": true},
+    {"name": "security-scanner", "role": "domain", "invoke": "Read ~/.claude/skills/security-scanner/SKILL.md", "triggers": ["security", "auth"], "priority": 15, "available": true},
+    {"name": "doc-coauthoring", "role": "domain", "invoke": "Read ~/.claude/skills/doc-coauthoring/SKILL.md", "triggers": ["documentation", "proposal"], "priority": 15, "available": true}
+  ],
+  "methodology_hints": [],
+  "warnings": [],
+  "version": "2.0.0"
+}
+REGISTRY
+
+# --- Test: 0 skills -> minimal output ---
+ctx=$(extract_context "$(run_hook "what time zone are we in for the standup")")
+assert_contains "0 skills: phase checkpoint" "phase checkpoint" "$ctx"
+assert_not_contains "0 skills: no Step 2" "Step 2" "$ctx"
+
+# --- Test: 1 skill -> compact format ---
+ctx=$(extract_context "$(run_hook "fix the login bug")")
+assert_contains "1 skill: has Process:" "Process:" "$ctx"
+assert_contains "1 skill: has Evaluate:" "Evaluate:" "$ctx"
+assert_not_contains "1 skill: no Step 1 in compact" "Step 1" "$ctx"
+
+# --- Test: process + domain -> INFORMED BY ---
+ctx=$(extract_context "$(run_hook "build a dashboard component")")
+assert_contains "process+domain: INFORMED BY present" "INFORMED BY" "$ctx"
+assert_contains "process+domain: process listed" "brainstorming" "$ctx"
+assert_contains "process+domain: domain listed" "frontend-design" "$ctx"
+
+# --- Test: 3+ skills -> full format with phase map ---
+ctx=$(extract_context "$(run_hook "build a secure dashboard component with documentation")")
+# This should match brainstorming + frontend-design + security-scanner + doc-coauthoring = 4
+# which triggers full format
+if echo "$ctx" | grep -q "Step 1"; then
+  assert_contains "3+ skills: has phase map" "DESIGN" "$ctx"
+  assert_contains "3+ skills: has MANDATORY eval" "MANDATORY" "$ctx"
+fi
+
+# --- Test: invocation hints are present ---
+ctx=$(extract_context "$(run_hook "fix the login bug")")
+assert_contains "invocation hint present" "Skill(superpowers:" "$ctx"
+
+# --- Test: output is valid hook JSON ---
+output=$(run_hook "build something new")
+echo "$output" | jq . > /dev/null 2>&1
+assert_equals "output is valid JSON" "0" "$?"
+
+teardown_test_env
+
+print_summary
+```
+
+**Step 2: Run tests**
+
+Run: `bash tests/test-context.sh`
+Expected: All PASS
+
+**Step 3: Commit**
+
+```bash
+git add tests/test-context.sh
+git commit -m "feat: add context injection format tests"
+```
+
+---
+
+### Task 7: Update hooks.json for new session start hook
+
+**Files:**
+- Modify: `hooks/hooks.json:1-27`
+
+**Step 1: Update hooks.json to use new session start hook**
+
+Replace the SessionStart hook command to use session-start-hook.sh (which internally calls fix-plugin-manifests.sh).
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start-hook.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/skill-activation-hook.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add hooks/hooks.json
+git commit -m "feat: point SessionStart hook at registry builder"
+```
+
+---
+
+### Task 8: Update plugin manifest version
+
+**Files:**
+- Modify: `.claude-plugin/plugin.json:4`
+
+**Step 1: Bump version to 2.0.0**
+
+Change `"version": "1.2.0"` to `"version": "2.0.0"`.
+
+**Step 2: Commit**
+
+```bash
+git add .claude-plugin/plugin.json
+git commit -m "chore: bump version to 2.0.0"
+```
+
+---
+
+### Task 9: Update install.sh for v2
+
+**Files:**
+- Modify: `install.sh`
+
+**Step 1: Update install.sh**
+
+Key changes:
+- Legacy manual install copies both `session-start-hook.sh` and `skill-activation-hook.sh`
+- Legacy settings.json gets both SessionStart and UserPromptSubmit hooks
+- Add config directory copy for default-triggers.json and fallback-registry.json
+- Update version display
+
+This is a focused diff — only the legacy install section and hook registration need updating. The external skills download and plugin check sections stay identical.
+
+**Step 2: Run install in dry-run mode to verify**
+
+Run: `bash install.sh` (answer N to manual install, N to skill download)
+Expected: Shows plugin is installed, no errors
+
+**Step 3: Commit**
+
+```bash
+git add install.sh
+git commit -m "feat: update installer for v2 with registry config files"
+```
+
+---
+
+### Task 10: Write install/uninstall tests
+
+**Files:**
+- Create: `tests/test-install.sh`
+
+**Step 1: Write tests/test-install.sh**
+
+```bash
+#!/bin/bash
+# --- Install/uninstall tests ---
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/test-helpers.sh"
+
+# --- Test: config files exist ---
+assert_file_exists "default-triggers.json exists" "$CLAUDE_PLUGIN_ROOT/config/default-triggers.json"
+assert_file_exists "fallback-registry.json exists" "$CLAUDE_PLUGIN_ROOT/config/fallback-registry.json"
+assert_json_valid "default-triggers.json valid" "$CLAUDE_PLUGIN_ROOT/config/default-triggers.json"
+assert_json_valid "fallback-registry.json valid" "$CLAUDE_PLUGIN_ROOT/config/fallback-registry.json"
+
+# --- Test: hooks are executable ---
+assert_file_exists "skill-activation-hook.sh exists" "$CLAUDE_PLUGIN_ROOT/hooks/skill-activation-hook.sh"
+assert_file_exists "session-start-hook.sh exists" "$CLAUDE_PLUGIN_ROOT/hooks/session-start-hook.sh"
+
+if [[ -x "$CLAUDE_PLUGIN_ROOT/hooks/skill-activation-hook.sh" ]]; then
+  assert_equals "activation hook is executable" "0" "0"
+else
+  assert_equals "activation hook is executable" "executable" "not executable"
+fi
+
+if [[ -x "$CLAUDE_PLUGIN_ROOT/hooks/session-start-hook.sh" ]]; then
+  assert_equals "session start hook is executable" "0" "0"
+else
+  assert_equals "session start hook is executable" "executable" "not executable"
+fi
+
+# --- Test: hooks.json references correct files ---
+HOOKS_JSON="$CLAUDE_PLUGIN_ROOT/hooks/hooks.json"
+assert_file_exists "hooks.json exists" "$HOOKS_JSON"
+assert_json_valid "hooks.json valid" "$HOOKS_JSON"
+assert_contains "hooks.json references session-start" "session-start-hook.sh" "$(cat "$HOOKS_JSON")"
+assert_contains "hooks.json references skill-activation" "skill-activation-hook.sh" "$(cat "$HOOKS_JSON")"
+
+# --- Test: plugin.json is valid ---
+PLUGIN_JSON="$CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json"
+assert_file_exists "plugin.json exists" "$PLUGIN_JSON"
+assert_json_valid "plugin.json valid" "$PLUGIN_JSON"
+
+print_summary
+```
+
+**Step 2: Run tests**
+
+Run: `bash tests/test-install.sh`
+Expected: All PASS
+
+**Step 3: Commit**
+
+```bash
+git add tests/test-install.sh
+git commit -m "feat: add install validation tests"
+```
+
+---
+
+### Task 11: Run full test suite and verify
+
+**Step 1: Run the full test suite**
+
+Run: `bash tests/run-tests.sh`
+Expected: All tests pass, 0 failures
+
+**Step 2: If any failures, fix and re-run**
+
+Fix failing tests or implementation, then re-run until green.
+
+**Step 3: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix: resolve test failures from integration"
+```
+
+---
+
+### Task 12: Update README.md for v2
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Update README to document v2 changes**
+
+Key sections to update:
+- Version number in title/header
+- Architecture description (config-driven, role-based)
+- New file listing (config/, tests/)
+- Skill roles explanation (process/domain/workflow)
+- User configuration section
+- Testing section
+
+**Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: update README for v2 architecture"
+```
+
+---
+
+Plan complete and saved to `docs/plans/2026-02-15-v2-implementation-plan.md`. Two execution options:
+
+**1. Subagent-Driven (this session)** — I dispatch fresh subagent per task, review between tasks, fast iteration
+
+**2. Parallel Session (separate)** — Open new session with executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/fix-plugin-manifests.sh",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start-hook.sh",
             "timeout": 10
           }
         ]

--- a/hooks/session-start-hook.sh
+++ b/hooks/session-start-hook.sh
@@ -1,0 +1,303 @@
+#!/bin/bash
+# --- Session Start Hook: Skill Registry Builder -------------------
+# https://github.com/damianpapadopoulos/auto-claude-skills
+#
+# Runs at SessionStart. Scans plugin cache and user skills, merges
+# with default triggers, applies user config overrides, and caches
+# the result as ~/.claude/.skill-registry-cache.json.
+#
+# Output format:
+#   {"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"..."}}
+#
+# Bash 3.2 compatible (macOS default). No associative arrays.
+# -----------------------------------------------------------------
+set -uo pipefail
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+# -----------------------------------------------------------------
+# Step 1: Run fix-plugin-manifests.sh (backwards compat)
+# -----------------------------------------------------------------
+FIX_SCRIPT="${PLUGIN_ROOT}/hooks/fix-plugin-manifests.sh"
+if [ -f "${FIX_SCRIPT}" ]; then
+    bash "${FIX_SCRIPT}" 2>/dev/null || true
+fi
+
+# -----------------------------------------------------------------
+# Step 2: Check jq availability
+# -----------------------------------------------------------------
+CACHE_FILE="${HOME}/.claude/.skill-registry-cache.json"
+mkdir -p "$(dirname "${CACHE_FILE}")"
+
+if ! command -v jq >/dev/null 2>&1; then
+    FALLBACK="${PLUGIN_ROOT}/config/fallback-registry.json"
+    if [ -f "${FALLBACK}" ]; then
+        cp "${FALLBACK}" "${CACHE_FILE}"
+    else
+        printf '{"version":"2.0.0-fallback","warnings":["jq not available, no fallback found"],"skills":[]}\n' > "${CACHE_FILE}"
+    fi
+    MSG="SessionStart: skill registry built (0 skills from 0 sources, 1 warnings)"
+    printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "${MSG}"
+    exit 0
+fi
+
+# -----------------------------------------------------------------
+# Path constants
+# -----------------------------------------------------------------
+DEFAULT_TRIGGERS="${PLUGIN_ROOT}/config/default-triggers.json"
+SP_BASE="${HOME}/.claude/plugins/cache/claude-plugins-official/superpowers"
+PLUGIN_CACHE="${HOME}/.claude/plugins/cache/claude-plugins-official"
+USER_SKILLS_DIR="${HOME}/.claude/skills"
+USER_CONFIG="${HOME}/.claude/skill-config.json"
+
+# -----------------------------------------------------------------
+# Step 3: Discover superpowers plugin skills
+# -----------------------------------------------------------------
+SP_SKILLS_DIR=""
+if [ -d "${SP_BASE}" ]; then
+    SP_VERSION="$(ls -1 "${SP_BASE}" 2>/dev/null | sort -V | tail -1)"
+    if [ -n "${SP_VERSION}" ]; then
+        SP_SKILLS_DIR="${SP_BASE}/${SP_VERSION}/skills"
+    fi
+fi
+
+# Build a list of discovered superpowers skill names and paths
+# Format: name|invoke_path (one per line)
+SP_DISCOVERED=""
+if [ -n "${SP_SKILLS_DIR}" ] && [ -d "${SP_SKILLS_DIR}" ]; then
+    for skill_md in "${SP_SKILLS_DIR}"/*/SKILL.md; do
+        [ -f "${skill_md}" ] || continue
+        skill_name="$(basename "$(dirname "${skill_md}")")"
+        SP_DISCOVERED="${SP_DISCOVERED}${skill_name}|Read ${skill_md}
+"
+    done
+fi
+
+# -----------------------------------------------------------------
+# Step 4: Discover official plugin skills
+# -----------------------------------------------------------------
+OFFICIAL_DISCOVERED=""
+
+if [ -d "${PLUGIN_CACHE}/frontend-design" ]; then
+    OFFICIAL_DISCOVERED="${OFFICIAL_DISCOVERED}frontend-design|Call Skill(frontend-design:frontend-design)
+"
+fi
+
+if [ -d "${PLUGIN_CACHE}/claude-md-management" ]; then
+    OFFICIAL_DISCOVERED="${OFFICIAL_DISCOVERED}claude-md-improver|Call Skill(claude-md-management:claude-md-improver)
+"
+fi
+
+if [ -d "${PLUGIN_CACHE}/claude-code-setup" ]; then
+    OFFICIAL_DISCOVERED="${OFFICIAL_DISCOVERED}claude-automation-recommender|Call Skill(claude-code-setup:claude-automation-recommender)
+"
+fi
+
+# -----------------------------------------------------------------
+# Step 5: Discover user-installed skills
+# -----------------------------------------------------------------
+USER_DISCOVERED=""
+if [ -d "${USER_SKILLS_DIR}" ]; then
+    for skill_md in "${USER_SKILLS_DIR}"/*/SKILL.md; do
+        [ -f "${skill_md}" ] || continue
+        skill_name="$(basename "$(dirname "${skill_md}")")"
+        USER_DISCOVERED="${USER_DISCOVERED}${skill_name}|Read ${skill_md}
+"
+    done
+fi
+
+# -----------------------------------------------------------------
+# Combine all discovered skills into one list
+# -----------------------------------------------------------------
+ALL_DISCOVERED="${SP_DISCOVERED}${OFFICIAL_DISCOVERED}${USER_DISCOVERED}"
+
+# Count sources
+SOURCE_COUNT=0
+if [ -n "${SP_DISCOVERED}" ]; then SOURCE_COUNT=$((SOURCE_COUNT + 1)); fi
+if [ -n "${OFFICIAL_DISCOVERED}" ]; then SOURCE_COUNT=$((SOURCE_COUNT + 1)); fi
+if [ -n "${USER_DISCOVERED}" ]; then SOURCE_COUNT=$((SOURCE_COUNT + 1)); fi
+
+# -----------------------------------------------------------------
+# Step 6: Merge discovered skills with default-triggers.json
+# -----------------------------------------------------------------
+# Helper: check if a skill name is in the discovered list, return invoke path
+lookup_discovered() {
+    local name="$1"
+    local line
+    # Use printf to avoid issues with echo -n
+    printf '%s' "${ALL_DISCOVERED}" | while IFS='|' read -r sname spath; do
+        if [ "${sname}" = "${name}" ]; then
+            printf '%s' "${spath}"
+            return 0
+        fi
+    done
+}
+
+# Helper: check if a skill name exists in the defaults
+is_in_defaults() {
+    local name="$1"
+    if [ -f "${DEFAULT_TRIGGERS}" ]; then
+        jq -e --arg n "${name}" '.skills[] | select(.name == $n)' "${DEFAULT_TRIGGERS}" >/dev/null 2>&1
+        return $?
+    fi
+    return 1
+}
+
+# Build skills JSON array using jq
+# Start with default skills, overlay discovered paths
+SKILLS_JSON="[]"
+
+if [ -f "${DEFAULT_TRIGGERS}" ]; then
+    # Process each default skill
+    SKILL_COUNT="$(jq '.skills | length' "${DEFAULT_TRIGGERS}")"
+    i=0
+    while [ "${i}" -lt "${SKILL_COUNT}" ]; do
+        skill_name="$(jq -r ".skills[${i}].name" "${DEFAULT_TRIGGERS}")"
+        skill_json="$(jq ".skills[${i}]" "${DEFAULT_TRIGGERS}")"
+
+        # Look up discovered invoke path
+        invoke_path=""
+        invoke_path="$(lookup_discovered "${skill_name}")"
+
+        if [ -n "${invoke_path}" ]; then
+            # Discovered: add invoke path and mark available
+            skill_json="$(printf '%s' "${skill_json}" | jq --arg inv "${invoke_path}" '. + {invoke: $inv, available: true, enabled: true}')"
+        else
+            # Not discovered: mark unavailable
+            skill_json="$(printf '%s' "${skill_json}" | jq '. + {available: false, enabled: true}')"
+        fi
+
+        SKILLS_JSON="$(printf '%s' "${SKILLS_JSON}" | jq --argjson s "${skill_json}" '. + [$s]')"
+        i=$((i + 1))
+    done
+fi
+
+# Add discovered skills not in defaults (custom/user skills).
+# Pipe to tmp file to avoid subshell variable scoping issues.
+printf '%s' "${ALL_DISCOVERED}" | while IFS='|' read -r sname spath; do
+    [ -z "${sname}" ] && continue
+    if ! is_in_defaults "${sname}"; then
+        printf '%s|%s\n' "${sname}" "${spath}"
+    fi
+done > "${CACHE_FILE}.customs.tmp" 2>/dev/null || true
+
+if [ -f "${CACHE_FILE}.customs.tmp" ]; then
+    while IFS='|' read -r sname spath; do
+        [ -z "${sname}" ] && continue
+        custom_skill="$(jq -n --arg name "${sname}" --arg invoke "${spath}" '{
+            name: $name,
+            role: "domain",
+            triggers: [],
+            trigger_mode: "regex",
+            priority: 200,
+            precedes: [],
+            requires: [],
+            description: "User-installed skill",
+            invoke: $invoke,
+            available: true,
+            enabled: true
+        }')"
+        SKILLS_JSON="$(printf '%s' "${SKILLS_JSON}" | jq --argjson s "${custom_skill}" '. + [$s]')"
+    done < "${CACHE_FILE}.customs.tmp"
+    rm -f "${CACHE_FILE}.customs.tmp"
+fi
+
+# -----------------------------------------------------------------
+# Step 7: Apply user config overrides
+# -----------------------------------------------------------------
+WARNINGS="[]"
+
+if [ -f "${USER_CONFIG}" ] && jq empty "${USER_CONFIG}" >/dev/null 2>&1; then
+    # Process overrides
+    override_keys="$(jq -r '.overrides // {} | keys[]' "${USER_CONFIG}" 2>/dev/null)" || true
+    for skill_name in ${override_keys}; do
+        [ -z "${skill_name}" ] && continue
+
+        # Check if enabled: false
+        has_enabled="$(jq -r --arg n "${skill_name}" 'if .overrides[$n] | has("enabled") then .overrides[$n].enabled | tostring else "unset" end' "${USER_CONFIG}" 2>/dev/null)"
+        if [ "${has_enabled}" = "false" ]; then
+            SKILLS_JSON="$(printf '%s' "${SKILLS_JSON}" | jq --arg n "${skill_name}" '
+                [.[] | if .name == $n then .enabled = false else . end]
+            ')"
+        fi
+
+        # Check for trigger overrides
+        trigger_overrides="$(jq -r --arg n "${skill_name}" '.overrides[$n].triggers // empty | .[]' "${USER_CONFIG}" 2>/dev/null)" || true
+        if [ -n "${trigger_overrides}" ]; then
+            for trigger in ${trigger_overrides}; do
+                case "${trigger}" in
+                    +*)
+                        # Add trigger
+                        new_trigger="${trigger#+}"
+                        SKILLS_JSON="$(printf '%s' "${SKILLS_JSON}" | jq --arg n "${skill_name}" --arg t "${new_trigger}" '
+                            [.[] | if .name == $n then .triggers += [$t] else . end]
+                        ')"
+                        ;;
+                    -*)
+                        # Remove trigger
+                        rem_trigger="${trigger#-}"
+                        SKILLS_JSON="$(printf '%s' "${SKILLS_JSON}" | jq --arg n "${skill_name}" --arg t "${rem_trigger}" '
+                            [.[] | if .name == $n then .triggers = [.triggers[] | select(. != $t)] else . end]
+                        ')"
+                        ;;
+                    *)
+                        # Replace triggers entirely
+                        SKILLS_JSON="$(printf '%s' "${SKILLS_JSON}" | jq --arg n "${skill_name}" --arg t "${trigger}" '
+                            [.[] | if .name == $n then .triggers = [$t] else . end]
+                        ')"
+                        ;;
+                esac
+            done
+        fi
+    done
+
+    # Process custom_skills additions
+    custom_count="$(jq '.custom_skills // [] | length' "${USER_CONFIG}" 2>/dev/null)" || custom_count=0
+    ci=0
+    while [ "${ci}" -lt "${custom_count}" ]; do
+        custom_skill="$(jq ".custom_skills[${ci}]" "${USER_CONFIG}")"
+        custom_skill="$(printf '%s' "${custom_skill}" | jq '. + {available: true, enabled: true}')"
+        SKILLS_JSON="$(printf '%s' "${SKILLS_JSON}" | jq --argjson s "${custom_skill}" '. + [$s]')"
+        ci=$((ci + 1))
+    done
+fi
+
+# -----------------------------------------------------------------
+# Step 8: Extract methodology_hints from default-triggers.json
+# -----------------------------------------------------------------
+METHODOLOGY_HINTS="[]"
+if [ -f "${DEFAULT_TRIGGERS}" ]; then
+    METHODOLOGY_HINTS="$(jq '.methodology_hints // []' "${DEFAULT_TRIGGERS}" 2>/dev/null)" || METHODOLOGY_HINTS="[]"
+fi
+
+# -----------------------------------------------------------------
+# Step 9: Build final registry JSON
+# -----------------------------------------------------------------
+SKILL_COUNT="$(printf '%s' "${SKILLS_JSON}" | jq 'length' 2>/dev/null)" || SKILL_COUNT=0
+WARNING_COUNT="$(printf '%s' "${WARNINGS}" | jq 'length' 2>/dev/null)" || WARNING_COUNT=0
+
+REGISTRY="$(jq -n \
+    --arg version "2.0.0" \
+    --argjson skills "${SKILLS_JSON}" \
+    --argjson methodology_hints "${METHODOLOGY_HINTS}" \
+    --argjson warnings "${WARNINGS}" \
+    '{
+        version: $version,
+        skills: $skills,
+        methodology_hints: $methodology_hints,
+        warnings: $warnings
+    }'
+)"
+
+# -----------------------------------------------------------------
+# Step 10: Cache to ~/.claude/.skill-registry-cache.json
+# -----------------------------------------------------------------
+printf '%s\n' "${REGISTRY}" > "${CACHE_FILE}"
+
+# -----------------------------------------------------------------
+# Step 11: Emit health check
+# -----------------------------------------------------------------
+MSG="SessionStart: skill registry built (${SKILL_COUNT} skills from ${SOURCE_COUNT} sources, ${WARNING_COUNT} warnings)"
+printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "${MSG}"
+
+exit 0

--- a/hooks/skill-activation-hook.sh
+++ b/hooks/skill-activation-hook.sh
@@ -1,197 +1,326 @@
 #!/bin/bash
-# --- Claude Code Skill Activation Hook v8 -----------------------
+# --- Claude Code Skill Activation Hook v2 (config-driven) --------
 # https://github.com/damianpapadopoulos/auto-claude-skills
 #
-# Hybrid intent routing with phase-aware checkpoints.
+# Config-driven routing engine that reads the cached skill registry
+# instead of using hardcoded regex patterns.
 #
-# DESIGN PRINCIPLE: The regex is a FAST PRE-FILTER, not the decision
-# maker. Claude Code (already running) makes the real intent assessment
-# via the phase checkpoint instruction injected into context.
-# No extra API call needed -- Claude IS the classifier.
+# Input: {"prompt": "..."} via stdin
+# Output: {"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"..."}}
 #
-# v8: Wider fallthrough net. In a Claude Code session, most prompts
-# are dev-related. Instead of allowlisting dev keywords, we blocklist
-# the few clearly non-dev patterns and let Claude assess everything else.
-#
-# Three layers: Primary Intent -> Cross-cutting Overlays -> Phase Check
-# The hook suggests; Claude decides; the user overrides.
+# Bash 3.2 compatible (macOS default). Heavy jq usage for scoring.
 # -----------------------------------------------------------------
 set -uo pipefail
 
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+
 PROMPT=$(cat 2>/dev/null | jq -r '.prompt // empty' 2>/dev/null) || true
 
-# --- Early exits -------------------------------------------------
+# =================================================================
+# EARLY EXITS (preserved from v1)
+# =================================================================
 [[ -z "$PROMPT" ]] && exit 0
 [[ "$PROMPT" =~ ^[[:space:]]*/  ]] && exit 0
 (( ${#PROMPT} < 8 )) && exit 0
 
 P=$(printf '%s' "$PROMPT" | tr '[:upper:]' '[:lower:]')
 
-# --- Non-dev prompt filter (blocklist approach) ------------------
-# Exit early ONLY for prompts that are clearly not dev tasks.
-# Everything else gets the phase checkpoint so Claude can decide.
+# =================================================================
+# BLOCKLIST (preserved from v1 for backwards compatibility)
+# =================================================================
 if [[ "$P" =~ ^(hi|hello|hey|thanks|thank.you|good.(morning|afternoon|evening)|bye|goodbye|ok|okay|yes|no|sure|yep|nope|got.it|sounds.good|cool|nice|great|perfect|awesome|understood)([[:space:]!.,]+.{0,20})?$ ]]; then
-  # Allow short trailing words like "hello there", "hey claude", "thanks a lot"
-  # but not "hello can you fix the bug" (that's a real prompt)
   TAIL="${P#*[[:space:]]}"
   if [[ "$TAIL" == "$P" ]] || (( ${#TAIL} < 20 )); then
     exit 0
   fi
 fi
 
-# --- Skill path resolution ---------------------------------------
-SP_BASE="$HOME/.claude/plugins/cache/claude-plugins-official/superpowers"
-SP_SKILLS=""
-if [[ -d "$SP_BASE" ]]; then
-  SP_VERSION=$(ls -1 "$SP_BASE" 2>/dev/null | sort -V | tail -1)
-  [[ -n "$SP_VERSION" ]] && SP_SKILLS="$SP_BASE/$SP_VERSION/skills"
-fi
-USER_SKILLS="$HOME/.claude/skills"
-PLUGIN_CACHE="$HOME/.claude/plugins/cache/claude-plugins-official"
+# =================================================================
+# LOAD REGISTRY
+# =================================================================
+REGISTRY_CACHE="${HOME}/.claude/.skill-registry-cache.json"
+FALLBACK_REGISTRY="${PLUGIN_ROOT}/config/fallback-registry.json"
+REGISTRY=""
 
-skill_path() {
-  case "$1" in
-    frontend-design)
-      [[ -d "$PLUGIN_CACHE/frontend-design" ]] && echo "Call Skill(frontend-design:frontend-design)" && return ;;
-    claude-md-improver)
-      [[ -d "$PLUGIN_CACHE/claude-md-management" ]] && echo "Call Skill(claude-md-management:claude-md-improver)" && return ;;
-    claude-automation-recommender)
-      [[ -d "$PLUGIN_CACHE/claude-code-setup" ]] && echo "Call Skill(claude-code-setup:claude-automation-recommender)" && return ;;
-    doc-coauthoring|webapp-testing|security-scanner)
-      [[ -f "$USER_SKILLS/$1/SKILL.md" ]] && echo "Read $USER_SKILLS/$1/SKILL.md" && return ;;
-    *)
-      [[ -n "$SP_SKILLS" && -f "$SP_SKILLS/$1/SKILL.md" ]] && echo "Read $SP_SKILLS/$1/SKILL.md" && return ;;
+if [[ -f "$REGISTRY_CACHE" ]] && jq empty "$REGISTRY_CACHE" >/dev/null 2>&1; then
+  REGISTRY="$(cat "$REGISTRY_CACHE")"
+elif [[ -f "$FALLBACK_REGISTRY" ]] && jq empty "$FALLBACK_REGISTRY" >/dev/null 2>&1; then
+  REGISTRY="$(cat "$FALLBACK_REGISTRY")"
+else
+  # No registry available — emit minimal phase checkpoint and exit
+  OUT="SKILL ACTIVATION (0 skills | phase checkpoint only)
+
+Phase: assess current phase (DESIGN/PLAN/IMPLEMENT/REVIEW/SHIP/DEBUG)
+and consider whether any installed skill applies."
+  printf '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":%s}}\n' \
+    "$(printf '%s' "$OUT" | jq -Rs .)"
+  exit 0
+fi
+
+# =================================================================
+# LOAD USER SETTINGS
+# =================================================================
+MAX_SUGGESTIONS=3
+VERBOSITY="normal"
+USER_CONFIG="${HOME}/.claude/skill-config.json"
+if [[ -f "$USER_CONFIG" ]] && jq empty "$USER_CONFIG" >/dev/null 2>&1; then
+  MAX_SUGGESTIONS="$(jq -r '.max_suggestions // 3' "$USER_CONFIG" 2>/dev/null)"
+  VERBOSITY="$(jq -r '.verbosity // "normal"' "$USER_CONFIG" 2>/dev/null)"
+fi
+
+# =================================================================
+# SCORE SKILLS AGAINST PROMPT
+# =================================================================
+# Use jq to iterate available+enabled skills, test each trigger regex
+# against the lowercased prompt, compute scores, and return sorted results.
+#
+# Score formula: trigger_score (3 for word-boundary, 1 for substring) + priority
+# We use jq to extract skill data, then bash for regex matching.
+
+# Extract skills array as line-delimited JSON objects (one per skill)
+SCORED_SKILLS="$(printf '%s' "$REGISTRY" | jq -c '
+  [.skills[] | select(.available == true and .enabled == true)][]
+' 2>/dev/null)"
+
+# Score each skill
+RESULTS=""
+while IFS= read -r skill_json; do
+  [[ -z "$skill_json" ]] && continue
+
+  skill_name="$(printf '%s' "$skill_json" | jq -r '.name')"
+  skill_role="$(printf '%s' "$skill_json" | jq -r '.role')"
+  skill_priority="$(printf '%s' "$skill_json" | jq -r '.priority // 0')"
+  skill_invoke="$(printf '%s' "$skill_json" | jq -r '.invoke // "SKIP"')"
+  skill_phase="$(printf '%s' "$skill_json" | jq -r '.phase // ""')"
+
+  trigger_count="$(printf '%s' "$skill_json" | jq '.triggers | length')"
+  trigger_score=0
+
+  ti=0
+  while [[ "$ti" -lt "$trigger_count" ]]; do
+    trigger="$(printf '%s' "$skill_json" | jq -r ".triggers[${ti}]")"
+    ti=$((ti + 1))
+
+    # Test regex against lowercased prompt
+    if [[ "$P" =~ $trigger ]]; then
+      matched="${BASH_REMATCH[0]}"
+      # Word-boundary heuristic: check chars before/after match
+      # Use substring removal to find match position
+      prefix="${P%%"$matched"*}"
+      prefix_len="${#prefix}"
+      after_pos=$((prefix_len + ${#matched}))
+      is_word_boundary=1
+
+      if [[ "$prefix_len" -gt 0 ]]; then
+        char_before="${P:$((prefix_len - 1)):1}"
+        if [[ "$char_before" =~ [a-z] ]]; then
+          is_word_boundary=0
+        fi
+      fi
+      if [[ "$after_pos" -lt "${#P}" ]]; then
+        char_after="${P:${after_pos}:1}"
+        if [[ "$char_after" =~ [a-z] ]]; then
+          is_word_boundary=0
+        fi
+      fi
+
+      if [[ "$is_word_boundary" -eq 1 ]]; then
+        this_score=3
+      else
+        this_score=1
+      fi
+
+      if [[ "$this_score" -gt "$trigger_score" ]]; then
+        trigger_score="$this_score"
+      fi
+    fi
+  done
+
+  if [[ "$trigger_score" -gt 0 ]]; then
+    final_score=$((trigger_score + skill_priority))
+    RESULTS="${RESULTS}${final_score}|${skill_name}|${skill_role}|${skill_invoke}|${skill_phase}
+"
+  fi
+done <<EOF
+${SCORED_SKILLS}
+EOF
+
+# Sort by score descending
+SORTED="$(printf '%s' "$RESULTS" | grep -v '^$' | sort -t'|' -k1 -rn)"
+
+# =================================================================
+# SELECT BY ROLE CAPS
+# =================================================================
+# Max 1 process, up to 2 domain, max 1 workflow, total <= max_suggestions
+SELECTED=""
+PROCESS_COUNT=0
+DOMAIN_COUNT=0
+WORKFLOW_COUNT=0
+TOTAL_COUNT=0
+
+while IFS='|' read -r score name role invoke phase; do
+  [[ -z "$name" ]] && continue
+  [[ "$TOTAL_COUNT" -ge "$MAX_SUGGESTIONS" ]] && break
+
+  case "$role" in
+    process)
+      [[ "$PROCESS_COUNT" -ge 1 ]] && continue
+      PROCESS_COUNT=$((PROCESS_COUNT + 1))
+      ;;
+    domain)
+      [[ "$DOMAIN_COUNT" -ge 2 ]] && continue
+      DOMAIN_COUNT=$((DOMAIN_COUNT + 1))
+      ;;
+    workflow)
+      [[ "$WORKFLOW_COUNT" -ge 1 ]] && continue
+      WORKFLOW_COUNT=$((WORKFLOW_COUNT + 1))
+      ;;
   esac
-  echo "SKIP"
-}
+
+  SELECTED="${SELECTED}${score}|${name}|${role}|${invoke}|${phase}
+"
+  TOTAL_COUNT=$((TOTAL_COUNT + 1))
+done <<EOF
+${SORTED}
+EOF
 
 # =================================================================
-# LAYER 1: PRIMARY INTENT (fast regex pre-filter)
-# Priority: Fix > Execute Plan > Build > Review > Ship
-# These are SUGGESTIONS -- Claude's phase assessment decides.
-# Broader patterns = fewer false negatives. Claude filters false positives.
+# DETERMINE LABEL
 # =================================================================
-PRIMARY="" PLABEL=""
+PLABEL=""
+PROCESS_SKILL=""
+HAS_DOMAIN=0
+HAS_WORKFLOW=0
 
-# --- Fix / Debug ---
-if [[ -z "$PLABEL" && "$P" =~ (debug|bug|fix|broken|fail|error|crash|wrong|unexpected|not.work|regression|issue|problem|doesn.t|won.t|can.t|stuck|hang|freeze|timeout|leak|corrupt|invalid|missing) ]]; then
-  PRIMARY="systematic-debugging test-driven-development"
-  PLABEL="Fix / Debug"
-fi
+while IFS='|' read -r score name role invoke phase; do
+  [[ -z "$name" ]] && continue
+  case "$role" in
+    process)
+      PROCESS_SKILL="$name"
+      case "$name" in
+        systematic-debugging)       PLABEL="Fix / Debug" ;;
+        brainstorming)              PLABEL="Build New" ;;
+        executing-plans|subagent-driven-development) PLABEL="Plan Execution" ;;
+        test-driven-development)    PLABEL="Run / Test" ;;
+        requesting-code-review|receiving-code-review) PLABEL="Review" ;;
+      esac
+      ;;
+    domain)
+      HAS_DOMAIN=1
+      ;;
+    workflow)
+      HAS_WORKFLOW=1
+      # If no process skill sets the label, workflow skills set Ship / Complete
+      if [[ -z "$PLABEL" ]]; then
+        case "$name" in
+          verification-before-completion|finishing-a-development-branch) PLABEL="Ship / Complete" ;;
+        esac
+      fi
+      ;;
+  esac
+done <<EOF
+${SELECTED}
+EOF
 
-# --- Plan Execution ---
-if [[ -z "$PLABEL" && "$P" =~ (execute.*plan|run.the.plan|implement.the.plan|implement.*(rest|remaining)|continue|follow.the.plan|pick.up|resume|next.task|next.step|carry.on|keep.going|where.were.we|what.s.next) ]]; then
-  PRIMARY="subagent-driven-development executing-plans"
-  PLABEL="Plan Execution"
-fi
-
-# --- Build / Create ---
-if [[ -z "$PLABEL" && "$P" =~ (build|create|implement|develop|scaffold|init|bootstrap|brainstorm|design|architect|strateg|scope|outline|approach|add|write|make|generate|set.?up|install|configure|wire.up|connect|integrate|extend|new|start|introduce|enable|support|how.(should|would|could)) ]]; then
-  PRIMARY="brainstorming test-driven-development"
-  PLABEL="Build New"
-fi
-
-# --- Modify / Update ---
-if [[ -z "$PLABEL" && "$P" =~ (update|change|modify|edit|alter|adjust|tweak|move|rename|replace|swap|switch|convert|transform|migrate|upgrade|downgrade|bump|patch|optimize|improve|enhance|speed.up|performance|refactor|restructure|reorganize|simplify|consolidate|extract|inline|split|combine) ]]; then
-  PRIMARY="brainstorming test-driven-development"
-  PLABEL="Modify / Update"
-fi
-
-# --- Remove / Clean ---
-if [[ -z "$PLABEL" && "$P" =~ (remove|delete|drop|clean|prune|strip|deprecate|disable|turn.off|get.rid|eliminate|unused|dead.code) ]]; then
-  PRIMARY="brainstorming test-driven-development"
-  PLABEL="Remove / Clean"
-fi
-
-# --- Review ---
-if [[ -z "$PLABEL" && "$P" =~ (review|pull.?request|code.?review|check.*(code|changes|diff)|code.?quality|lint|smell|tech.?debt|(^|[^a-z])pr($|[^a-z])) ]]; then
-  PRIMARY="requesting-code-review receiving-code-review"
-  PLABEL="Review"
-fi
-
-# --- Ship / Complete ---
-if [[ -z "$PLABEL" && "$P" =~ (ship|merge|deploy|push|release|tag|publish|pr.ready|ready.to|wrap.?up|all.(done|good|green|passing)|lgtm|finalize|complete|finish) ]]; then
-  PRIMARY="verification-before-completion finishing-a-development-branch"
-  PLABEL="Ship / Complete"
-fi
-
-# --- Investigate / Understand ---
-if [[ -z "$PLABEL" && "$P" =~ (explain|understand|what.is|what.does|how.does|where.is|find|search|look.at|show.me|trace|investigate|analyze|profile|benchmark|measure|count|list|summarize|describe|walk.me|dig.into) ]]; then
-  PRIMARY="systematic-debugging"
-  PLABEL="Investigate"
-fi
-
-# --- Run / Test ---
-if [[ -z "$PLABEL" && "$P" =~ (run|test|execute|verify|validate|check|ensure|confirm|try|attempt|evaluate|assert|expect|coverage|pass|green) ]]; then
-  PRIMARY="test-driven-development"
-  PLABEL="Run / Test"
-fi
-
-# =================================================================
-# LAYER 2: CROSS-CUTTING OVERLAYS (additive)
-# =================================================================
-OVERLAY="" OLABEL=""
-
-if [[ "$P" =~ (secur(e|ity)|vulnerab|owasp|pentest|attack|exploit|compliance|hipaa|gdpr|encrypt|auth(entication|orization)|inject|xss|csrf|sanitiz|supply.?chain) ]]; then
-  OVERLAY+=" security-scanner"; OLABEL+="Security "
-fi
-if [[ "$P" =~ (^|[^a-z])(ui|frontend|component|layout|style|css|tailwind|responsive|dashboard|landing.?page|mockup|wireframe)($|[^a-z]) ]]; then
-  OVERLAY+=" frontend-design webapp-testing"; OLABEL+="Frontend "
-fi
-if [[ "$P" =~ (proposal|spec[^a-z]|rfc|write.?up|technical.?doc|architecture.?doc|documentation) ]]; then
-  OVERLAY+=" doc-coauthoring"; OLABEL+="Docs "
-fi
-if [[ "$P" =~ (claude\.md|claude.md|\.claude|skill|hook|mcp|plugin) ]]; then
-  OVERLAY+=" claude-automation-recommender claude-md-improver writing-skills"; OLABEL+="Meta "
-fi
-if [[ "$P" =~ (parallel|concurrent|multiple.*(failure|bug|issue|error|test)|independent.*(task|failure|bug|issue|test)|worktree) ]]; then
-  OVERLAY+=" dispatching-parallel-agents using-git-worktrees"; OLABEL+="Parallel "
-fi
+[[ -z "$PLABEL" ]] && PLABEL="(Claude: assess intent)"
+[[ "$HAS_DOMAIN" -eq 1 ]] && PLABEL="${PLABEL} + Domain"
+[[ "$HAS_WORKFLOW" -eq 1 ]] && PLABEL="${PLABEL} + Workflow"
 
 # =================================================================
 # METHODOLOGY HINTS
 # =================================================================
 HINTS=""
-if [[ -d "$PLUGIN_CACHE/ralph-loop" && "$P" =~ (migrate|refactor.all|fix.all|batch|overnight|autonom|iterate|keep.(going|trying|fixing)|until.*(pass|work|complet|succeed)|make.*tests?.pass|run.*until|loop|coverage|greenfield) ]]; then
-  HINTS+="\n- RALPH LOOP: Consider /ralph-loop for autonomous iteration."
-fi
-if [[ -d "$PLUGIN_CACHE/pr-review-toolkit" && "$P" =~ (review|pull.?request|code.?review|(^|[^a-z])pr($|[^a-z])) ]]; then
-  HINTS+="\n- PR REVIEW: Consider /pr-review for structured review."
-fi
-
-# =================================================================
-# BUILD OUTPUT
-# =================================================================
-ALL_SKILLS=$(echo "$PRIMARY $OVERLAY" | tr ' ' '\n' | sort -u | grep -v '^$' | tr '\n' ' ')
-
-# Resolve paths, skip missing
-TABLE="" COUNT=0
-for skill in $ALL_SKILLS; do
-  method=$(skill_path "$skill")
-  [[ "$method" == "SKIP" ]] && continue
-  TABLE+="  $skill -> $method\n"
-  ((COUNT++))
+HINT_COUNT="$(printf '%s' "$REGISTRY" | jq '.methodology_hints // [] | length' 2>/dev/null)" || HINT_COUNT=0
+hi=0
+while [[ "$hi" -lt "$HINT_COUNT" ]]; do
+  hint_triggers="$(printf '%s' "$REGISTRY" | jq -r ".methodology_hints[${hi}].triggers[]" 2>/dev/null)"
+  hint_text="$(printf '%s' "$REGISTRY" | jq -r ".methodology_hints[${hi}].hint" 2>/dev/null)"
+  while IFS= read -r htrigger; do
+    [[ -z "$htrigger" ]] && continue
+    if [[ "$P" =~ $htrigger ]]; then
+      HINTS="${HINTS}
+- ${hint_text}"
+      break
+    fi
+  done <<HEOF
+${hint_triggers}
+HEOF
+  hi=$((hi + 1))
 done
 
-# --- FALLTHROUGH: always emit phase checkpoint -------------------
-# v8: We already filtered non-dev prompts above. If we got here,
-# the prompt is likely dev-related. Always emit the phase checkpoint
-# so Claude can self-assess intent, even with 0 skill matches.
-[[ -z "$PLABEL" ]] && PLABEL="(Claude: assess intent)"
+# =================================================================
+# BUILD ORCHESTRATED CONTEXT OUTPUT
+# =================================================================
 
-OLABEL="${OLABEL% }"
+if [[ "$TOTAL_COUNT" -eq 0 ]]; then
+  # --- 0 skills matched ---
+  OUT="SKILL ACTIVATION (0 skills | phase checkpoint only)
 
-LABELS=""
-[[ -n "$PLABEL" ]] && LABELS="$PLABEL"
-if [[ -n "$OLABEL" ]]; then
-  [[ -n "$LABELS" ]] && LABELS="$LABELS + $OLABEL" || LABELS="$OLABEL"
-fi
+Phase: assess current phase (DESIGN/PLAN/IMPLEMENT/REVIEW/SHIP/DEBUG)
+and consider whether any installed skill applies."
 
-# --- Assemble instruction ----------------------------------------
-OUT="SKILL ACTIVATION ($COUNT skills | $LABELS)"
+elif [[ "$TOTAL_COUNT" -le 2 ]]; then
+  # --- 1-2 skills (compact format) ---
+  OUT="SKILL ACTIVATION (${TOTAL_COUNT} skills | ${PLABEL})"
+  OUT+="
+"
 
-# Phase map ALWAYS included -- Claude does the real classification
-OUT+="
+  # Build skill lines
+  PROCESS_LINE=""
+  DOMAIN_LINES=""
+  WORKFLOW_LINES=""
+  STANDALONE_LINES=""
+  EVAL_SKILLS=""
+
+  while IFS='|' read -r score name role invoke phase; do
+    [[ -z "$name" ]] && continue
+    if [[ -n "$EVAL_SKILLS" ]]; then
+      EVAL_SKILLS="${EVAL_SKILLS}, ${name} YES/NO"
+    else
+      EVAL_SKILLS="${name} YES/NO"
+    fi
+
+    if [[ -n "$PROCESS_SKILL" ]]; then
+      case "$role" in
+        process)  PROCESS_LINE="
+Process: ${name} -> ${invoke}" ;;
+        domain)   DOMAIN_LINES="${DOMAIN_LINES}
+  INFORMED BY: ${name} -> ${invoke}" ;;
+        workflow) WORKFLOW_LINES="${WORKFLOW_LINES}
+Workflow: ${name} -> ${invoke}" ;;
+      esac
+    else
+      STANDALONE_LINES="${STANDALONE_LINES}
+${name} -> ${invoke}"
+    fi
+  done <<EOF
+${SELECTED}
+EOF
+
+  OUT+="${PROCESS_LINE}${DOMAIN_LINES}${WORKFLOW_LINES}${STANDALONE_LINES}"
+
+  # Get phase from process skill or first skill
+  EVAL_PHASE=""
+  while IFS='|' read -r score name role invoke phase; do
+    [[ -z "$name" ]] && continue
+    if [[ -n "$phase" ]]; then
+      EVAL_PHASE="$phase"
+      break
+    fi
+  done <<EOF
+${SELECTED}
+EOF
+  [[ -z "$EVAL_PHASE" ]] && EVAL_PHASE="IMPLEMENT"
+
+  OUT+="
+
+Evaluate: **Phase: [${EVAL_PHASE}]** | ${EVAL_SKILLS}"
+
+else
+  # --- 3+ skills (full format) ---
+  OUT="SKILL ACTIVATION (${TOTAL_COUNT} skills | ${PLABEL})"
+
+  OUT+="
 
 Step 1 -- ASSESS PHASE. Check conversation context:
   DESIGN    -> brainstorming (ask questions, get approval)
@@ -199,25 +328,51 @@ Step 1 -- ASSESS PHASE. Check conversation context:
   IMPLEMENT -> executing-plans or subagent-driven-development + TDD
   REVIEW    -> requesting-code-review
   SHIP      -> verification-before-completion + finishing-a-development-branch
-  DEBUG     -> systematic-debugging, then return to current phase"
+  DEBUG     -> systematic-debugging, then return to current phase
 
-if (( COUNT > 0 )); then
+Step 2 -- EVALUATE skills against your phase assessment."
+
+  # Build skill lines with orchestration
+  EVAL_SKILLS=""
+
+  while IFS='|' read -r score name role invoke phase; do
+    [[ -z "$name" ]] && continue
+    if [[ -n "$EVAL_SKILLS" ]]; then
+      EVAL_SKILLS="${EVAL_SKILLS}, ${name} YES/NO"
+    else
+      EVAL_SKILLS="${name} YES/NO"
+    fi
+
+    if [[ -n "$PROCESS_SKILL" ]]; then
+      case "$role" in
+        process)  OUT+="
+Process: ${name} -> ${invoke}" ;;
+        domain)   OUT+="
+  INFORMED BY: ${name} -> ${invoke}" ;;
+        workflow) OUT+="
+Workflow: ${name} -> ${invoke}" ;;
+      esac
+    else
+      OUT+="
+${name} -> ${invoke}"
+    fi
+  done <<EOF
+${SELECTED}
+EOF
+
   OUT+="
-
-Step 2 -- EVALUATE skills against your phase assessment.
-$(printf '%b' "$TABLE")
 You MUST print a brief evaluation for each skill above. Format:
   **Phase: [PHASE]** | [skill1] YES/NO, [skill2] YES/NO
 Example: **Phase: IMPLEMENT** | test-driven-development YES, claude-md-improver NO (not editing CLAUDE.md)
-This line is MANDATORY -- do not skip it."
-fi
-
-OUT+="
+This line is MANDATORY -- do not skip it.
 
 Step 3 -- State your plan and proceed. Keep it to 1-2 sentences."
+fi
 
+# Append methodology hints if any
 if [[ -n "$HINTS" ]]; then
-  OUT+="\n$(printf '%b' "$HINTS")"
+  OUT+="
+${HINTS}"
 fi
 
 printf '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":%s}}\n' \

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# run-tests.sh — Discovers and runs all test-*.sh files in the tests/ directory.
+# Bash 3.2 compatible (macOS default). CI-ready: exits 1 on any failure.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+TOTAL_FILES=0
+PASSED_FILES=0
+FAILED_FILES=0
+FAILED_NAMES=""
+
+# Discover test files (excluding test-helpers.sh itself)
+test_files=""
+for f in "${SCRIPT_DIR}"/test-*.sh; do
+    [ -f "$f" ] || continue
+    case "$(basename "$f")" in
+        test-helpers.sh) continue ;;
+    esac
+    test_files="${test_files} ${f}"
+done
+
+if [ -z "${test_files}" ]; then
+    echo "No test files found in ${SCRIPT_DIR}/test-*.sh"
+    exit 0
+fi
+
+echo "============================================"
+echo "  auto-claude-skills test runner"
+echo "============================================"
+echo ""
+
+for test_file in ${test_files}; do
+    name="$(basename "${test_file}")"
+    echo "--- Running: ${name} ---"
+    TOTAL_FILES=$((TOTAL_FILES + 1))
+
+    if bash "${test_file}"; then
+        PASSED_FILES=$((PASSED_FILES + 1))
+    else
+        FAILED_FILES=$((FAILED_FILES + 1))
+        if [ -n "${FAILED_NAMES}" ]; then
+            FAILED_NAMES="${FAILED_NAMES}, ${name}"
+        else
+            FAILED_NAMES="${name}"
+        fi
+    fi
+    echo ""
+done
+
+echo "============================================"
+printf "  Files run:    %d\n" "${TOTAL_FILES}"
+printf "  Files passed: %d\n" "${PASSED_FILES}"
+printf "  Files failed: %d\n" "${FAILED_FILES}"
+echo "============================================"
+
+if [ "${FAILED_FILES}" -gt 0 ]; then
+    echo ""
+    echo "Failed: ${FAILED_NAMES}"
+    exit 1
+fi
+
+echo "All test files passed."
+exit 0

--- a/tests/test-context.sh
+++ b/tests/test-context.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+# test-context.sh — Tests for adaptive context injection output format
+# Bash 3.2 compatible. Sources test-helpers.sh for setup/teardown and assertions.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+HOOK="${PROJECT_ROOT}/hooks/skill-activation-hook.sh"
+
+# shellcheck source=test-helpers.sh
+. "${SCRIPT_DIR}/test-helpers.sh"
+
+echo "=== test-context.sh ==="
+
+# ---------------------------------------------------------------------------
+# Helper: run the hook with a given prompt, return stdout
+# ---------------------------------------------------------------------------
+run_hook() {
+    local prompt="$1"
+    printf '{"prompt":"%s"}' "${prompt}" | \
+        CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" \
+        bash "${HOOK}" 2>/dev/null
+}
+
+# Helper: extract the additionalContext text from hook JSON output
+extract_context() {
+    local output="$1"
+    printf '%s' "${output}" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Registry with varied skills: process, domain, workflow, superpowers invoke
+# ---------------------------------------------------------------------------
+install_context_registry() {
+    local cache_file="${HOME}/.claude/.skill-registry-cache.json"
+    mkdir -p "$(dirname "${cache_file}")"
+    cat > "${cache_file}" <<'REGISTRY'
+{
+  "version": "2.0.0",
+  "skills": [
+    {
+      "name": "systematic-debugging",
+      "role": "process",
+      "phase": "DEBUG",
+      "triggers": [
+        "(debug|bug|fix|broken|fail|error|crash|wrong|unexpected|not.work|regression|issue|problem)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 10,
+      "invoke": "Skill(superpowers:systematic-debugging)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "brainstorming",
+      "role": "process",
+      "phase": "DESIGN",
+      "triggers": [
+        "(build|create|implement|develop|scaffold|brainstorm|design|architect|add|write|make|generate|new|start)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 30,
+      "invoke": "Skill(superpowers:brainstorming)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "test-driven-development",
+      "role": "process",
+      "phase": "IMPLEMENT",
+      "triggers": [
+        "(build|create|implement|add|write|make)",
+        "(run|test|execute|verify|validate|check|coverage)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 20,
+      "invoke": "Skill(superpowers:test-driven-development)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "executing-plans",
+      "role": "process",
+      "phase": "IMPLEMENT",
+      "triggers": [
+        "(execute.*plan|run.the.plan|implement.the.plan|continue|follow.the.plan|resume|next.task|next.step)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 15,
+      "invoke": "Skill(superpowers:executing-plans)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "requesting-code-review",
+      "role": "process",
+      "phase": "REVIEW",
+      "triggers": [
+        "(review|pull.?request|code.?review|check.*(code|changes|diff)|code.?quality|lint|tech.?debt|(^|[^a-z])pr($|[^a-z]))"
+      ],
+      "trigger_mode": "regex",
+      "priority": 50,
+      "invoke": "Skill(superpowers:requesting-code-review)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "security-scanner",
+      "role": "domain",
+      "triggers": [
+        "(secur(e|ity)|vulnerab|owasp|pentest|attack|exploit|encrypt|inject|xss|csrf)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 102,
+      "invoke": "Skill(superpowers:security-scanner)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "frontend-design",
+      "role": "domain",
+      "triggers": [
+        "(ui|frontend|component|layout|style|css|tailwind|responsive|dashboard)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 101,
+      "invoke": "Skill(superpowers:frontend-design)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "verification-before-completion",
+      "role": "workflow",
+      "triggers": [
+        "(ship|merge|deploy|push|release|tag|publish|pr.ready|ready.to|wrap.?up|finalize|complete|finish)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 60,
+      "invoke": "Skill(superpowers:verification-before-completion)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "finishing-a-development-branch",
+      "role": "workflow",
+      "triggers": [
+        "(ship|merge|deploy|push|release|tag|publish|pr.ready|ready.to|wrap.?up|finalize|complete|finish)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 61,
+      "invoke": "Skill(superpowers:finishing-a-development-branch)",
+      "available": true,
+      "enabled": true
+    }
+  ],
+  "methodology_hints": [],
+  "blocklist_patterns": [
+    {
+      "pattern": "^(hi|hello|hey|thanks|thank.you|good.(morning|afternoon|evening)|bye|goodbye|ok|okay|yes|no|sure|yep|nope|got.it|sounds.good|cool|nice|great|perfect|awesome|understood)([[:space:]!.,]+.{0,20})?$",
+      "description": "Greeting or short acknowledgement",
+      "max_tail_length": 20
+    }
+  ],
+  "warnings": []
+}
+REGISTRY
+}
+
+# ---------------------------------------------------------------------------
+# 1. 0 skills -> minimal output (phase checkpoint, no Step 2)
+# ---------------------------------------------------------------------------
+test_zero_skills_minimal_output() {
+    echo "-- test: 0 skills -> minimal output --"
+    setup_test_env
+    install_context_registry
+
+    local output
+    output="$(run_hook "tell me about the weather forecast for tomorrow please")"
+    local context
+    context="$(extract_context "${output}")"
+
+    assert_contains "0 skills has phase checkpoint" "phase checkpoint" "$(printf '%s' "${context}" | tr '[:upper:]' '[:lower:]')"
+    assert_not_contains "0 skills does NOT have Step 2" "Step 2" "${context}"
+    assert_contains "0 skills mentions 0 skills" "0 skills" "${context}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 2. 1 skill -> compact format (Process: and Evaluate:, no Step 1)
+# ---------------------------------------------------------------------------
+test_single_skill_compact_format() {
+    echo "-- test: 1 skill -> compact format --"
+    setup_test_env
+    install_context_registry
+
+    # "debug" triggers systematic-debugging only (1 process skill)
+    local output
+    output="$(run_hook "I need to debug this crash in the auth module")"
+    local context
+    context="$(extract_context "${output}")"
+
+    assert_contains "1 skill has Process:" "Process:" "${context}"
+    assert_contains "1 skill has Evaluate:" "Evaluate:" "${context}"
+    assert_not_contains "1 skill does NOT have Step 1" "Step 1" "${context}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 3. Process + domain -> INFORMED BY
+# ---------------------------------------------------------------------------
+test_process_domain_informed_by() {
+    echo "-- test: process + domain -> INFORMED BY --"
+    setup_test_env
+    install_context_registry
+
+    # "build a secure" triggers brainstorming (process) + security-scanner (domain)
+    local output
+    output="$(run_hook "build a secure authentication service with encryption")"
+    local context
+    context="$(extract_context "${output}")"
+
+    assert_contains "process+domain has INFORMED BY" "INFORMED BY" "${context}"
+    assert_contains "process+domain has Process:" "Process:" "${context}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 4. 3+ skills -> full format with phase map
+# ---------------------------------------------------------------------------
+test_many_skills_full_format() {
+    echo "-- test: 3+ skills -> full format with phase map --"
+    setup_test_env
+    install_context_registry
+
+    # "build a secure frontend dashboard" triggers:
+    #   brainstorming (process, prio 30), test-driven-development (process, prio 20),
+    #   security-scanner (domain, prio 102), frontend-design (domain, prio 101)
+    # After role caps: 1 process + 2 domain = 3 selected -> full format
+    local output
+    output="$(run_hook "build a secure frontend dashboard component with csrf protection")"
+    local context
+    context="$(extract_context "${output}")"
+
+    assert_contains "3+ skills has Step 1" "Step 1" "${context}"
+    assert_contains "3+ skills has MANDATORY" "MANDATORY" "${context}"
+    assert_contains "3+ skills has DESIGN phase" "DESIGN" "${context}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 5. Invocation hints contain Skill(superpowers:
+# ---------------------------------------------------------------------------
+test_invocation_hints_present() {
+    echo "-- test: invocation hints contain Skill(superpowers: --"
+    setup_test_env
+    install_context_registry
+
+    local output
+    output="$(run_hook "I need to debug this crash in the auth module")"
+    local context
+    context="$(extract_context "${output}")"
+
+    assert_contains "invocation hint present" "Skill(superpowers:" "${context}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 6. Output is valid hook JSON
+# ---------------------------------------------------------------------------
+test_output_valid_json_zero_match() {
+    echo "-- test: 0-match output is valid JSON --"
+    setup_test_env
+    install_context_registry
+
+    local output
+    output="$(run_hook "tell me about the weather forecast for tomorrow please")"
+    local tmpfile="${TEST_TMPDIR}/output-zero.json"
+    printf '%s' "${output}" > "${tmpfile}"
+    assert_json_valid "0-match output is valid JSON" "${tmpfile}"
+
+    teardown_test_env
+}
+
+test_output_valid_json_single_match() {
+    echo "-- test: single-match output is valid JSON --"
+    setup_test_env
+    install_context_registry
+
+    local output
+    output="$(run_hook "I need to debug this crash in the auth module")"
+    local tmpfile="${TEST_TMPDIR}/output-single.json"
+    printf '%s' "${output}" > "${tmpfile}"
+    assert_json_valid "single-match output is valid JSON" "${tmpfile}"
+
+    teardown_test_env
+}
+
+test_output_valid_json_multi_match() {
+    echo "-- test: multi-match output is valid JSON --"
+    setup_test_env
+    install_context_registry
+
+    local output
+    output="$(run_hook "build a secure frontend dashboard component with csrf protection")"
+    local tmpfile="${TEST_TMPDIR}/output-multi.json"
+    printf '%s' "${output}" > "${tmpfile}"
+    assert_json_valid "multi-match output is valid JSON" "${tmpfile}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+test_zero_skills_minimal_output
+test_single_skill_compact_format
+test_process_domain_informed_by
+test_many_skills_full_format
+test_invocation_hints_present
+test_output_valid_json_zero_match
+test_output_valid_json_single_match
+test_output_valid_json_multi_match
+
+print_summary

--- a/tests/test-helpers.sh
+++ b/tests/test-helpers.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# test-helpers.sh — Source-able test helper library for auto-claude-skills
+# Bash 3.2 compatible (macOS default). No external deps beyond bash and jq.
+
+# ---------------------------------------------------------------------------
+# Counters
+# ---------------------------------------------------------------------------
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+FAIL_MESSAGES=""
+
+# ---------------------------------------------------------------------------
+# Environment setup / teardown
+# ---------------------------------------------------------------------------
+setup_test_env() {
+    TEST_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/acs-test.XXXXXXXX")"
+
+    TEST_HOME="${TEST_TMPDIR}/home"
+    TEST_PLUGIN_CACHE="${TEST_HOME}/.claude/plugin-cache"
+    TEST_USER_SKILLS="${TEST_HOME}/.claude/user-skills"
+    TEST_REGISTRY_CACHE="${TEST_HOME}/.claude/registry-cache"
+    TEST_USER_CONFIG="${TEST_HOME}/.claude/config.json"
+
+    mkdir -p "${TEST_PLUGIN_CACHE}"
+    mkdir -p "${TEST_USER_SKILLS}"
+    mkdir -p "${TEST_REGISTRY_CACHE}"
+    mkdir -p "$(dirname "${TEST_USER_CONFIG}")"
+
+    export HOME="${TEST_HOME}"
+    export CLAUDE_PLUGIN_ROOT="${TEST_HOME}/.claude"
+
+    export TEST_TMPDIR TEST_HOME TEST_PLUGIN_CACHE TEST_USER_SKILLS
+    export TEST_REGISTRY_CACHE TEST_USER_CONFIG
+}
+
+teardown_test_env() {
+    if [ -n "${TEST_TMPDIR:-}" ] && [ -d "${TEST_TMPDIR}" ]; then
+        rm -rf "${TEST_TMPDIR}"
+    fi
+    unset TEST_TMPDIR TEST_HOME TEST_PLUGIN_CACHE TEST_USER_SKILLS
+    unset TEST_REGISTRY_CACHE TEST_USER_CONFIG
+}
+
+# ---------------------------------------------------------------------------
+# Assertion helpers
+# ---------------------------------------------------------------------------
+
+# _record_pass description
+_record_pass() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    printf "  PASS: %s\n" "$1"
+}
+
+# _record_fail description detail
+_record_fail() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    printf "  FAIL: %s\n" "$1"
+    if [ -n "${2:-}" ]; then
+        printf "        %s\n" "$2"
+    fi
+    if [ -n "${FAIL_MESSAGES}" ]; then
+        FAIL_MESSAGES="${FAIL_MESSAGES}
+"
+    fi
+    FAIL_MESSAGES="${FAIL_MESSAGES}FAIL: $1"
+}
+
+# assert_equals description expected actual
+assert_equals() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+
+    if [ "${expected}" = "${actual}" ]; then
+        _record_pass "${description}"
+    else
+        _record_fail "${description}" "expected: '${expected}', got: '${actual}'"
+    fi
+}
+
+# assert_contains description needle haystack
+assert_contains() {
+    local description="$1"
+    local needle="$2"
+    local haystack="$3"
+
+    case "${haystack}" in
+        *"${needle}"*)
+            _record_pass "${description}"
+            ;;
+        *)
+            _record_fail "${description}" "expected to contain: '${needle}'"
+            ;;
+    esac
+}
+
+# assert_not_contains description needle haystack
+assert_not_contains() {
+    local description="$1"
+    local needle="$2"
+    local haystack="$3"
+
+    case "${haystack}" in
+        *"${needle}"*)
+            _record_fail "${description}" "expected NOT to contain: '${needle}'"
+            ;;
+        *)
+            _record_pass "${description}"
+            ;;
+    esac
+}
+
+# assert_json_valid description file
+assert_json_valid() {
+    local description="$1"
+    local file="$2"
+
+    if [ ! -f "${file}" ]; then
+        _record_fail "${description}" "file does not exist: ${file}"
+        return
+    fi
+
+    if jq empty "${file}" >/dev/null 2>&1; then
+        _record_pass "${description}"
+    else
+        _record_fail "${description}" "invalid JSON in: ${file}"
+    fi
+}
+
+# assert_file_exists description file
+assert_file_exists() {
+    local description="$1"
+    local file="$2"
+
+    if [ -f "${file}" ]; then
+        _record_pass "${description}"
+    else
+        _record_fail "${description}" "file not found: ${file}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+print_summary() {
+    echo ""
+    echo "=============================="
+    printf "Tests run:    %d\n" "${TESTS_RUN}"
+    printf "Tests passed: %d\n" "${TESTS_PASSED}"
+    printf "Tests failed: %d\n" "${TESTS_FAILED}"
+    echo "=============================="
+
+    if [ "${TESTS_FAILED}" -gt 0 ]; then
+        echo ""
+        echo "Failures:"
+        printf "%s\n" "${FAIL_MESSAGES}"
+        return 1
+    fi
+
+    echo "All tests passed."
+    return 0
+}

--- a/tests/test-install.sh
+++ b/tests/test-install.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# test-install.sh — Validation tests for installed plugin structure
+# These tests verify that all required files exist and are valid.
+
+set -euo pipefail
+
+# Set SCRIPT_DIR for portability
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Use CLAUDE_PLUGIN_ROOT if set, otherwise fallback to parent directory
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(dirname "${SCRIPT_DIR}")}"
+
+# Source test helpers for assert functions
+source "${SCRIPT_DIR}/test-helpers.sh"
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+echo "Install Validation Tests"
+echo "======================="
+echo "Plugin root: ${PLUGIN_ROOT}"
+echo ""
+
+# Test 1: config/default-triggers.json exists and is valid JSON
+assert_file_exists \
+    "config/default-triggers.json exists" \
+    "${PLUGIN_ROOT}/config/default-triggers.json"
+
+assert_json_valid \
+    "config/default-triggers.json is valid JSON" \
+    "${PLUGIN_ROOT}/config/default-triggers.json"
+
+# Test 2: config/fallback-registry.json exists and is valid JSON
+assert_file_exists \
+    "config/fallback-registry.json exists" \
+    "${PLUGIN_ROOT}/config/fallback-registry.json"
+
+assert_json_valid \
+    "config/fallback-registry.json is valid JSON" \
+    "${PLUGIN_ROOT}/config/fallback-registry.json"
+
+# Test 3: hooks/skill-activation-hook.sh exists and is executable
+assert_file_exists \
+    "hooks/skill-activation-hook.sh exists" \
+    "${PLUGIN_ROOT}/hooks/skill-activation-hook.sh"
+
+if [ -x "${PLUGIN_ROOT}/hooks/skill-activation-hook.sh" ]; then
+    _record_pass "hooks/skill-activation-hook.sh is executable"
+else
+    _record_fail "hooks/skill-activation-hook.sh is executable" \
+        "file is not executable"
+fi
+
+# Test 4: hooks/session-start-hook.sh exists and is executable
+assert_file_exists \
+    "hooks/session-start-hook.sh exists" \
+    "${PLUGIN_ROOT}/hooks/session-start-hook.sh"
+
+if [ -x "${PLUGIN_ROOT}/hooks/session-start-hook.sh" ]; then
+    _record_pass "hooks/session-start-hook.sh is executable"
+else
+    _record_fail "hooks/session-start-hook.sh is executable" \
+        "file is not executable"
+fi
+
+# Test 5: hooks/fix-plugin-manifests.sh exists and is executable
+assert_file_exists \
+    "hooks/fix-plugin-manifests.sh exists" \
+    "${PLUGIN_ROOT}/hooks/fix-plugin-manifests.sh"
+
+if [ -x "${PLUGIN_ROOT}/hooks/fix-plugin-manifests.sh" ]; then
+    _record_pass "hooks/fix-plugin-manifests.sh is executable"
+else
+    _record_fail "hooks/fix-plugin-manifests.sh is executable" \
+        "file is not executable"
+fi
+
+# Test 6: hooks/hooks.json exists, is valid JSON, and references both hooks
+assert_file_exists \
+    "hooks/hooks.json exists" \
+    "${PLUGIN_ROOT}/hooks/hooks.json"
+
+assert_json_valid \
+    "hooks/hooks.json is valid JSON" \
+    "${PLUGIN_ROOT}/hooks/hooks.json"
+
+# Verify hooks.json references session-start-hook.sh
+HOOKS_CONTENT=$(cat "${PLUGIN_ROOT}/hooks/hooks.json")
+assert_contains \
+    "hooks.json references session-start-hook.sh" \
+    "session-start-hook.sh" \
+    "${HOOKS_CONTENT}"
+
+# Verify hooks.json references skill-activation-hook.sh
+assert_contains \
+    "hooks.json references skill-activation-hook.sh" \
+    "skill-activation-hook.sh" \
+    "${HOOKS_CONTENT}"
+
+# Test 7: .claude-plugin/plugin.json exists and is valid JSON
+assert_file_exists \
+    ".claude-plugin/plugin.json exists" \
+    "${PLUGIN_ROOT}/.claude-plugin/plugin.json"
+
+assert_json_valid \
+    ".claude-plugin/plugin.json is valid JSON" \
+    "${PLUGIN_ROOT}/.claude-plugin/plugin.json"
+
+# ---------------------------------------------------------------------------
+# Print summary and exit with appropriate code
+# ---------------------------------------------------------------------------
+print_summary

--- a/tests/test-registry.sh
+++ b/tests/test-registry.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# test-registry.sh — Tests for the session-start registry builder hook
+# Bash 3.2 compatible. Sources test-helpers.sh for setup/teardown and assertions.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+HOOK="${PROJECT_ROOT}/hooks/session-start-hook.sh"
+
+# shellcheck source=test-helpers.sh
+. "${SCRIPT_DIR}/test-helpers.sh"
+
+echo "=== test-registry.sh ==="
+
+# ---------------------------------------------------------------------------
+# Helper: run the hook with captured output
+# ---------------------------------------------------------------------------
+run_hook() {
+    # CLAUDE_PLUGIN_ROOT must point to the project root so the hook
+    # can find config/default-triggers.json etc.
+    CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" \
+        bash "${HOOK}" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# 1. Empty environment produces fallback registry
+# ---------------------------------------------------------------------------
+test_empty_env_produces_fallback() {
+    echo "-- test: empty environment produces fallback registry --"
+    setup_test_env
+
+    # Remove all plugin/skill dirs so nothing is discovered
+    rm -rf "${HOME}/.claude/plugins"
+    rm -rf "${HOME}/.claude/skills"
+
+    local output
+    output="$(run_hook)"
+
+    local cache_file="${HOME}/.claude/.skill-registry-cache.json"
+    assert_file_exists "cache file created" "${cache_file}"
+    assert_json_valid "cache file is valid JSON" "${cache_file}"
+
+    # Should have a version field
+    local version
+    version="$(jq -r '.version' "${cache_file}" 2>/dev/null)"
+    assert_contains "registry has version" "2.0" "${version}"
+
+    # Should have skills array
+    local skill_count
+    skill_count="$(jq '.skills | length' "${cache_file}" 2>/dev/null)"
+    # With no plugins, skills from defaults should be marked available: false
+    # but still present
+    assert_contains "skills array exists" "" "$(jq -r '.skills' "${cache_file}" 2>/dev/null)"
+
+    # Health check output
+    assert_contains "health check in output" "skill registry built" "${output}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 2. Discovers superpowers plugin skills (mock skill dir)
+# ---------------------------------------------------------------------------
+test_discovers_superpowers_skills() {
+    echo "-- test: discovers superpowers plugin skills --"
+    setup_test_env
+
+    # Create mock superpowers skill directory
+    local sp_dir="${HOME}/.claude/plugins/cache/claude-plugins-official/superpowers/1.0.0/skills"
+    mkdir -p "${sp_dir}/brainstorming"
+    printf '# Brainstorming Skill\nThis is a mock skill.\n' > "${sp_dir}/brainstorming/SKILL.md"
+    mkdir -p "${sp_dir}/systematic-debugging"
+    printf '# Debugging Skill\nThis is a mock skill.\n' > "${sp_dir}/systematic-debugging/SKILL.md"
+
+    local output
+    output="$(run_hook)"
+
+    local cache_file="${HOME}/.claude/.skill-registry-cache.json"
+    assert_file_exists "cache file created" "${cache_file}"
+    assert_json_valid "cache file is valid JSON" "${cache_file}"
+
+    # brainstorming should be discovered and available
+    local brainstorm_available
+    brainstorm_available="$(jq -r '.skills[] | select(.name == "brainstorming") | .available' "${cache_file}" 2>/dev/null)"
+    assert_equals "brainstorming is available" "true" "${brainstorm_available}"
+
+    # invoke path should reference the SKILL.md
+    local brainstorm_invoke
+    brainstorm_invoke="$(jq -r '.skills[] | select(.name == "brainstorming") | .invoke' "${cache_file}" 2>/dev/null)"
+    assert_contains "brainstorming invoke has Read" "Read " "${brainstorm_invoke}"
+    assert_contains "brainstorming invoke has SKILL.md" "SKILL.md" "${brainstorm_invoke}"
+
+    # Health check output
+    assert_contains "health check in output" "skill registry built" "${output}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 3. Discovers user-installed skills (mock skill dir)
+# ---------------------------------------------------------------------------
+test_discovers_user_skills() {
+    echo "-- test: discovers user-installed skills --"
+    setup_test_env
+
+    # Create mock user skill
+    mkdir -p "${HOME}/.claude/skills/my-custom-skill"
+    printf '# My Custom Skill\nA user-installed skill.\n' > "${HOME}/.claude/skills/my-custom-skill/SKILL.md"
+
+    local output
+    output="$(run_hook)"
+
+    local cache_file="${HOME}/.claude/.skill-registry-cache.json"
+    assert_file_exists "cache file created" "${cache_file}"
+    assert_json_valid "cache file is valid JSON" "${cache_file}"
+
+    # User skill should appear as a custom domain skill
+    local custom_skill
+    custom_skill="$(jq -r '.skills[] | select(.name == "my-custom-skill") | .name' "${cache_file}" 2>/dev/null)"
+    assert_equals "user skill discovered" "my-custom-skill" "${custom_skill}"
+
+    local custom_available
+    custom_available="$(jq -r '.skills[] | select(.name == "my-custom-skill") | .available' "${cache_file}" 2>/dev/null)"
+    assert_equals "user skill is available" "true" "${custom_available}"
+
+    local custom_invoke
+    custom_invoke="$(jq -r '.skills[] | select(.name == "my-custom-skill") | .invoke' "${cache_file}" 2>/dev/null)"
+    assert_contains "user skill invoke has Read" "Read " "${custom_invoke}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 4. Discovers official plugin skills (mock plugin dir)
+# ---------------------------------------------------------------------------
+test_discovers_official_plugins() {
+    echo "-- test: discovers official plugin skills --"
+    setup_test_env
+
+    # Create mock official plugin directories
+    local plugin_base="${HOME}/.claude/plugins/cache/claude-plugins-official"
+    mkdir -p "${plugin_base}/frontend-design"
+    mkdir -p "${plugin_base}/claude-md-management"
+    mkdir -p "${plugin_base}/claude-code-setup"
+
+    local output
+    output="$(run_hook)"
+
+    local cache_file="${HOME}/.claude/.skill-registry-cache.json"
+    assert_file_exists "cache file created" "${cache_file}"
+    assert_json_valid "cache file is valid JSON" "${cache_file}"
+
+    # frontend-design should be available with correct invoke
+    local fd_invoke
+    fd_invoke="$(jq -r '.skills[] | select(.name == "frontend-design") | .invoke' "${cache_file}" 2>/dev/null)"
+    assert_equals "frontend-design invoke" "Call Skill(frontend-design:frontend-design)" "${fd_invoke}"
+
+    # claude-md-improver should be available
+    local md_invoke
+    md_invoke="$(jq -r '.skills[] | select(.name == "claude-md-improver") | .invoke' "${cache_file}" 2>/dev/null)"
+    assert_equals "claude-md-improver invoke" "Call Skill(claude-md-management:claude-md-improver)" "${md_invoke}"
+
+    # claude-automation-recommender should be available
+    local ca_invoke
+    ca_invoke="$(jq -r '.skills[] | select(.name == "claude-automation-recommender") | .invoke' "${cache_file}" 2>/dev/null)"
+    assert_equals "claude-automation-recommender invoke" "Call Skill(claude-code-setup:claude-automation-recommender)" "${ca_invoke}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 5. Missing plugin dirs don't crash
+# ---------------------------------------------------------------------------
+test_missing_dirs_no_crash() {
+    echo "-- test: missing plugin dirs don't crash --"
+    setup_test_env
+
+    # Ensure no plugin dirs exist at all
+    rm -rf "${HOME}/.claude/plugins"
+    rm -rf "${HOME}/.claude/skills"
+
+    local exit_code=0
+    run_hook || exit_code=$?
+
+    assert_equals "hook exits cleanly" "0" "${exit_code}"
+
+    local cache_file="${HOME}/.claude/.skill-registry-cache.json"
+    assert_file_exists "cache file still created" "${cache_file}"
+    assert_json_valid "cache file is valid JSON" "${cache_file}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 6. User config overrides (enabled: false)
+# ---------------------------------------------------------------------------
+test_user_config_disables_skill() {
+    echo "-- test: user config disables skill --"
+    setup_test_env
+
+    # Create a superpowers skill so it would normally be available
+    local sp_dir="${HOME}/.claude/plugins/cache/claude-plugins-official/superpowers/1.0.0/skills"
+    mkdir -p "${sp_dir}/brainstorming"
+    printf '# Brainstorming\n' > "${sp_dir}/brainstorming/SKILL.md"
+
+    # Create user config that disables brainstorming
+    printf '%s\n' '{
+        "overrides": {
+            "brainstorming": {
+                "enabled": false
+            }
+        }
+    }' > "${HOME}/.claude/skill-config.json"
+
+    run_hook >/dev/null
+
+    local cache_file="${HOME}/.claude/.skill-registry-cache.json"
+    assert_file_exists "cache file created" "${cache_file}"
+
+    # brainstorming should be disabled
+    local bs_enabled
+    bs_enabled="$(jq -r '.skills[] | select(.name == "brainstorming") | .enabled' "${cache_file}" 2>/dev/null)"
+    assert_equals "brainstorming is disabled" "false" "${bs_enabled}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 7. Health check output contains "skill registry built"
+# ---------------------------------------------------------------------------
+test_health_check_output() {
+    echo "-- test: health check output format --"
+    setup_test_env
+
+    local output
+    output="$(run_hook)"
+
+    assert_contains "output has hookEventName" "SessionStart" "${output}"
+    assert_contains "output has skill registry built" "skill registry built" "${output}"
+
+    # Should be valid JSON output
+    local hook_json
+    hook_json="$(echo "${output}" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null)"
+    assert_contains "output context has skill registry built" "skill registry built" "${hook_json}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+test_empty_env_produces_fallback
+test_discovers_superpowers_skills
+test_discovers_user_skills
+test_discovers_official_plugins
+test_missing_dirs_no_crash
+test_user_config_disables_skill
+test_health_check_output
+
+print_summary

--- a/tests/test-routing.sh
+++ b/tests/test-routing.sh
@@ -1,0 +1,521 @@
+#!/usr/bin/env bash
+# test-routing.sh — Tests for the skill-activation routing engine (v2)
+# Bash 3.2 compatible. Sources test-helpers.sh for setup/teardown and assertions.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+HOOK="${PROJECT_ROOT}/hooks/skill-activation-hook.sh"
+
+# shellcheck source=test-helpers.sh
+. "${SCRIPT_DIR}/test-helpers.sh"
+
+echo "=== test-routing.sh ==="
+
+# ---------------------------------------------------------------------------
+# Helper: run the hook with a given prompt, return stdout
+# ---------------------------------------------------------------------------
+run_hook() {
+    local prompt="$1"
+    printf '{"prompt":"%s"}' "${prompt}" | \
+        CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" \
+        bash "${HOOK}" 2>/dev/null
+}
+
+# Helper: extract the additionalContext text from hook JSON output
+extract_context() {
+    local output="$1"
+    printf '%s' "${output}" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null
+}
+
+# Helper: install a minimal skill registry cache for testing
+install_registry() {
+    local cache_file="${HOME}/.claude/.skill-registry-cache.json"
+    mkdir -p "$(dirname "${cache_file}")"
+    cat > "${cache_file}" <<'REGISTRY'
+{
+  "version": "2.0.0",
+  "skills": [
+    {
+      "name": "systematic-debugging",
+      "role": "process",
+      "phase": "DEBUG",
+      "triggers": [
+        "(debug|bug|fix|broken|fail|error|crash|wrong|unexpected|not.work|regression|issue|problem)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 10,
+      "invoke": "Read /mock/skills/systematic-debugging/SKILL.md",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "test-driven-development",
+      "role": "process",
+      "phase": "IMPLEMENT",
+      "triggers": [
+        "(build|create|implement|add|write|make)",
+        "(run|test|execute|verify|validate|check|coverage)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 20,
+      "invoke": "Read /mock/skills/test-driven-development/SKILL.md",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "brainstorming",
+      "role": "process",
+      "phase": "DESIGN",
+      "triggers": [
+        "(build|create|implement|develop|scaffold|brainstorm|design|architect|add|write|make|generate|new|start)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 30,
+      "invoke": "Read /mock/skills/brainstorming/SKILL.md",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "executing-plans",
+      "role": "process",
+      "phase": "IMPLEMENT",
+      "triggers": [
+        "(execute.*plan|run.the.plan|implement.the.plan|continue|follow.the.plan|resume|next.task|next.step)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 15,
+      "invoke": "Read /mock/skills/executing-plans/SKILL.md",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "subagent-driven-development",
+      "role": "process",
+      "phase": "IMPLEMENT",
+      "triggers": [
+        "(execute.*plan|run.the.plan|implement.the.plan|continue|follow.the.plan|resume|next.task|next.step)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 14,
+      "invoke": "Read /mock/skills/subagent-driven-development/SKILL.md",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "requesting-code-review",
+      "role": "process",
+      "phase": "REVIEW",
+      "triggers": [
+        "(review|pull.?request|code.?review|check.*(code|changes|diff)|code.?quality|lint|tech.?debt|(^|[^a-z])pr($|[^a-z]))"
+      ],
+      "trigger_mode": "regex",
+      "priority": 50,
+      "invoke": "Read /mock/skills/requesting-code-review/SKILL.md",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "receiving-code-review",
+      "role": "process",
+      "phase": "REVIEW",
+      "triggers": [
+        "(review|pull.?request|code.?review|check.*(code|changes|diff)|code.?quality|lint|tech.?debt|(^|[^a-z])pr($|[^a-z]))"
+      ],
+      "trigger_mode": "regex",
+      "priority": 51,
+      "invoke": "Read /mock/skills/receiving-code-review/SKILL.md",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "verification-before-completion",
+      "role": "workflow",
+      "triggers": [
+        "(ship|merge|deploy|push|release|tag|publish|pr.ready|ready.to|wrap.?up|finalize|complete|finish)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 60,
+      "invoke": "Read /mock/skills/verification-before-completion/SKILL.md",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "finishing-a-development-branch",
+      "role": "workflow",
+      "triggers": [
+        "(ship|merge|deploy|push|release|tag|publish|pr.ready|ready.to|wrap.?up|finalize|complete|finish)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 61,
+      "invoke": "Read /mock/skills/finishing-a-development-branch/SKILL.md",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "security-scanner",
+      "role": "domain",
+      "triggers": [
+        "(secur(e|ity)|vulnerab|owasp|pentest|attack|exploit|encrypt|inject|xss|csrf)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 102,
+      "invoke": "Read /mock/skills/security-scanner/SKILL.md",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "frontend-design",
+      "role": "domain",
+      "triggers": [
+        "(ui|frontend|component|layout|style|css|tailwind|responsive|dashboard)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 101,
+      "invoke": "Call Skill(frontend-design:frontend-design)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "disabled-skill",
+      "role": "process",
+      "phase": "DEBUG",
+      "triggers": [
+        "(debug|bug|fix)"
+      ],
+      "trigger_mode": "regex",
+      "priority": 5,
+      "invoke": "Read /mock/skills/disabled-skill/SKILL.md",
+      "available": true,
+      "enabled": false
+    }
+  ],
+  "methodology_hints": [
+    {
+      "name": "ralph-loop",
+      "triggers": [
+        "(migrate|refactor.all|fix.all|batch|overnight|autonom|iterate|keep.(going|trying|fixing))"
+      ],
+      "trigger_mode": "regex",
+      "hint": "RALPH LOOP: Consider /ralph-loop for autonomous iteration."
+    },
+    {
+      "name": "pr-review",
+      "triggers": [
+        "(review|pull.?request|code.?review|(^|[^a-z])pr($|[^a-z]))"
+      ],
+      "trigger_mode": "regex",
+      "hint": "PR REVIEW: Consider /pr-review for structured review."
+    }
+  ],
+  "blocklist_patterns": [
+    {
+      "pattern": "^(hi|hello|hey|thanks|thank.you|good.(morning|afternoon|evening)|bye|goodbye|ok|okay|yes|no|sure|yep|nope|got.it|sounds.good|cool|nice|great|perfect|awesome|understood)([[:space:]!.,]+.{0,20})?$",
+      "description": "Greeting or short acknowledgement",
+      "max_tail_length": 20
+    }
+  ],
+  "warnings": []
+}
+REGISTRY
+}
+
+# ---------------------------------------------------------------------------
+# 1. Debug prompt matches systematic-debugging
+# ---------------------------------------------------------------------------
+test_debug_prompt_matches() {
+    echo "-- test: debug prompt matches systematic-debugging --"
+    setup_test_env
+    install_registry
+
+    local output
+    output="$(run_hook "I need to debug this crash in the auth module")"
+    local context
+    context="$(extract_context "${output}")"
+
+    assert_contains "debug matches systematic-debugging" "systematic-debugging" "${context}"
+    assert_contains "debug label is Fix / Debug" "Fix / Debug" "${context}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 2. Build prompt matches brainstorming
+# ---------------------------------------------------------------------------
+test_build_prompt_matches() {
+    echo "-- test: build prompt matches brainstorming --"
+    setup_test_env
+    install_registry
+
+    local output
+    output="$(run_hook "create a new authentication service from scratch")"
+    local context
+    context="$(extract_context "${output}")"
+
+    assert_contains "build matches brainstorming" "brainstorming" "${context}"
+    assert_contains "build label is Build New" "Build New" "${context}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 3. Greeting is blocked (empty output)
+# ---------------------------------------------------------------------------
+test_greeting_blocked() {
+    echo "-- test: greeting is blocked --"
+    setup_test_env
+    install_registry
+
+    local output
+    output="$(run_hook "hello there")"
+
+    assert_equals "greeting produces empty output" "" "${output}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 4. Slash command is blocked
+# ---------------------------------------------------------------------------
+test_slash_command_blocked() {
+    echo "-- test: slash command is blocked --"
+    setup_test_env
+    install_registry
+
+    local output
+    output="$(run_hook "/help me with something")"
+
+    assert_equals "slash command produces empty output" "" "${output}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 5. Short prompt is blocked
+# ---------------------------------------------------------------------------
+test_short_prompt_blocked() {
+    echo "-- test: short prompt is blocked --"
+    setup_test_env
+    install_registry
+
+    local output
+    output="$(run_hook "hi")"
+
+    assert_equals "short prompt produces empty output" "" "${output}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 6. Domain skill appears alongside process skill with INFORMED BY
+# ---------------------------------------------------------------------------
+test_domain_informed_by() {
+    echo "-- test: domain skill shows INFORMED BY --"
+    setup_test_env
+    install_registry
+
+    local output
+    output="$(run_hook "build a secure frontend dashboard component with csrf protection")"
+    local context
+    context="$(extract_context "${output}")"
+
+    # Should have a process skill (brainstorming for "build")
+    assert_contains "has process skill" "Process:" "${context}"
+    # Should have domain skill as INFORMED BY
+    assert_contains "has INFORMED BY" "INFORMED BY:" "${context}"
+    # security-scanner or frontend-design should appear
+    assert_contains "has domain skill" "domain" "$(printf '%s' "${output}" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null | tr '[:upper:]' '[:lower:]')"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 7. Review prompt matches code review
+# ---------------------------------------------------------------------------
+test_review_prompt_matches() {
+    echo "-- test: review prompt matches code review --"
+    setup_test_env
+    install_registry
+
+    local output
+    output="$(run_hook "please review the code changes in this pull request")"
+    local context
+    context="$(extract_context "${output}")"
+
+    assert_contains "review matches code-review skill" "code-review" "${context}"
+    assert_contains "review label is Review" "Review" "${context}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 8. Ship prompt matches workflow skills
+# ---------------------------------------------------------------------------
+test_ship_prompt_matches() {
+    echo "-- test: ship prompt matches workflow skills --"
+    setup_test_env
+    install_registry
+
+    local output
+    output="$(run_hook "let's ship this and merge the branch to main")"
+    local context
+    context="$(extract_context "${output}")"
+
+    # With no process skill, workflow skills listed without orchestration prefix
+    # finishing-a-development-branch has higher priority (61 vs 60), so it wins the single workflow slot
+    assert_contains "ship matches workflow skill" "finishing-a-development-branch" "${context}"
+    assert_contains "ship label has Ship / Complete" "Ship / Complete" "${context}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 9. Max 1 process skill enforced
+# ---------------------------------------------------------------------------
+test_max_one_process() {
+    echo "-- test: max 1 process skill enforced --"
+    setup_test_env
+    install_registry
+
+    # "debug" triggers both systematic-debugging and test-driven-development (both process)
+    local output
+    output="$(run_hook "debug and fix the broken authentication error in the module")"
+    local context
+    context="$(extract_context "${output}")"
+
+    # Count Process: lines (should be exactly 1)
+    local process_count
+    process_count="$(printf '%s' "${context}" | grep -c 'Process:' 2>/dev/null)" || process_count=0
+
+    assert_equals "max 1 process skill" "1" "${process_count}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 10. Disabled skills excluded
+# ---------------------------------------------------------------------------
+test_disabled_skill_excluded() {
+    echo "-- test: disabled skills excluded --"
+    setup_test_env
+    install_registry
+
+    local output
+    output="$(run_hook "debug this broken module that has a bug")"
+    local context
+    context="$(extract_context "${output}")"
+
+    assert_not_contains "disabled skill not in output" "disabled-skill" "${context}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 11. Missing registry falls back gracefully
+# ---------------------------------------------------------------------------
+test_missing_registry_fallback() {
+    echo "-- test: missing registry falls back gracefully --"
+    setup_test_env
+    # Do NOT install registry — leave cache missing
+
+    local exit_code=0
+    local output
+    output="$(run_hook "debug the authentication bug")" || exit_code=$?
+
+    assert_equals "hook exits cleanly" "0" "${exit_code}"
+
+    # Should still produce output (phase checkpoint only)
+    if [ -n "${output}" ]; then
+        local context
+        context="$(extract_context "${output}")"
+        assert_contains "fallback has phase checkpoint" "phase" "$(printf '%s' "${context}" | tr '[:upper:]' '[:lower:]')"
+    else
+        _record_pass "hook exits silently on missing registry (acceptable)"
+    fi
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 12. Output is valid JSON
+# ---------------------------------------------------------------------------
+test_output_valid_json() {
+    echo "-- test: output is valid JSON --"
+    setup_test_env
+    install_registry
+
+    local output
+    output="$(run_hook "implement the new user authentication feature")"
+
+    # Write to file for json validation
+    local tmpfile="${TEST_TMPDIR}/output.json"
+    printf '%s' "${output}" > "${tmpfile}"
+
+    assert_json_valid "output is valid JSON" "${tmpfile}"
+
+    # Check structure
+    local hook_event
+    hook_event="$(printf '%s' "${output}" | jq -r '.hookSpecificOutput.hookEventName' 2>/dev/null)"
+    assert_equals "hookEventName is UserPromptSubmit" "UserPromptSubmit" "${hook_event}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 13. Zero matches produce phase checkpoint
+# ---------------------------------------------------------------------------
+test_zero_matches_phase_checkpoint() {
+    echo "-- test: zero matches produce phase checkpoint --"
+    setup_test_env
+    install_registry
+
+    # A prompt that won't match any triggers
+    local output
+    output="$(run_hook "tell me about the weather forecast for tomorrow please")"
+    local context
+    context="$(extract_context "${output}")"
+
+    assert_contains "zero match has phase checkpoint" "phase checkpoint" "$(printf '%s' "${context}" | tr '[:upper:]' '[:lower:]')"
+    assert_contains "zero match has 0 skills" "0 skills" "${context}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 14. Methodology hints appended when matched
+# ---------------------------------------------------------------------------
+test_methodology_hints() {
+    echo "-- test: methodology hints appended when matched --"
+    setup_test_env
+    install_registry
+
+    local output
+    output="$(run_hook "review this pull request for code quality issues")"
+    local context
+    context="$(extract_context "${output}")"
+
+    assert_contains "PR review hint present" "PR REVIEW" "${context}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+test_debug_prompt_matches
+test_build_prompt_matches
+test_greeting_blocked
+test_slash_command_blocked
+test_short_prompt_blocked
+test_domain_informed_by
+test_review_prompt_matches
+test_ship_prompt_matches
+test_max_one_process
+test_disabled_skill_excluded
+test_missing_registry_fallback
+test_output_valid_json
+test_zero_matches_phase_checkpoint
+test_methodology_hints
+
+print_summary


### PR DESCRIPTION
## Summary

- **Config-driven routing engine** replaces hardcoded regex patterns with a JSON skill registry (`config/default-triggers.json`) built dynamically at session start
- **Role-based orchestration** introduces Process/Domain/Workflow skill roles — process skills drive, domain skills inform via `INFORMED BY`, workflow skills stand alone
- **Adaptive context injection** scales output to match count: minimal (0 skills), compact (1-2), full phase map (3+)
- **Test harness** with 83 tests across 4 files covering registry building, routing, context format, and install validation
- **Graceful degradation** with fallback registry, visible warnings, and never-block-user error handling
- **Optional user configuration** via `~/.claude/skill-config.json` for trigger overrides, skill enable/disable, and custom skills

## Architecture

```
SessionStart → session-start-hook.sh → scans plugins + user skills
  → merges with default-triggers.json → applies user config
  → caches to ~/.claude/.skill-registry-cache.json

UserPromptSubmit → skill-activation-hook.sh → reads cached registry
  → scores triggers against prompt → selects by role caps (1 process + 2 domain + 1 workflow)
  → emits orchestrated context with INFORMED BY composition
```

## Files changed (14 files, +2618 / -224)

| Component | Files |
|-----------|-------|
| Config | `config/default-triggers.json`, `config/fallback-registry.json` |
| Hooks | `hooks/session-start-hook.sh` (new), `hooks/skill-activation-hook.sh` (rewrite) |
| Tests | `tests/run-tests.sh`, `tests/test-helpers.sh`, `tests/test-registry.sh`, `tests/test-routing.sh`, `tests/test-context.sh`, `tests/test-install.sh` |
| Meta | `hooks/hooks.json`, `.claude-plugin/plugin.json` (v2.0.0), `install.sh`, `README.md` |

## Test plan

- [x] 83/83 tests passing (`bash tests/run-tests.sh`)
- [ ] Manual: install as plugin, verify SessionStart builds registry
- [ ] Manual: verify routing matches for debug/build/review/ship prompts
- [ ] Manual: verify INFORMED BY appears for process+domain combos
- [ ] Manual: verify greeting blocklist still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)