### PR TITLE
feat: comprehensive plugin orchestration v4.0

### DIFF
--- a/config/default-triggers.json
+++ b/config/default-triggers.json
@@ -371,5 +371,109 @@
       "phase_fit": ["DESIGN"],
       "description": "Skill eval/improvement loop with benchmarking"
     }
-  ]
+  ],
+  "phase_compositions": {
+    "DESIGN": {
+      "driver": "brainstorming",
+      "parallel": [
+        {
+          "plugin": "feature-dev",
+          "use": "agents:code-explorer",
+          "when": "installed",
+          "purpose": "Parallel codebase exploration while brainstorming clarifies intent"
+        }
+      ],
+      "hints": [
+        {
+          "plugin": "feature-dev",
+          "text": "Consider /feature-dev for agent-parallel feature development",
+          "when": "installed"
+        },
+        {
+          "plugin": "skill-creator",
+          "text": "Consider Skill(skill-creator) to eval/benchmark skill quality",
+          "when": "installed AND prompt matches skill"
+        },
+        {
+          "plugin": "hookify",
+          "text": "Consider /hookify to create behavior rules",
+          "when": "installed AND prompt matches (prevent|block|guard|rule)"
+        }
+      ]
+    },
+    "PLAN": {
+      "driver": "writing-plans",
+      "parallel": [],
+      "hints": []
+    },
+    "IMPLEMENT": {
+      "driver": "executing-plans",
+      "parallel": [
+        {
+          "plugin": "security-guidance",
+          "use": "hooks:PreToolUse",
+          "when": "installed",
+          "purpose": "Passive write-time security guard (always active, no explicit invocation)"
+        }
+      ],
+      "hints": []
+    },
+    "REVIEW": {
+      "driver": "requesting-code-review",
+      "parallel": [
+        {
+          "plugin": "code-review",
+          "use": "commands:/code-review",
+          "when": "installed",
+          "purpose": "Run 5 parallel review agents and post findings to GitHub PR"
+        },
+        {
+          "plugin": "code-simplifier",
+          "use": "agents:code-simplifier",
+          "when": "installed",
+          "purpose": "Post-review simplification pass for clarity"
+        }
+      ],
+      "hints": [
+        {
+          "plugin": "code-review",
+          "text": "Consider /code-review for automated multi-agent PR review",
+          "when": "installed"
+        }
+      ]
+    },
+    "SHIP": {
+      "driver": "verification-before-completion",
+      "sequence": [
+        {
+          "plugin": "commit-commands",
+          "use": "commands:/commit",
+          "when": "installed",
+          "purpose": "Execute structured commit after verification passes"
+        },
+        {
+          "step": "finishing-a-development-branch",
+          "purpose": "Branch cleanup, merge, or PR creation"
+        },
+        {
+          "plugin": "commit-commands",
+          "use": "commands:/commit-push-pr",
+          "when": "installed AND user chooses PR option",
+          "purpose": "Automated branch-to-PR flow"
+        }
+      ],
+      "hints": [
+        {
+          "plugin": "commit-commands",
+          "text": "Consider /commit-push-pr for automated branch-to-PR workflow",
+          "when": "installed"
+        }
+      ]
+    },
+    "DEBUG": {
+      "driver": "systematic-debugging",
+      "parallel": [],
+      "hints": []
+    }
+  }
 }

--- a/config/default-triggers.json
+++ b/config/default-triggers.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.2.0",
+  "version": "4.0.0",
   "skills": [
     {
       "name": "systematic-debugging",

--- a/config/default-triggers.json
+++ b/config/default-triggers.json
@@ -285,5 +285,91 @@
       "hint": "PR REVIEW: Consider /pr-review for structured review.",
       "skill": "requesting-code-review"
     }
+  ],
+  "plugins": [
+    {
+      "name": "commit-commands",
+      "source": "claude-plugins-official",
+      "provides": {
+        "commands": ["/commit", "/commit-push-pr", "/clean_gone"],
+        "skills": [],
+        "agents": [],
+        "hooks": []
+      },
+      "phase_fit": ["SHIP"],
+      "description": "Structured commit workflows and branch-to-PR automation"
+    },
+    {
+      "name": "security-guidance",
+      "source": "claude-plugins-official",
+      "provides": {
+        "commands": [],
+        "skills": [],
+        "agents": [],
+        "hooks": ["PreToolUse:security-patterns"]
+      },
+      "phase_fit": ["*"],
+      "description": "Write-time security blocker for XSS, injection, unsafe deserialization"
+    },
+    {
+      "name": "hookify",
+      "source": "claude-plugins-official",
+      "provides": {
+        "commands": ["/hookify", "/hookify:list", "/hookify:configure"],
+        "skills": ["writing-rules"],
+        "agents": ["conversation-analyzer"],
+        "hooks": []
+      },
+      "phase_fit": ["DESIGN"],
+      "description": "Custom rule authoring for Claude behavior guards"
+    },
+    {
+      "name": "feature-dev",
+      "source": "claude-plugins-official",
+      "provides": {
+        "commands": ["/feature-dev"],
+        "skills": [],
+        "agents": ["code-explorer", "code-architect", "code-reviewer"],
+        "hooks": []
+      },
+      "phase_fit": ["DESIGN", "IMPLEMENT", "REVIEW"],
+      "description": "Full feature pipeline with parallel exploration and architecture agents"
+    },
+    {
+      "name": "code-review",
+      "source": "claude-plugins-official",
+      "provides": {
+        "commands": ["/code-review"],
+        "skills": [],
+        "agents": [],
+        "hooks": []
+      },
+      "phase_fit": ["REVIEW"],
+      "description": "5 parallel review agents with confidence scoring, posts to GitHub"
+    },
+    {
+      "name": "code-simplifier",
+      "source": "claude-plugins-official",
+      "provides": {
+        "commands": [],
+        "skills": [],
+        "agents": ["code-simplifier"],
+        "hooks": []
+      },
+      "phase_fit": ["REVIEW"],
+      "description": "Post-review code clarity and simplification pass"
+    },
+    {
+      "name": "skill-creator",
+      "source": "claude-plugins-official",
+      "provides": {
+        "commands": [],
+        "skills": ["skill-creator"],
+        "agents": ["executor", "grader", "comparator", "analyzer"],
+        "hooks": []
+      },
+      "phase_fit": ["DESIGN"],
+      "description": "Skill eval/improvement loop with benchmarking"
+    }
   ]
 }

