### PR TITLE
fix: skill activation hook logic improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 docs/plans/
 docs/session-backups/
 docs/superpowers-analysis.md
+.worktrees/

--- a/hooks/skill-activation-hook.sh
+++ b/hooks/skill-activation-hook.sh
@@ -493,8 +493,13 @@ Evaluate: **Phase: [${EVAL_PHASE}]** | ${EVAL_SKILLS}"
 
   # Add domain invocation instruction when domain skills are present
   if [[ "$DOMAIN_COUNT" -gt 0 ]] || [[ -n "$OVERFLOW_DOMAIN" ]]; then
-    OUT+="
+    if [[ -n "$PROCESS_SKILL" ]]; then
+      OUT+="
 Domain skills evaluated YES: invoke them (before, during, or after the process skill) -- do not just note them."
+    else
+      OUT+="
+Domain skills evaluated YES: invoke them -- do not just note them."
+    fi
   fi
 
 else
@@ -568,8 +573,13 @@ Step 3 -- State your plan and proceed. Keep it to 1-2 sentences."
 
   # Add domain invocation instruction when domain skills are present
   if [[ "$DOMAIN_COUNT" -gt 0 ]] || [[ -n "$OVERFLOW_DOMAIN" ]]; then
-    OUT+="
+    if [[ -n "$PROCESS_SKILL" ]]; then
+      OUT+="
 Domain skills evaluated YES: invoke them (before, during, or after the process skill) -- do not just note them."
+    else
+      OUT+="
+Domain skills evaluated YES: invoke them -- do not just note them."
+    fi
   fi
 fi
 

--- a/hooks/skill-activation-hook.sh
+++ b/hooks/skill-activation-hook.sh
@@ -177,6 +177,7 @@ SORTED="$(printf '%s' "$RESULTS" | grep -v '^$' | sort -s -t'|' -k1 -rn)"
 # SELECT BY ROLE CAPS
 # =================================================================
 # Max 1 process, up to 2 domain, max 1 workflow, total <= max_suggestions
+# INVARIANT: If any process skill matched, it gets a reserved slot.
 SELECTED=""
 OVERFLOW_DOMAIN=""
 PROCESS_COUNT=0
@@ -184,8 +185,30 @@ DOMAIN_COUNT=0
 WORKFLOW_COUNT=0
 TOTAL_COUNT=0
 
+# Pre-select: find the highest-ranked process skill and reserve a slot
+RESERVED_PROCESS=""
 while IFS='|' read -r score name role invoke phase; do
   [[ -z "$name" ]] && continue
+  if [[ "$role" == "process" ]]; then
+    RESERVED_PROCESS="${score}|${name}|${role}|${invoke}|${phase}"
+    SELECTED="${RESERVED_PROCESS}
+"
+    PROCESS_COUNT=1
+    TOTAL_COUNT=1
+    break
+  fi
+done <<EOF
+${SORTED}
+EOF
+
+# Fill remaining slots from SORTED, skipping the reserved process skill
+while IFS='|' read -r score name role invoke phase; do
+  [[ -z "$name" ]] && continue
+
+  # Skip the already-reserved process skill
+  if [[ -n "$RESERVED_PROCESS" ]] && [[ "$role" == "process" ]] && [[ "$RESERVED_PROCESS" == "${score}|${name}|${role}|${invoke}|${phase}" ]]; then
+    continue
+  fi
 
   case "$role" in
     process)

--- a/hooks/skill-activation-hook.sh
+++ b/hooks/skill-activation-hook.sh
@@ -281,6 +281,39 @@ EOF
 [[ "$HAS_WORKFLOW" -eq 1 ]] && PLABEL="${PLABEL} + Workflow"
 
 # =================================================================