--- a/config/fallback-registry.json
+++ b/config/fallback-registry.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.2.0-fallback",
+  "version": "4.0.0-fallback",
   "description": "Static fallback registry for degraded environments (no jq, missing plugin dirs)",
   "warnings": [
     "Using static fallback registry — dynamic discovery unavailable"
@@ -101,5 +101,14 @@
       "enabled": true,
       "description": "Clean up, squash, and prepare a branch for merge"
     }
-  ]
+  ],
+  "plugins": [],
+  "phase_compositions": {
+    "DESIGN": {"driver": "brainstorming", "parallel": [], "hints": []},
+    "PLAN": {"driver": "writing-plans", "parallel": [], "hints": []},
+    "IMPLEMENT": {"driver": "executing-plans", "parallel": [], "hints": []},
+    "REVIEW": {"driver": "requesting-code-review", "parallel": [], "hints": []},
+    "SHIP": {"driver": "verification-before-completion", "sequence": [], "hints": []},
+    "DEBUG": {"driver": "systematic-debugging", "parallel": [], "hints": []}
+  }
 }

--- a/hooks/session-start-hook.sh
+++ b/hooks/session-start-hook.sh
@@ -332,6 +332,12 @@ if [ -f "${DEFAULT_TRIGGERS}" ]; then
     METHODOLOGY_HINTS="$(jq '.methodology_hints // []' "${DEFAULT_TRIGGERS}" 2>/dev/null)" || METHODOLOGY_HINTS="[]"
 fi
 
+# Extract phase_compositions from default-triggers.json
+PHASE_COMPOSITIONS="{}"
+if [ -f "${DEFAULT_TRIGGERS}" ]; then
+    PHASE_COMPOSITIONS="$(jq '.phase_compositions // {}' "${DEFAULT_TRIGGERS}" 2>/dev/null)" || PHASE_COMPOSITIONS="{}"
+fi
+
 # -----------------------------------------------------------------
 # Step 8b: Discover curated plugins from default-triggers.json
 # -----------------------------------------------------------------
@@ -473,12 +479,14 @@ REGISTRY="$(jq -n \
     --arg version "3.2.0" \
     --argjson skills "${SKILLS_JSON}" \
     --argjson plugins "${PLUGINS_JSON}" \
+    --argjson phase_compositions "${PHASE_COMPOSITIONS}" \
     --argjson methodology_hints "${METHODOLOGY_HINTS}" \
     --argjson warnings "${WARNINGS}" \
     '{
         version: $version,
         skills: $skills,
         plugins: $plugins,
+        phase_compositions: $phase_compositions,
         methodology_hints: $methodology_hints,
         warnings: $warnings
     }'

--- a/hooks/session-start-hook.sh
+++ b/hooks/session-start-hook.sh
@@ -361,6 +361,107 @@ if [ -f "${DEFAULT_TRIGGERS}" ]; then
 fi
 
 # -----------------------------------------------------------------
+# Step 8c: Auto-discover unknown plugins from all marketplaces
+# -----------------------------------------------------------------
+# Build list of curated plugin names for exclusion
+CURATED_NAMES="$(printf '%s' "${PLUGINS_JSON}" | jq -r '.[].name' 2>/dev/null)"
+# Also exclude plugins we already handle as skill sources
+KNOWN_NAMES="${CURATED_NAMES}
+superpowers
+frontend-design
+claude-md-management
+claude-code-setup
+pr-review-toolkit
+ralph-loop
+auto-claude-skills"
+
+for _mkt_dir in "${HOME}/.claude/plugins/cache"/*/; do
+    [ -d "${_mkt_dir}" ] || continue
+    for _plugin_dir in "${_mkt_dir}"*/; do
+        [ -d "${_plugin_dir}" ] || continue
+        _pname="$(basename "${_plugin_dir}")"
+
+        # Skip known/curated plugins
+        _skip=0
+        while IFS= read -r _kn; do
+            [ -z "${_kn}" ] && continue
+            if [ "${_kn}" = "${_pname}" ]; then
+                _skip=1
+                break
+            fi
+        done <<KNEOF
+${KNOWN_NAMES}
+KNEOF
+        [ "${_skip}" -eq 1 ] && continue
+
+        # Look for plugin.json — may be directly in plugin dir or in a version subdir
+        _pjson=""
+        _plugin_root=""
+        if [ -f "${_plugin_dir}.claude-plugin/plugin.json" ]; then
+            _pjson="${_plugin_dir}.claude-plugin/plugin.json"
+            _plugin_root="${_plugin_dir}"
+        else
+            for _vdir in "${_plugin_dir}"*/; do
+                [ -d "${_vdir}" ] || continue
+                if [ -f "${_vdir}.claude-plugin/plugin.json" ]; then
+                    _pjson="${_vdir}.claude-plugin/plugin.json"
+                    _plugin_root="${_vdir}"
+                    break
+                fi
+            done
+        fi
+        [ -z "${_pjson}" ] && continue
+
+        # Scan for skills
+        _skills="[]"
+        if [ -d "${_plugin_root}skills" ]; then
+            for _smd in "${_plugin_root}skills"/*/SKILL.md; do
+                [ -f "${_smd}" ] || continue
+                _sname="$(basename "$(dirname "${_smd}")")"
+                _skills="$(printf '%s' "${_skills}" | jq --arg s "${_sname}" '. + [$s]')"
+            done
+        fi
+
+        # Scan for commands
+        _commands="[]"
+        if [ -d "${_plugin_root}commands" ]; then
+            for _cmd in "${_plugin_root}commands"/*.md; do
+                [ -f "${_cmd}" ] || continue
+                _cname="/$(basename "${_cmd}" .md)"
+                _commands="$(printf '%s' "${_commands}" | jq --arg c "${_cname}" '. + [$c]')"
+            done
+        fi
+
+        # Scan for agents
+        _agents="[]"
+        if [ -d "${_plugin_root}agents" ]; then
+            for _agent in "${_plugin_root}agents"/*.md; do
+                [ -f "${_agent}" ] || continue
+                _aname="$(basename "${_agent}" .md)"
+                _agents="$(printf '%s' "${_agents}" | jq --arg a "${_aname}" '. + [$a]')"
+            done
+        fi
+
+        # Build plugin entry
+        _entry="$(jq -n \
+            --arg name "${_pname}" \
+            --arg source "auto-discovered" \
+            --argjson skills "${_skills}" \
+            --argjson commands "${_commands}" \
+            --argjson agents "${_agents}" \
+            '{
+                name: $name,
+                source: $source,
+                provides: {commands: $commands, skills: $skills, agents: $agents, hooks: []},
+                phase_fit: ["*"],
+                description: "Auto-discovered plugin",
+                available: true
+            }')"
+        PLUGINS_JSON="$(printf '%s' "${PLUGINS_JSON}" | jq --argjson p "${_entry}" '. + [$p]')"
+    done
+done
+
+# -----------------------------------------------------------------
 # Step 9: Build final registry JSON
 # -----------------------------------------------------------------
 SKILL_COUNT="$(printf '%s' "${SKILLS_JSON}" | jq 'length' 2>/dev/null)" || SKILL_COUNT=0

--- a/hooks/session-start-hook.sh
+++ b/hooks/session-start-hook.sh
@@ -504,7 +504,7 @@ MISSING_PLUGINS=""
 MISSING_COUNT=0
 
 # Check companion plugins
-for _plugin in superpowers frontend-design claude-md-management pr-review-toolkit claude-code-setup; do
+for _plugin in superpowers frontend-design claude-md-management pr-review-toolkit claude-code-setup commit-commands security-guidance hookify feature-dev code-review code-simplifier skill-creator; do
     _found=0
     case "${_plugin}" in
         superpowers)
@@ -551,7 +551,10 @@ fi
 # -----------------------------------------------------------------
 # Step 12: Emit health check
 # -----------------------------------------------------------------
-MSG="SessionStart: skill registry built (${SKILL_COUNT} skills, ${AVAILABLE_COUNT} available, from ${SOURCE_COUNT} sources, ${WARNING_COUNT} warnings)${SETUP_HINTS}"
+PLUGIN_COUNT="$(printf '%s' "${PLUGINS_JSON}" | jq 'length' 2>/dev/null)" || PLUGIN_COUNT=0
+PLUGIN_AVAILABLE="$(printf '%s' "${PLUGINS_JSON}" | jq '[.[] | select(.available == true)] | length' 2>/dev/null)" || PLUGIN_AVAILABLE=0
+
+MSG="SessionStart: skill registry built (${SKILL_COUNT} skills, ${AVAILABLE_COUNT} available, from ${SOURCE_COUNT} sources, ${PLUGIN_COUNT} plugins (${PLUGIN_AVAILABLE} installed), ${WARNING_COUNT} warnings)${SETUP_HINTS}"
 printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":%s}}\n' \
     "$(printf '%s' "${MSG}" | jq -Rs .)"
 

--- a/hooks/session-start-hook.sh
+++ b/hooks/session-start-hook.sh
@@ -55,7 +55,7 @@ if ! command -v jq >/dev/null 2>&1; then
     if [ -f "${FALLBACK}" ]; then
         cp "${FALLBACK}" "${CACHE_FILE}"
     else
-        printf '{"version":"3.2.0-fallback","warnings":["jq not available, no fallback found"],"skills":[]}\n' > "${CACHE_FILE}"
+        printf '{"version":"4.0.0-fallback","warnings":["jq not available, no fallback found"],"skills":[]}\n' > "${CACHE_FILE}"
     fi
     # NOTE: jq unavailable on this path; MSG must remain a simple ASCII string (no quotes or backslashes)
     MSG="SessionStart: jq not found -- skill routing disabled. Install jq: brew install jq (macOS) or apt install jq (Linux)"
@@ -476,7 +476,7 @@ UNAVAILABLE_COUNT=$((SKILL_COUNT - AVAILABLE_COUNT))
 WARNING_COUNT="$(printf '%s' "${WARNINGS}" | jq 'length' 2>/dev/null)" || WARNING_COUNT=0
 
 REGISTRY="$(jq -n \
-    --arg version "3.2.0" \
+    --arg version "4.0.0" \
     --argjson skills "${SKILLS_JSON}" \
     --argjson plugins "${PLUGINS_JSON}" \
     --argjson phase_compositions "${PHASE_COMPOSITIONS}" \

--- a/hooks/session-start-hook.sh
+++ b/hooks/session-start-hook.sh
@@ -333,6 +333,34 @@ if [ -f "${DEFAULT_TRIGGERS}" ]; then
 fi
 
 # -----------------------------------------------------------------
+# Step 8b: Discover curated plugins from default-triggers.json
+# -----------------------------------------------------------------
+PLUGINS_JSON="[]"
+if [ -f "${DEFAULT_TRIGGERS}" ]; then
+    CURATED_COUNT="$(jq '.plugins // [] | length' "${DEFAULT_TRIGGERS}" 2>/dev/null)" || CURATED_COUNT=0
+    pi=0
+    while [ "${pi}" -lt "${CURATED_COUNT}" ]; do
+        plugin_name="$(jq -r ".plugins[${pi}].name" "${DEFAULT_TRIGGERS}")"
+        plugin_json="$(jq ".plugins[${pi}]" "${DEFAULT_TRIGGERS}")"
+
+        # Check if installed in any marketplace cache dir
+        _installed=false
+        for _mkt_dir in "${HOME}/.claude/plugins/cache"/*/; do
+            [ -d "${_mkt_dir}" ] || continue
+            if [ -d "${_mkt_dir}${plugin_name}" ]; then
+                _installed=true
+                break
+            fi
+        done
+
+        plugin_json="$(printf '%s' "${plugin_json}" | jq --argjson avail "${_installed}" '. + {available: $avail}')"
+        PLUGINS_JSON="$(printf '%s' "${PLUGINS_JSON}" | jq --argjson p "${plugin_json}" '. + [$p]')"
+
+        pi=$((pi + 1))
+    done
+fi
+
+# -----------------------------------------------------------------
 # Step 9: Build final registry JSON
 # -----------------------------------------------------------------
 SKILL_COUNT="$(printf '%s' "${SKILLS_JSON}" | jq 'length' 2>/dev/null)" || SKILL_COUNT=0
@@ -343,11 +371,13 @@ WARNING_COUNT="$(printf '%s' "${WARNINGS}" | jq 'length' 2>/dev/null)" || WARNIN
 REGISTRY="$(jq -n \
     --arg version "3.2.0" \
     --argjson skills "${SKILLS_JSON}" \
+    --argjson plugins "${PLUGINS_JSON}" \
     --argjson methodology_hints "${METHODOLOGY_HINTS}" \
     --argjson warnings "${WARNINGS}" \
     '{
         version: $version,
         skills: $skills,
+        plugins: $plugins,
         methodology_hints: $methodology_hints,
         warnings: $warnings
     }'

--- a/hooks/skill-activation-hook.sh
+++ b/hooks/skill-activation-hook.sh
@@ -289,6 +289,84 @@ HEOF
 done
 
 # =================================================================