+# PRIMARY PHASE (process > workflow > domain > first non-empty)
+# =================================================================
+PRIMARY_PHASE=""
+_PHASE_PROCESS=""
+_PHASE_WORKFLOW=""
+_PHASE_DOMAIN=""
+_PHASE_FIRST=""
+
+while IFS='|' read -r score name role invoke phase; do
+  [[ -z "$name" ]] && continue
+  if [[ -n "$phase" ]] && [[ -z "$_PHASE_FIRST" ]]; then
+    _PHASE_FIRST="$phase"
+  fi
+  case "$role" in
+    process)  [[ -z "$_PHASE_PROCESS" ]] && _PHASE_PROCESS="$phase" ;;
+    workflow) [[ -z "$_PHASE_WORKFLOW" ]] && _PHASE_WORKFLOW="$phase" ;;
+    domain)   [[ -z "$_PHASE_DOMAIN" ]] && _PHASE_DOMAIN="$phase" ;;
+  esac
+done <<EOF
+${SELECTED}
+EOF
+
+if [[ -n "$_PHASE_PROCESS" ]]; then
+  PRIMARY_PHASE="$_PHASE_PROCESS"
+elif [[ -n "$_PHASE_WORKFLOW" ]]; then
+  PRIMARY_PHASE="$_PHASE_WORKFLOW"
+elif [[ -n "$_PHASE_DOMAIN" ]]; then
+  PRIMARY_PHASE="$_PHASE_DOMAIN"
+else
+  PRIMARY_PHASE="$_PHASE_FIRST"
+fi
+
+# =================================================================
 # METHODOLOGY HINTS
 # =================================================================
 HINTS=""
@@ -316,17 +349,8 @@ done
 COMPOSITION_LINES=""
 COMPOSITION_HINTS=""
 
-# Determine the current phase from selected skills
-CURRENT_PHASE=""
-while IFS='|' read -r score name role invoke phase; do
-    [[ -z "$name" ]] && continue
-    if [[ -n "$phase" ]]; then
-        CURRENT_PHASE="$phase"
-        break
-    fi
-done <<EOF
-${SELECTED}
-EOF
+# Determine the current phase from selected skills (use PRIMARY_PHASE)
+CURRENT_PHASE="$PRIMARY_PHASE"
 
 # Look up phase composition if registry has it and a phase was determined
 if [[ -n "$CURRENT_PHASE" ]]; then
@@ -451,17 +475,8 @@ ${OVERFLOW_DOMAIN}
 EOF
   OUT+="${OVERFLOW_LINES}"
 
-  # Get phase from process skill or first skill
-  EVAL_PHASE=""
-  while IFS='|' read -r score name role invoke phase; do
-    [[ -z "$name" ]] && continue
-    if [[ -n "$phase" ]]; then
-      EVAL_PHASE="$phase"
-      break
-    fi
-  done <<EOF
-${SELECTED}
-EOF
+  # Phase from process skill (with precedence)
+  EVAL_PHASE="$PRIMARY_PHASE"
   [[ -z "$EVAL_PHASE" ]] && EVAL_PHASE="IMPLEMENT"
 
   OUT+="

--- a/hooks/skill-activation-hook.sh
+++ b/hooks/skill-activation-hook.sh
@@ -106,18 +106,17 @@ RESULTS=""
 while IFS= read -r skill_json; do
   [[ -z "$skill_json" ]] && continue
 
-  skill_name="$(printf '%s' "$skill_json" | jq -r '.name')"
-  skill_role="$(printf '%s' "$skill_json" | jq -r '.role')"
-  skill_priority="$(printf '%s' "$skill_json" | jq -r '.priority // 0')"
-  skill_invoke="$(printf '%s' "$skill_json" | jq -r '.invoke // "SKIP"')"
-  skill_phase="$(printf '%s' "$skill_json" | jq -r '.phase // ""')"
+  # Extract all fields in one jq call (reduces 5 forks to 1 per skill)
+  read -r skill_name skill_role skill_priority skill_invoke skill_phase <<FIELDS
+$(printf '%s' "$skill_json" | jq -r '[.name, .role, (.priority // 0 | tostring), (.invoke // "SKIP"), (.phase // "")] | @tsv')
+FIELDS
 