+# PHASE COMPOSITION: PARALLEL / SEQUENCE / HINTS
+# =================================================================
+COMPOSITION_LINES=""
+COMPOSITION_HINTS=""
+
+# Determine the current phase from selected skills
+CURRENT_PHASE=""
+while IFS='|' read -r score name role invoke phase; do
+    [[ -z "$name" ]] && continue
+    if [[ -n "$phase" ]]; then
+        CURRENT_PHASE="$phase"
+        break
+    fi
+done <<EOF
+${SELECTED}
+EOF
+
+# Look up phase composition if registry has it and a phase was determined
+if [[ -n "$CURRENT_PHASE" ]]; then
+    _pc="$(printf '%s' "$REGISTRY" | jq -c --arg ph "$CURRENT_PHASE" '.phase_compositions[$ph] // empty' 2>/dev/null)"
+    if [[ -n "$_pc" ]]; then
+        # Emit PARALLEL lines for available plugins
+        _par_count="$(printf '%s' "$_pc" | jq '.parallel // [] | length' 2>/dev/null)" || _par_count=0
+        _pi=0
+        while [[ "$_pi" -lt "$_par_count" ]]; do
+            _plugin="$(printf '%s' "$_pc" | jq -r ".parallel[${_pi}].plugin" 2>/dev/null)"
+            _use="$(printf '%s' "$_pc" | jq -r ".parallel[${_pi}].use" 2>/dev/null)"
+            _purpose="$(printf '%s' "$_pc" | jq -r ".parallel[${_pi}].purpose" 2>/dev/null)"
+
+            # Check if plugin is available
+            _pavail="$(printf '%s' "$REGISTRY" | jq -r --arg pn "$_plugin" '.plugins // [] | .[] | select(.name == $pn) | .available' 2>/dev/null)"
+            if [[ "$_pavail" == "true" ]]; then
+                COMPOSITION_LINES="${COMPOSITION_LINES}
+  PARALLEL: ${_use} -> ${_purpose} [${_plugin}]"
+            fi
+            _pi=$((_pi + 1))
+        done
+
+        # Emit SEQUENCE lines (SHIP phase)
+        _seq_count="$(printf '%s' "$_pc" | jq '.sequence // [] | length' 2>/dev/null)" || _seq_count=0
+        _si=0
+        while [[ "$_si" -lt "$_seq_count" ]]; do
+            _plugin="$(printf '%s' "$_pc" | jq -r ".sequence[${_si}].plugin // empty" 2>/dev/null)"
+            _step="$(printf '%s' "$_pc" | jq -r ".sequence[${_si}].step // empty" 2>/dev/null)"
+            _use="$(printf '%s' "$_pc" | jq -r ".sequence[${_si}].use // empty" 2>/dev/null)"
+            _purpose="$(printf '%s' "$_pc" | jq -r ".sequence[${_si}].purpose" 2>/dev/null)"
+
+            if [[ -n "$_plugin" ]]; then
+                _pavail="$(printf '%s' "$REGISTRY" | jq -r --arg pn "$_plugin" '.plugins // [] | .[] | select(.name == $pn) | .available' 2>/dev/null)"
+                if [[ "$_pavail" == "true" ]]; then
+                    COMPOSITION_LINES="${COMPOSITION_LINES}
+  SEQUENCE: ${_use} -> ${_purpose} [${_plugin}]"
+                fi
+            elif [[ -n "$_step" ]]; then
+                COMPOSITION_LINES="${COMPOSITION_LINES}
+  SEQUENCE: ${_step} -> ${_purpose}"
+            fi
+            _si=$((_si + 1))
+        done
+
+        # Collect composition hints for available plugins
+        _hint_count="$(printf '%s' "$_pc" | jq '.hints // [] | length' 2>/dev/null)" || _hint_count=0
+        _hi=0
+        while [[ "$_hi" -lt "$_hint_count" ]]; do
+            _plugin="$(printf '%s' "$_pc" | jq -r ".hints[${_hi}].plugin" 2>/dev/null)"
+            _text="$(printf '%s' "$_pc" | jq -r ".hints[${_hi}].text" 2>/dev/null)"
+
+            _pavail="$(printf '%s' "$REGISTRY" | jq -r --arg pn "$_plugin" '.plugins // [] | .[] | select(.name == $pn) | .available' 2>/dev/null)"
+            if [[ "$_pavail" == "true" ]]; then
+                COMPOSITION_HINTS="${COMPOSITION_HINTS}
+- ${_text}"
+            fi
+            _hi=$((_hi + 1))
+        done
+    fi
+fi
+
+# =================================================================
 # BUILD ORCHESTRATED CONTEXT OUTPUT
 # =================================================================
 
@@ -337,7 +415,7 @@ ${name} -> ${invoke}"
 ${SELECTED}
 EOF
 
-  OUT+="${PROCESS_LINE}${DOMAIN_LINES}${WORKFLOW_LINES}${STANDALONE_LINES}"
+  OUT+="${PROCESS_LINE}${DOMAIN_LINES}${WORKFLOW_LINES}${STANDALONE_LINES}${COMPOSITION_LINES}"
 
   # Append overflow domain skills (relevant but didn't fit in top suggestions)
   OVERFLOW_LINES=""
@@ -427,6 +505,7 @@ EOF
   done <<EOF
 ${OVERFLOW_DOMAIN}
 EOF
+  OUT+="${COMPOSITION_LINES}"
 
   OUT+="
 You MUST print a brief evaluation for each skill above. Format:
@@ -444,9 +523,9 @@ Domain skills evaluated YES: invoke them (before, during, or after the process s
 fi
 
 # Append methodology hints if any
-if [[ -n "$HINTS" ]]; then
+if [[ -n "$HINTS" ]] || [[ -n "$COMPOSITION_HINTS" ]]; then
   OUT+="
-${HINTS}"
+${HINTS}${COMPOSITION_HINTS}"
 fi
 
 printf '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":%s}}\n' \

--- a/tests/test-context.sh
+++ b/tests/test-context.sh
@@ -37,7 +37,7 @@ install_context_registry() {
     mkdir -p "$(dirname "${cache_file}")"
     cat > "${cache_file}" <<'REGISTRY'
 {
-  "version": "3.2.0",
+  "version": "4.0.0",
   "skills": [
     {
       "name": "systematic-debugging",

--- a/tests/test-install.sh
+++ b/tests/test-install.sh
@@ -165,6 +165,17 @@ assert_json_valid \
     ".claude-plugin/plugin.json is valid JSON" \
     "${PLUGIN_ROOT}/.claude-plugin/plugin.json"
 
+# Test: fallback registry has plugins and phase_compositions sections
+echo "-- test: fallback has plugins key --"
+FALLBACK="${PLUGIN_ROOT}/config/fallback-registry.json"
+
+has_plugins="$(jq 'has("plugins")' "${FALLBACK}" 2>/dev/null)"
+assert_equals "fallback has plugins key" "true" "${has_plugins}"
+
+echo "-- test: fallback has phase_compositions key --"
+has_pc="$(jq 'has("phase_compositions")' "${FALLBACK}" 2>/dev/null)"
+assert_equals "fallback has phase_compositions key" "true" "${has_pc}"
+
 # ---------------------------------------------------------------------------
 # Print summary and exit with appropriate code
 # ---------------------------------------------------------------------------

--- a/tests/test-registry.sh
+++ b/tests/test-registry.sh
@@ -430,6 +430,22 @@ test_auto_discovers_unknown_plugins() {
     teardown_test_env
 }
 
+test_health_check_reports_new_plugins() {
+    echo "-- test: health check reports plugin count --"
+    setup_test_env
+
+    # Install one curated plugin
+    mkdir -p "${HOME}/.claude/plugins/cache/claude-plugins-official/commit-commands"
+
+    local output
+    output="$(run_hook)"
+
+    # Health check should mention plugins
+    assert_contains "health check mentions plugins" "plugin" "$(printf '%s' "${output}" | tr '[:upper:]' '[:lower:]')"
+
+    teardown_test_env
+}
+
 # ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
@@ -446,5 +462,6 @@ test_default_triggers_has_phase_compositions
 test_discovers_curated_plugins
 test_registry_includes_phase_compositions
 test_auto_discovers_unknown_plugins
+test_health_check_reports_new_plugins
 
 print_summary

--- a/tests/test-registry.sh
+++ b/tests/test-registry.sh
@@ -336,6 +336,41 @@ test_default_triggers_has_phase_compositions() {
     teardown_test_env
 }
 
+test_discovers_curated_plugins() {
+    echo "-- test: discovers curated plugins --"
+    setup_test_env
+
+    # Create mock plugin directories for curated plugins
+    local plugin_base="${HOME}/.claude/plugins/cache/claude-plugins-official"
+    mkdir -p "${plugin_base}/commit-commands"
+    mkdir -p "${plugin_base}/feature-dev"
+    mkdir -p "${plugin_base}/code-review"
+
+    local output
+    output="$(run_hook)"
+
+    local cache_file="${HOME}/.claude/.skill-registry-cache.json"
+    assert_file_exists "cache file created" "${cache_file}"
+    assert_json_valid "cache file is valid JSON" "${cache_file}"
+
+    # commit-commands should be in plugins array and marked available
+    local cc_available
+    cc_available="$(jq -r '.plugins[] | select(.name == "commit-commands") | .available' "${cache_file}" 2>/dev/null)"
+    assert_equals "commit-commands is available" "true" "${cc_available}"
+
+    # feature-dev should be available
+    local fd_available
+    fd_available="$(jq -r '.plugins[] | select(.name == "feature-dev") | .available' "${cache_file}" 2>/dev/null)"
+    assert_equals "feature-dev is available" "true" "${fd_available}"
+
+    # security-guidance should exist but be unavailable (not installed)
+    local sg_available
+    sg_available="$(jq -r '.plugins[] | select(.name == "security-guidance") | .available' "${cache_file}" 2>/dev/null)"
+    assert_equals "security-guidance is unavailable" "false" "${sg_available}"
+
+    teardown_test_env
+}
+
 # ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
@@ -349,5 +384,6 @@ test_health_check_output
 test_discovers_agent_team_skills
 test_default_triggers_has_plugins_section
 test_default_triggers_has_phase_compositions
+test_discovers_curated_plugins
 
 print_summary

--- a/tests/test-registry.sh
+++ b/tests/test-registry.sh
@@ -44,7 +44,7 @@ test_empty_env_produces_fallback() {
     # Should have a version field
     local version
     version="$(jq -r '.version' "${cache_file}" 2>/dev/null)"
-    assert_contains "registry has version" "3.2" "${version}"
+    assert_contains "registry has version" "4.0" "${version}"
 
     # Should have skills array
     local skill_count

--- a/tests/test-registry.sh
+++ b/tests/test-registry.sh
@@ -304,6 +304,38 @@ test_default_triggers_has_plugins_section() {
     teardown_test_env
 }
 
+test_default_triggers_has_phase_compositions() {
+    echo "-- test: default-triggers has phase_compositions --"
+    setup_test_env
+
+    local phases
+    phases="$(jq '.phase_compositions | keys[]' "${PROJECT_ROOT}/config/default-triggers.json" 2>/dev/null | sort)"
+
+    assert_contains "has DESIGN phase" "DESIGN" "${phases}"
+    assert_contains "has PLAN phase" "PLAN" "${phases}"
+    assert_contains "has IMPLEMENT phase" "IMPLEMENT" "${phases}"
+    assert_contains "has REVIEW phase" "REVIEW" "${phases}"
+    assert_contains "has SHIP phase" "SHIP" "${phases}"
+    assert_contains "has DEBUG phase" "DEBUG" "${phases}"
+
+    # Each phase must have a driver field
+    local driver_count
+    driver_count="$(jq '[.phase_compositions | to_entries[] | select(.value.driver)] | length' "${PROJECT_ROOT}/config/default-triggers.json" 2>/dev/null)"
+    assert_equals "all 6 phases have drivers" "6" "${driver_count}"
+
+    # REVIEW should have parallel entries
+    local review_parallel
+    review_parallel="$(jq '.phase_compositions.REVIEW.parallel | length' "${PROJECT_ROOT}/config/default-triggers.json" 2>/dev/null)"
+    assert_equals "REVIEW has 2 parallel entries" "2" "${review_parallel}"
+
+    # SHIP should have sequence entries
+    local ship_sequence
+    ship_sequence="$(jq '.phase_compositions.SHIP.sequence | length' "${PROJECT_ROOT}/config/default-triggers.json" 2>/dev/null)"
+    assert_equals "SHIP has 3 sequence entries" "3" "${ship_sequence}"
+
+    teardown_test_env
+}
+
 # ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
@@ -316,5 +348,6 @@ test_user_config_disables_skill
 test_health_check_output
 test_discovers_agent_team_skills
 test_default_triggers_has_plugins_section
+test_default_triggers_has_phase_compositions
 
 print_summary

--- a/tests/test-registry.sh
+++ b/tests/test-registry.sh
@@ -371,6 +371,23 @@ test_discovers_curated_plugins() {
     teardown_test_env
 }
 
+test_registry_includes_phase_compositions() {
+    echo "-- test: registry cache includes phase_compositions --"
+    setup_test_env
+
+    local output
+    output="$(run_hook)"
+
+    local cache_file="${HOME}/.claude/.skill-registry-cache.json"
+    assert_json_valid "cache file is valid JSON" "${cache_file}"
+
+    local pc_keys
+    pc_keys="$(jq '.phase_compositions | keys | length' "${cache_file}" 2>/dev/null)"
+    assert_equals "phase_compositions has 6 phases" "6" "${pc_keys}"
+
+    teardown_test_env
+}
+
 test_auto_discovers_unknown_plugins() {
     echo "-- test: auto-discovers unknown plugins --"
     setup_test_env
@@ -427,6 +444,7 @@ test_discovers_agent_team_skills
 test_default_triggers_has_plugins_section
 test_default_triggers_has_phase_compositions
 test_discovers_curated_plugins
+test_registry_includes_phase_compositions
 test_auto_discovers_unknown_plugins
 
 print_summary

--- a/tests/test-registry.sh
+++ b/tests/test-registry.sh
@@ -371,6 +371,48 @@ test_discovers_curated_plugins() {
     teardown_test_env
 }
 
+test_auto_discovers_unknown_plugins() {
+    echo "-- test: auto-discovers unknown plugins --"
+    setup_test_env
+
+    # Create a mock unknown plugin with skills and commands
+    local unknown_dir="${HOME}/.claude/plugins/cache/community-marketplace/my-unknown-plugin/1.0.0"
+    mkdir -p "${unknown_dir}/skills/custom-lint"
+    printf '---\nname: custom-lint\ndescription: Custom lint rules\n---\n# Custom Lint\n' > \
+        "${unknown_dir}/skills/custom-lint/SKILL.md"
+    mkdir -p "${unknown_dir}/commands"
+    printf '# Run Lint\n' > "${unknown_dir}/commands/lint.md"
+    mkdir -p "${unknown_dir}/.claude-plugin"
+    printf '{"name":"my-unknown-plugin","version":"1.0.0"}\n' > "${unknown_dir}/.claude-plugin/plugin.json"
+
+    local output
+    output="$(run_hook)"
+
+    local cache_file="${HOME}/.claude/.skill-registry-cache.json"
+    assert_json_valid "cache file is valid JSON" "${cache_file}"
+
+    # Unknown plugin should appear in plugins array
+    local up_name
+    up_name="$(jq -r '.plugins[] | select(.name == "my-unknown-plugin") | .name' "${cache_file}" 2>/dev/null)"
+    assert_equals "unknown plugin discovered" "my-unknown-plugin" "${up_name}"
+
+    local up_available
+    up_available="$(jq -r '.plugins[] | select(.name == "my-unknown-plugin") | .available' "${cache_file}" 2>/dev/null)"
+    assert_equals "unknown plugin is available" "true" "${up_available}"
+
+    # Should detect the skill
+    local up_skills
+    up_skills="$(jq -r '.plugins[] | select(.name == "my-unknown-plugin") | .provides.skills[0]' "${cache_file}" 2>/dev/null)"
+    assert_equals "unknown plugin skill detected" "custom-lint" "${up_skills}"
+
+    # Should detect the command
+    local up_commands
+    up_commands="$(jq -r '.plugins[] | select(.name == "my-unknown-plugin") | .provides.commands[0]' "${cache_file}" 2>/dev/null)"
+    assert_equals "unknown plugin command detected" "/lint" "${up_commands}"
+
+    teardown_test_env
+}
+
 # ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
@@ -385,5 +427,6 @@ test_discovers_agent_team_skills
 test_default_triggers_has_plugins_section
 test_default_triggers_has_phase_compositions
 test_discovers_curated_plugins
+test_auto_discovers_unknown_plugins
 
 print_summary

--- a/tests/test-registry.sh
+++ b/tests/test-registry.sh
@@ -286,6 +286,24 @@ test_discovers_agent_team_skills() {
     teardown_test_env
 }
 
+test_default_triggers_has_plugins_section() {
+    echo "-- test: default-triggers has plugins section --"
+    setup_test_env
+
+    local plugin_count
+    plugin_count="$(jq '.plugins | length' "${PROJECT_ROOT}/config/default-triggers.json" 2>/dev/null)"
+
+    # Should have 7 curated plugins
+    assert_equals "default-triggers has 7 plugins" "7" "${plugin_count}"
+
+    # Each plugin should have required fields
+    local valid_count
+    valid_count="$(jq '[.plugins[] | select(.name and .source and .provides and .phase_fit and .description)] | length' "${PROJECT_ROOT}/config/default-triggers.json" 2>/dev/null)"
+    assert_equals "all plugins have required fields" "7" "${valid_count}"
+
+    teardown_test_env
+}
+
 # ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
@@ -297,5 +315,6 @@ test_missing_dirs_no_crash
 test_user_config_disables_skill
 test_health_check_output
 test_discovers_agent_team_skills
+test_default_triggers_has_plugins_section
 
 print_summary

--- a/tests/test-routing.sh
+++ b/tests/test-routing.sh
@@ -261,6 +261,205 @@ install_registry() {
 REGISTRY
 }
 
+# Helper: install a v4 skill registry cache with plugins and phase_compositions
+install_registry_v4() {
+    local cache_file="${HOME}/.claude/.skill-registry-cache.json"
+    mkdir -p "$(dirname "${cache_file}")"
+    cat > "${cache_file}" <<'REGISTRY_V4'
+{
+  "version": "4.0.0",
+  "skills": [
+    {
+      "name": "systematic-debugging",
+      "role": "process",
+      "phase": "DEBUG",
+      "triggers": ["(debug|bug|broken|crash|regression|not.work|error|fail|hang|freeze|timeout|leak|corrupt|unexpected|wrong)"],
+      "trigger_mode": "regex",
+      "priority": 10,
+      "invoke": "Skill(superpowers:systematic-debugging)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "test-driven-development",
+      "role": "process",
+      "phase": "IMPLEMENT",
+      "triggers": ["(build|create|implement|add|write|make)", "(run|test|execute|verify|validate|check|coverage)"],
+      "trigger_mode": "regex",
+      "priority": 20,
+      "invoke": "Skill(superpowers:test-driven-development)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "brainstorming",
+      "role": "process",
+      "phase": "DESIGN",
+      "triggers": ["(build|create|implement|develop|scaffold|init|bootstrap|brainstorm|design|architect|strateg|scope|outline|approach|generate|set.?up|wire.up|connect|integrate|extend|new|start|introduce|enable|support|how.(should|would|could))"],
+      "trigger_mode": "regex",
+      "priority": 30,
+      "invoke": "Skill(superpowers:brainstorming)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "executing-plans",
+      "role": "process",
+      "phase": "IMPLEMENT",
+      "triggers": ["(execute.*plan|run.the.plan|implement.the.plan|continue|follow.the.plan|resume|next.task|next.step)"],
+      "trigger_mode": "regex",
+      "priority": 15,
+      "invoke": "Skill(superpowers:executing-plans)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "subagent-driven-development",
+      "role": "process",
+      "phase": "IMPLEMENT",
+      "triggers": ["(execute.*plan|run.the.plan|implement.the.plan|continue|follow.the.plan|resume|next.task|next.step)"],
+      "trigger_mode": "regex",
+      "priority": 14,
+      "invoke": "Skill(superpowers:subagent-driven-development)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "requesting-code-review",
+      "role": "process",
+      "phase": "REVIEW",
+      "triggers": ["(review|pull.?request|code.?review|check.*(code|changes|diff)|code.?quality|lint|tech.?debt|(^|[^a-z])pr($|[^a-z]))"],
+      "trigger_mode": "regex",
+      "priority": 51,
+      "invoke": "Skill(superpowers:requesting-code-review)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "receiving-code-review",
+      "role": "process",
+      "phase": "REVIEW",
+      "triggers": ["(review|pull.?request|code.?review|check.*(code|changes|diff)|code.?quality|lint|tech.?debt|(^|[^a-z])pr($|[^a-z]))"],
+      "trigger_mode": "regex",
+      "priority": 50,
+      "invoke": "Skill(superpowers:receiving-code-review)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "verification-before-completion",
+      "role": "workflow",
+      "phase": "SHIP",
+      "triggers": ["(ship|merge|deploy|push|release|tag|publish|pr.ready|ready.to|wrap.?up|finalize|complete|finish)"],
+      "trigger_mode": "regex",
+      "priority": 60,
+      "invoke": "Skill(superpowers:verification-before-completion)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "finishing-a-development-branch",
+      "role": "workflow",
+      "phase": "SHIP",
+      "triggers": ["(ship|merge|deploy|push|release|tag|publish|pr.ready|ready.to|wrap.?up|finalize|complete|finish)"],
+      "trigger_mode": "regex",
+      "priority": 61,
+      "invoke": "Skill(superpowers:finishing-a-development-branch)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "security-scanner",
+      "role": "domain",
+      "triggers": ["(secur(e|ity)|vulnerab|owasp|pentest|attack|exploit|encrypt|inject|xss|csrf)"],
+      "trigger_mode": "regex",
+      "priority": 102,
+      "invoke": "Skill(security-scanner)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "frontend-design",
+      "role": "domain",
+      "triggers": ["(^|[^a-z])(ui|frontend|component|layout|style|css|tailwind|responsive|dashboard)($|[^a-z])"],
+      "trigger_mode": "regex",
+      "priority": 101,
+      "invoke": "Call Skill(frontend-design:frontend-design)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "disabled-skill",
+      "role": "process",
+      "phase": "DEBUG",
+      "triggers": ["(debug|bug|fix)"],
+      "trigger_mode": "regex",
+      "priority": 5,
+      "invoke": "Skill(mock:disabled-skill)",
+      "available": true,
+      "enabled": false
+    },
+    {
+      "name": "agent-team-execution",
+      "role": "workflow",
+      "phase": "IMPLEMENT",
+      "triggers": ["(agent.team|team.execute|parallel.team|swarm|fan.out|specialist|multi.agent)"],
+      "trigger_mode": "regex",
+      "priority": 16,
+      "invoke": "Skill(agent-team-execution)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "agent-team-review",
+      "role": "workflow",
+      "phase": "REVIEW",
+      "triggers": ["(review|pull.?request|code.?review|check.*(code|changes|diff)|code.?quality|lint|tech.?debt|(^|[^a-z])pr($|[^a-z]))"],
+      "trigger_mode": "regex",
+      "priority": 17,
+      "invoke": "Skill(agent-team-review)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "design-debate",
+      "role": "domain",
+      "phase": "DESIGN",
+      "triggers": ["(build|create|implement|develop|scaffold|brainstorm|design|architect|strateg|scope|outline|approach|generate|set.?up|integrate|extend|new|start)"],
+      "trigger_mode": "regex",
+      "priority": 14,
+      "invoke": "Skill(design-debate)",
+      "available": true,
+      "enabled": true
+    }
+  ],
+  "plugins": [
+    {"name": "code-review", "source": "claude-plugins-official", "provides": {"commands": ["/code-review"], "skills": [], "agents": [], "hooks": []}, "phase_fit": ["REVIEW"], "description": "5 parallel review agents", "available": true},
+    {"name": "code-simplifier", "source": "claude-plugins-official", "provides": {"commands": [], "skills": [], "agents": ["code-simplifier"], "hooks": []}, "phase_fit": ["REVIEW"], "description": "Post-review clarity pass", "available": true},
+    {"name": "commit-commands", "source": "claude-plugins-official", "provides": {"commands": ["/commit", "/commit-push-pr"], "skills": [], "agents": [], "hooks": []}, "phase_fit": ["SHIP"], "description": "Commit workflows", "available": true},
+    {"name": "security-guidance", "source": "claude-plugins-official", "provides": {"commands": [], "skills": [], "agents": [], "hooks": ["PreToolUse:security-patterns"]}, "phase_fit": ["*"], "description": "Write-time security blocker", "available": true},
+    {"name": "feature-dev", "source": "claude-plugins-official", "provides": {"commands": ["/feature-dev"], "skills": [], "agents": ["code-explorer", "code-architect", "code-reviewer"], "hooks": []}, "phase_fit": ["DESIGN", "IMPLEMENT", "REVIEW"], "description": "Full feature pipeline", "available": true}
+  ],
+  "phase_compositions": {
+    "DESIGN": {"driver": "brainstorming", "parallel": [{"plugin": "feature-dev", "use": "agents:code-explorer", "when": "installed", "purpose": "Parallel codebase exploration while brainstorming"}], "hints": [{"plugin": "feature-dev", "text": "Consider /feature-dev for agent-parallel feature development", "when": "installed"}]},
+    "PLAN": {"driver": "writing-plans", "parallel": [], "hints": []},
+    "IMPLEMENT": {"driver": "executing-plans", "parallel": [{"plugin": "security-guidance", "use": "hooks:PreToolUse", "when": "installed", "purpose": "Passive write-time security guard"}], "hints": []},
+    "REVIEW": {"driver": "requesting-code-review", "parallel": [{"plugin": "code-review", "use": "commands:/code-review", "when": "installed", "purpose": "5 parallel review agents, posts to GitHub PR"}, {"plugin": "code-simplifier", "use": "agents:code-simplifier", "when": "installed", "purpose": "Post-review simplification pass"}], "hints": [{"plugin": "code-review", "text": "Consider /code-review for automated multi-agent PR review", "when": "installed"}]},
+    "SHIP": {"driver": "verification-before-completion", "sequence": [{"plugin": "commit-commands", "use": "commands:/commit", "when": "installed", "purpose": "Execute structured commit after verification passes"}, {"step": "finishing-a-development-branch", "purpose": "Branch cleanup, merge, or PR"}, {"plugin": "commit-commands", "use": "commands:/commit-push-pr", "when": "installed AND user chooses PR option", "purpose": "Automated branch-to-PR flow"}], "hints": [{"plugin": "commit-commands", "text": "Consider /commit-push-pr for automated branch-to-PR workflow", "when": "installed"}]},
+    "DEBUG": {"driver": "systematic-debugging", "parallel": [], "hints": []}
+  },
+  "methodology_hints": [
+    {"name": "ralph-loop", "triggers": ["(migrate|refactor.all|fix.all|batch|overnight|autonom|iterate|keep.(going|trying|fixing))"], "trigger_mode": "regex", "hint": "RALPH LOOP: Consider /ralph-loop for autonomous iteration."},
+    {"name": "pr-review", "triggers": ["(review|pull.?request|code.?review|(^|[^a-z])pr($|[^a-z]))"], "trigger_mode": "regex", "hint": "PR REVIEW: Consider /pr-review for structured review.", "skill": "requesting-code-review"}
+  ],
+  "blocklist_patterns": [
+    {"pattern": "^(hi|hello|hey|thanks|thank.you|good.(morning|afternoon|evening)|bye|goodbye|ok|okay|yes|no|sure|yep|nope|got.it|sounds.good|cool|nice|great|perfect|awesome|understood)([[:space:]!.,]+.{0,20})?$", "description": "Greeting or short acknowledgement", "max_tail_length": 20}
+  ],
+  "warnings": []
+}
+REGISTRY_V4
+}
+
 # ---------------------------------------------------------------------------
 # 1. Debug prompt matches systematic-debugging
 # ---------------------------------------------------------------------------
@@ -720,6 +919,59 @@ test_teammate_idle_guard() {
 }
 
 # ---------------------------------------------------------------------------
+# 23. Review phase emits PARALLEL lines (v4 registry)
+# ---------------------------------------------------------------------------
+test_review_emits_parallel_lines() {
+    echo "-- test: review phase emits PARALLEL lines --"
+    setup_test_env
+    install_registry_v4
+
+    local output context
+    output="$(run_hook "please review the code changes in this pull request")"
+    context="$(extract_context "${output}")"
+
+    assert_contains "review has PARALLEL line" "PARALLEL:" "${context}"
+    assert_contains "review mentions code-review" "code-review" "${context}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 24. Ship phase emits SEQUENCE lines (v4 registry)
+# ---------------------------------------------------------------------------
+test_ship_emits_sequence_lines() {
+    echo "-- test: ship phase emits SEQUENCE lines --"
+    setup_test_env
+    install_registry_v4
+
+    local output context
+    output="$(run_hook "let's ship this and merge the branch to main")"
+    context="$(extract_context "${output}")"
+
+    assert_contains "ship has SEQUENCE line" "SEQUENCE:" "${context}"
+    assert_contains "ship mentions commit" "commit" "$(printf '%s' "${context}" | tr '[:upper:]' '[:lower:]')"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 25. No PARALLEL when plugin unavailable (v3 registry)
+# ---------------------------------------------------------------------------
+test_no_parallel_when_plugin_unavailable() {
+    echo "-- test: no PARALLEL when plugin unavailable --"
+    setup_test_env
+    install_registry  # v3 registry, no plugins
+
+    local output context
+    output="$(run_hook "please review the code changes in this pull request")"
+    context="$(extract_context "${output}")"
+
+    assert_not_contains "no PARALLEL without plugins" "PARALLEL:" "${context}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 test_debug_prompt_matches
@@ -744,5 +996,8 @@ test_skill_name_mention_boost
 test_domain_invocation_instruction
 test_overflow_domain_shown
 test_teammate_idle_guard
+test_review_emits_parallel_lines
+test_ship_emits_sequence_lines
+test_no_parallel_when_plugin_unavailable
 
 print_summary

--- a/tests/test-routing.sh
+++ b/tests/test-routing.sh
@@ -35,7 +35,7 @@ install_registry() {
     mkdir -p "$(dirname "${cache_file}")"
     cat > "${cache_file}" <<'REGISTRY'
 {
-  "version": "3.2.0",
+  "version": "4.0.0",
   "skills": [
     {
       "name": "systematic-debugging",


### PR DESCRIPTION
## Summary
- **Plugin registry**: 7 curated official marketplace plugins (commit-commands, security-guidance, hookify, feature-dev, code-review, code-simplifier, skill-creator) mapped to capabilities and pipeline phases in `default-triggers.json`
- **Phase compositions**: Per-phase orchestration rules defining parallel agents, sequential steps, and contextual hints across the DESIGN→PLAN→IMPLEMENT→REVIEW→SHIP→DEBUG pipeline
- **Auto-discovery**: Unknown plugins from any marketplace directory are scanned for skills, commands, and agents — providing basic routing for community plugins
- **Routing engine output**: `PARALLEL:` and `SEQUENCE:` composition lines emitted alongside skill suggestions when plugins are available; graceful degradation when they're not
- **Health reporting**: Session-start health check now reports plugin counts (installed vs total)

## Changes
- `config/default-triggers.json` — Added `plugins` (7 entries) and `phase_compositions` (6 phases) sections, version bumped to 4.0.0
- `hooks/session-start-hook.sh` — Steps 8b/8c for curated + auto plugin discovery, phase_compositions in registry cache, extended companion check (12 plugins), plugin counts in health message
- `hooks/skill-activation-hook.sh` — Phase composition section computes PARALLEL/SEQUENCE/hint lines from registry, injected into all output formats (0/1-2/3+ skills)
- `config/fallback-registry.json` — Empty plugins and phase_compositions for graceful degradation
- `tests/` — 18 new tests across 4 test suites (150 total, all passing)

## Test plan
- [x] All 150 tests pass across test-registry.sh, test-routing.sh, test-install.sh, test-context.sh
- [x] Curated plugins discovered and marked available/unavailable based on installation
- [x] Unknown plugins auto-discovered from community marketplace directories
- [x] PARALLEL lines emitted for REVIEW phase with code-review plugin
- [x] SEQUENCE lines emitted for SHIP phase with commit-commands plugin
- [x] No composition lines when plugins absent (v3 registry backward compat)
- [x] Fallback registry validates with new keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)