-  trigger_count="$(printf '%s' "$skill_json" | jq '.triggers | length')"
+  trigger_count="$(printf '%s' "$skill_json" | jq '.triggers // [] | length')"
   trigger_score=0
 
   ti=0
   while [[ "$ti" -lt "$trigger_count" ]]; do
-    trigger="$(printf '%s' "$skill_json" | jq -r ".triggers[${ti}]")"
+    trigger="$(printf '%s' "$skill_json" | jq -r "(.triggers // [])[${ti}]")"
     ti=$((ti + 1))
 
     # Test regex against lowercased prompt

--- a/hooks/skill-activation-hook.sh
+++ b/hooks/skill-activation-hook.sh
@@ -505,8 +505,12 @@ Step 1 -- ASSESS PHASE. Check conversation context:
 
 Step 2 -- EVALUATE skills against your phase assessment."
 
-  # Build skill lines with orchestration
+  # Build grouped skill lines (process-first ordering)
   EVAL_SKILLS=""
+  _FULL_PROCESS_LINE=""
+  _FULL_DOMAIN_LINES=""
+  _FULL_WORKFLOW_LINES=""
+  _FULL_STANDALONE_LINES=""
 
   while IFS='|' read -r score name role invoke phase; do
     [[ -z "$name" ]] && continue
@@ -518,20 +522,22 @@ Step 2 -- EVALUATE skills against your phase assessment."
 
     if [[ -n "$PROCESS_SKILL" ]]; then
       case "$role" in
-        process)  OUT+="
+        process)  _FULL_PROCESS_LINE="
 Process: ${name} -> ${invoke}" ;;
-        domain)   OUT+="
+        domain)   _FULL_DOMAIN_LINES="${_FULL_DOMAIN_LINES}
   Domain: ${name} -> ${invoke}" ;;
-        workflow) OUT+="
+        workflow) _FULL_WORKFLOW_LINES="${_FULL_WORKFLOW_LINES}
 Workflow: ${name} -> ${invoke}" ;;
       esac
     else
-      OUT+="
+      _FULL_STANDALONE_LINES="${_FULL_STANDALONE_LINES}
 ${name} -> ${invoke}"
     fi
   done <<EOF
 ${SELECTED}
 EOF
+
+  OUT+="${_FULL_PROCESS_LINE}${_FULL_DOMAIN_LINES}${_FULL_WORKFLOW_LINES}${_FULL_STANDALONE_LINES}"
 
   # Append overflow domain skills
   while IFS='|' read -r oname oinvoke; do

--- a/hooks/skill-activation-hook.sh
+++ b/hooks/skill-activation-hook.sh
@@ -89,13 +89,19 @@ SCORED_SKILLS="$(printf '%s' "$REGISTRY" | jq -c '
   [.skills[] | select(.available == true and .enabled == true)][]
 ' 2>/dev/null)"
 
-# L3: Pre-pass — collect skill names that appear verbatim in the prompt
+# L3: Pre-pass — collect skill names that appear as whole words in the prompt
+# Uses newline-delimited list + boundary checks to avoid prefix/substring false positives
 SKILL_NAME_MATCHES=""
 while IFS= read -r _sj; do
   [[ -z "$_sj" ]] && continue
   _sn="$(printf '%s' "$_sj" | jq -r '.name')"
-  if [[ "$P" == *"$_sn"* ]]; then
-    SKILL_NAME_MATCHES="${SKILL_NAME_MATCHES}|${_sn}"
+  _sn_lower="$(printf '%s' "$_sn" | tr '[:upper:]' '[:lower:]')"
+  # Check if skill name appears with word boundaries in the lowercased prompt
+  # Word boundaries for kebab-case names: start/end of string, or non-[a-z0-9-] character
+  if [[ "$P" =~ (^|[^a-z0-9-])${_sn_lower}($|[^a-z0-9-]) ]]; then
+    SKILL_NAME_MATCHES="${SKILL_NAME_MATCHES}
+${_sn}
+"
   fi
 done <<EOF
 ${SCORED_SKILLS}
@@ -131,13 +137,13 @@ FIELDS
 
       if [[ "$prefix_len" -gt 0 ]]; then
         char_before="${P:$((prefix_len - 1)):1}"
-        if [[ "$char_before" =~ [a-z0-9_-] ]]; then
+        if [[ "$char_before" =~ [a-z0-9_.-] ]]; then
           is_word_boundary=0
         fi
       fi
       if [[ "$after_pos" -lt "${#P}" ]]; then
         char_after="${P:${after_pos}:1}"
-        if [[ "$char_after" =~ [a-z0-9_-] ]]; then
+        if [[ "$char_after" =~ [a-z0-9_.-] ]]; then
           is_word_boundary=0
         fi
       fi
@@ -156,7 +162,9 @@ FIELDS
 
   # L3: Apply skill-name-mention boost (+100) and allow through even with zero trigger_score
   name_boost=0
-  if [[ "$SKILL_NAME_MATCHES" == *"|${skill_name}"* ]]; then
+  if [[ "$SKILL_NAME_MATCHES" == *"
+${skill_name}
+"* ]]; then
     name_boost=100
   fi
 

--- a/tests/test-context.sh
+++ b/tests/test-context.sh
@@ -316,6 +316,36 @@ test_output_valid_json_multi_match() {
 }
 
 # ---------------------------------------------------------------------------
+# 7. Full format lists Process: before Domain:
+# ---------------------------------------------------------------------------
+test_full_format_process_first() {
+    echo "-- test: full format lists Process before Domain --"
+    setup_test_env
+    install_context_registry
+
+    local output context
+    output="$(run_hook "build a secure frontend dashboard component with csrf protection")"
+    context="$(extract_context "${output}")"
+
+    # Process: line should appear before any Domain: line
+    local process_pos domain_pos
+    process_pos="$(printf '%s' "${context}" | grep -n 'Process:' | head -1 | cut -d: -f1)"
+    domain_pos="$(printf '%s' "${context}" | grep -n 'Domain:' | head -1 | cut -d: -f1)"
+
+    if [[ -n "$process_pos" ]] && [[ -n "$domain_pos" ]]; then
+        if [[ "$process_pos" -lt "$domain_pos" ]]; then
+            _record_pass "Process: appears before Domain:"
+        else
+            _record_fail "Process: appears before Domain:" "Process at line ${process_pos}, Domain at line ${domain_pos}"
+        fi
+    else
+        _record_fail "Process: appears before Domain:" "Missing Process: or Domain: line"
+    fi
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 test_zero_skills_minimal_output
@@ -326,5 +356,6 @@ test_invocation_hints_present
 test_output_valid_json_zero_match
 test_output_valid_json_single_match
 test_output_valid_json_multi_match
+test_full_format_process_first
 
 print_summary

--- a/tests/test-routing.sh
+++ b/tests/test-routing.sh
@@ -1128,6 +1128,106 @@ PHASEREG
 }
 
 # ---------------------------------------------------------------------------
+# 29. Skill name boost uses boundary-aware matching
+# ---------------------------------------------------------------------------
+test_name_boost_boundary_aware() {
+    echo "-- test: skill name boost boundary-aware --"
+    setup_test_env
+
+    # Custom registry with two skills: "debug" and "debug-advanced"
+    local cache_file="${HOME}/.claude/.skill-registry-cache.json"
+    mkdir -p "$(dirname "${cache_file}")"
+    cat > "${cache_file}" <<'NAMEREG'
+{
+  "version": "test",
+  "skills": [
+    {
+      "name": "debug",
+      "role": "domain",
+      "triggers": ["(never-match-this-nonsense-string)"],
+      "priority": 10,
+      "invoke": "Skill(mock:debug)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "debug-advanced",
+      "role": "domain",
+      "triggers": ["(never-match-this-nonsense-string)"],
+      "priority": 10,
+      "invoke": "Skill(mock:debug-advanced)",
+      "available": true,
+      "enabled": true
+    }
+  ],
+  "methodology_hints": [],
+  "phase_compositions": {}
+}
+NAMEREG
+
+    # Mention only "debug-advanced" by name — "debug" should NOT get boosted
+    local output context
+    output="$(run_hook "tell me about the debug-advanced skill and how it works")"
+    context="$(extract_context "${output}")"
+
+    assert_contains "debug-advanced is selected" "debug-advanced" "${context}"
+    assert_not_contains "plain debug not selected" "mock:debug)" "${context}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 29.5. Trigger word-boundary excludes dot (file extension separator)
+# ---------------------------------------------------------------------------
+test_trigger_boundary_excludes_dot() {
+    echo "-- test: trigger word-boundary excludes dot --"
+    setup_test_env
+
+    local cache_file="${HOME}/.claude/.skill-registry-cache.json"
+    mkdir -p "$(dirname "${cache_file}")"
+    cat > "${cache_file}" <<'DOTREG'
+{
+  "version": "test",
+  "skills": [
+    {
+      "name": "py-tool",
+      "role": "domain",
+      "triggers": ["py"],
+      "priority": 0,
+      "invoke": "Skill(mock:py-tool)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "other-tool",
+      "role": "domain",
+      "triggers": ["(skill|tool)"],
+      "priority": 0,
+      "invoke": "Skill(mock:other-tool)",
+      "available": true,
+      "enabled": true
+    }
+  ],
+  "methodology_hints": [],
+  "phase_compositions": {}
+}
+DOTREG
+
+    # "check skill.py file" — "py" appears after a dot, NOT a word boundary
+    # "other-tool" has trigger "skill" which gets word-boundary score (30)
+    # "py-tool" trigger "py" should only get substring score (10)
+    # With equal priority (0), other-tool (score 30) should rank above py-tool (score 10)
+    local output context
+    output="$(run_hook "check the skill.py file for issues please")"
+    context="$(extract_context "${output}")"
+
+    # other-tool should appear (word-boundary match on "skill")
+    assert_contains "other-tool selected" "other-tool" "${context}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 test_debug_prompt_matches
@@ -1159,5 +1259,7 @@ test_process_slot_reserved
 test_missing_triggers_handled
 test_phase_uses_process_precedence
 test_eval_phase_uses_process
+test_name_boost_boundary_aware
+test_trigger_boundary_excludes_dot
 
 print_summary

--- a/tests/test-routing.sh
+++ b/tests/test-routing.sh
@@ -1228,6 +1228,55 @@ DOTREG
 }
 
 # ---------------------------------------------------------------------------
+# 30. Domain instruction wording without process skill
+# ---------------------------------------------------------------------------
+test_domain_instruction_no_process() {
+    echo "-- test: domain instruction wording without process --"
+    setup_test_env
+
+    # Custom registry: only domain skills, no process skills
+    local cache_file="${HOME}/.claude/.skill-registry-cache.json"
+    mkdir -p "$(dirname "${cache_file}")"
+    cat > "${cache_file}" <<'DOMREG'
+{
+  "version": "test",
+  "skills": [
+    {
+      "name": "security-scanner",
+      "role": "domain",
+      "triggers": ["(secur(e|ity)|vulnerab)"],
+      "priority": 102,
+      "invoke": "Skill(security-scanner)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "frontend-design",
+      "role": "domain",
+      "triggers": ["(frontend|dashboard|component)"],
+      "priority": 101,
+      "invoke": "Skill(frontend-design)",
+      "available": true,
+      "enabled": true
+    }
+  ],
+  "methodology_hints": [],
+  "phase_compositions": {}
+}
+DOMREG
+
+    local output context
+    output="$(run_hook "build a secure frontend dashboard component")"
+    context="$(extract_context "${output}")"
+
+    # Should have domain invocation instruction but NOT mention "the process skill"
+    assert_contains "has domain invocation instruction" "invoke them" "${context}"
+    assert_not_contains "no process skill reference" "the process skill" "${context}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 test_debug_prompt_matches
@@ -1261,5 +1310,6 @@ test_phase_uses_process_precedence
 test_eval_phase_uses_process
 test_name_boost_boundary_aware
 test_trigger_boundary_excludes_dot
+test_domain_instruction_no_process
 
 print_summary

--- a/tests/test-routing.sh
+++ b/tests/test-routing.sh
@@ -972,6 +972,29 @@ test_no_parallel_when_plugin_unavailable() {
 }
 
 # ---------------------------------------------------------------------------
+# 26. Process skill reserved when high-priority domain/workflow fill slots
+# ---------------------------------------------------------------------------
+test_process_slot_reserved() {
+    echo "-- test: process slot reserved under cap --"
+    setup_test_env
+    install_registry
+
+    # "build a secure frontend dashboard and ship it" triggers:
+    #   brainstorming (process, prio 30), security-scanner (domain, prio 102),
+    #   frontend-design (domain, prio 101), finishing-a-development-branch (workflow, prio 61)
+    # With max_suggestions=3, all 3 slots could go to non-process skills.
+    # Process skill MUST still be selected.
+    local output context
+    output="$(run_hook "build a secure frontend dashboard and ship it")"
+    context="$(extract_context "${output}")"
+
+    assert_contains "process skill reserved" "Skill(superpowers:brainstorming)" "${context}"
+    assert_contains "process skill has Process: prefix" "Process:" "${context}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 test_debug_prompt_matches
@@ -999,5 +1022,6 @@ test_teammate_idle_guard
 test_review_emits_parallel_lines
 test_ship_emits_sequence_lines
 test_no_parallel_when_plugin_unavailable
+test_process_slot_reserved
 
 print_summary

--- a/tests/test-routing.sh
+++ b/tests/test-routing.sh
@@ -995,6 +995,63 @@ test_process_slot_reserved() {
 }
 
 # ---------------------------------------------------------------------------
+# 26.5. Malformed skill entry (missing triggers) does not break hook
+# ---------------------------------------------------------------------------
+test_missing_triggers_handled() {
+    echo "-- test: missing triggers handled gracefully --"
+    setup_test_env
+
+    local cache_file="${HOME}/.claude/.skill-registry-cache.json"
+    mkdir -p "$(dirname "${cache_file}")"
+    cat > "${cache_file}" <<'BADREG'
+{
+  "version": "test",
+  "skills": [
+    {
+      "name": "good-skill",
+      "role": "process",
+      "phase": "DEBUG",
+      "triggers": ["(debug|bug)"],
+      "priority": 10,
+      "invoke": "Skill(mock:good-skill)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "no-triggers-skill",
+      "role": "domain",
+      "priority": 50,
+      "invoke": "Skill(mock:no-triggers)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "null-triggers-skill",
+      "role": "domain",
+      "triggers": null,
+      "priority": 50,
+      "invoke": "Skill(mock:null-triggers)",
+      "available": true,
+      "enabled": true
+    }
+  ],
+  "methodology_hints": [],
+  "phase_compositions": {}
+}
+BADREG
+
+    local exit_code=0
+    local output context
+    output="$(run_hook "debug this broken module")" || exit_code=$?
+
+    assert_equals "hook exits cleanly with malformed skills" "0" "${exit_code}"
+    context="$(extract_context "${output}")"
+    assert_contains "good skill still selected" "good-skill" "${context}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 test_debug_prompt_matches
@@ -1023,5 +1080,6 @@ test_review_emits_parallel_lines
 test_ship_emits_sequence_lines
 test_no_parallel_when_plugin_unavailable
 test_process_slot_reserved
+test_missing_triggers_handled
 
 print_summary

--- a/tests/test-routing.sh
+++ b/tests/test-routing.sh
@@ -1052,6 +1052,82 @@ BADREG
 }
 
 # ---------------------------------------------------------------------------
+# 27. Phase composition uses process phase, not domain phase
+# ---------------------------------------------------------------------------
+test_phase_uses_process_precedence() {
+    echo "-- test: phase composition uses process phase precedence --"
+    setup_test_env
+    install_registry_v4
+
+    # "build a secure frontend dashboard" triggers:
+    #   brainstorming (process, phase=DESIGN, prio 30),
+    #   security-scanner (domain, no phase, prio 102),
+    #   frontend-design (domain, no phase, prio 101)
+    # Phase should be DESIGN (from process), not any domain phase
+    local output context
+    output="$(run_hook "build a secure frontend dashboard component with csrf protection")"
+    context="$(extract_context "${output}")"
+
+    # The DESIGN phase composition has a PARALLEL line for feature-dev plugin
+    assert_contains "phase composition uses DESIGN" "PARALLEL:" "${context}"
+    assert_contains "phase composition mentions feature-dev" "feature-dev" "${context}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# 28. Compact Evaluate phase uses process phase
+# ---------------------------------------------------------------------------
+test_eval_phase_uses_process() {
+    echo "-- test: compact Evaluate phase uses process phase --"
+    setup_test_env
+
+    # Use a minimal registry with just 1 process + 1 domain to stay in compact format
+    local cache_file="${HOME}/.claude/.skill-registry-cache.json"
+    mkdir -p "$(dirname "${cache_file}")"
+    cat > "${cache_file}" <<'PHASEREG'
+{
+  "version": "test",
+  "skills": [
+    {
+      "name": "brainstorming",
+      "role": "process",
+      "phase": "DESIGN",
+      "triggers": ["(build|create)"],
+      "priority": 30,
+      "invoke": "Skill(superpowers:brainstorming)",
+      "available": true,
+      "enabled": true
+    },
+    {
+      "name": "security-scanner",
+      "role": "domain",
+      "phase": "IMPLEMENT",
+      "triggers": ["(secur(e|ity)|encrypt)"],
+      "priority": 102,
+      "invoke": "Skill(security-scanner)",
+      "available": true,
+      "enabled": true
+    }
+  ],
+  "methodology_hints": [],
+  "phase_compositions": {}
+}
+PHASEREG
+
+    # 2 skills -> compact format with Evaluate line
+    # security-scanner has phase=IMPLEMENT, brainstorming has phase=DESIGN
+    # Process phase (DESIGN) should win
+    local output context
+    output="$(run_hook "build a secure authentication service with encryption")"
+    context="$(extract_context "${output}")"
+
+    assert_contains "Evaluate uses DESIGN phase" "Phase: [DESIGN]" "${context}"
+
+    teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 test_debug_prompt_matches
@@ -1081,5 +1157,7 @@ test_ship_emits_sequence_lines
 test_no_parallel_when_plugin_unavailable
 test_process_slot_reserved
 test_missing_triggers_handled
+test_phase_uses_process_precedence
+test_eval_phase_uses_process
 
 print_summary


### PR DESCRIPTION
## Summary
- **Reserve process slot**: Process skill can no longer be crowded out by high-priority domain/workflow skills filling all `max_suggestions` slots
- **Phase precedence**: Phase composition and Evaluate line now derive from process skill phase (process > workflow > domain > first non-empty), preventing domain phases from driving wrong composition hints
- **jq fork reduction**: Per-skill field extraction reduced from 5 jq forks to 1 via single `@tsv` call; trigger extraction hardened with `.triggers // []` for malformed registry entries
- **Process-first output grouping**: Full-format (3+ skills) output now groups by role (Process, Domain, Workflow) matching compact-mode behavior
- **Boundary-aware name boost**: Skill-name-mention matching uses `[^a-z0-9-]` boundaries to prevent prefix false positives (e.g., `debug` no longer matches when only `debug-advanced` is mentioned); trigger word-boundary adds `.` to exclusion class to prevent file-extension false matches
- **Conditional domain wording**: Domain invocation instruction drops "the process skill" reference when no process skill is selected

## Test plan
- [x] 72/72 tests pass (56 routing + 16 context), up from 59
- [x] 7 new test functions covering each fix
- [x] Isolated reproduction of process starvation bug verified fixed
- [x] No JSON output schema changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)