### PR TITLE
fix: stable session token (Claude Code session_id) — fixes orphaned composition state

### DIFF
--- a/hooks/session-start-hook.sh
+++ b/hooks/session-start-hook.sh
@@ -41,12 +41,32 @@ fi
 # -----------------------------------------------------------------
 # Step 1c: Reset depth counter for new session
 # -----------------------------------------------------------------
-# Generate a session-scoped token so concurrent sessions don't share counters.
-# Format: <epoch>-<pid>-<rand>. The random suffix defends against collisions
-# when two sessions start in the same second with a reused PID (shell respawn,
-# rapid subshell invocation). Without it the token was 1-second-granularity.
-# Clean up stale counter files from previous sessions first.
-_SESSION_TOKEN="$(date +%s)-$$-${RANDOM}${RANDOM}"
+# Token strategy: prefer Claude Code's session_id from hook stdin (stable across
+# every SessionStart fire within the same conversation — IDE reloads, panel
+# restarts, etc.) so composition-state files keyed off the token survive
+# session-start re-fires. Without this, every SessionStart rotated the token
+# and orphaned in-flight composition state, blowing up the openspec-guard push
+# gate's REVIEW/VERIFY/SHIP checks (see #14, #15).
+#
+# Falls back to <epoch>-<pid>-<rand> when stdin is unavailable, contains no
+# session_id, or jq is missing — preserving the original collision-defense
+# guarantees for environments that don't deliver session_id.
+_HOOK_STDIN=""
+if [ ! -t 0 ]; then
+    _HOOK_STDIN="$(cat 2>/dev/null)" || _HOOK_STDIN=""
+fi
+_HOOK_SESSION_ID=""
+if [ -n "${_HOOK_STDIN}" ] && command -v jq >/dev/null 2>&1; then
+    _HOOK_SESSION_ID="$(printf '%s' "${_HOOK_STDIN}" | jq -r '.session_id // empty' 2>/dev/null)" || _HOOK_SESSION_ID=""
+fi
+if [ -n "${_HOOK_SESSION_ID}" ]; then
+    _SESSION_TOKEN="session-${_HOOK_SESSION_ID}"
+else
+    # Fallback for environments without session_id. Format: <epoch>-<pid>-<rand>.
+    # The random suffix defends against collisions when two sessions start in the
+    # same second with a reused PID (shell respawn, rapid subshell invocation).
+    _SESSION_TOKEN="$(date +%s)-$$-${RANDOM}${RANDOM}"
+fi
 printf '%s' "$_SESSION_TOKEN" > "${HOME}/.claude/.skill-session-token" 2>/dev/null || true
 # Read previous session's zero-match stats before cleanup
 _PREV_ZM=0

--- a/tests/test-registry.sh
+++ b/tests/test-registry.sh
@@ -545,6 +545,63 @@ test_context_capabilities_detection() {
     teardown_test_env
 }
 
+test_session_token_uses_session_id_when_provided() {
+    echo "-- test: session-start derives token from stdin .session_id when present --"
+    setup_test_env
+
+    # Run hook with a synthetic session_id on stdin
+    local input='{"session_id":"unit-test-stable-id-42","hook_event_name":"SessionStart","source":"startup"}'
+    printf '%s' "${input}" | CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" _SKILL_TEST_MODE=1 bash "${PROJECT_ROOT}/hooks/session-start-hook.sh" >/dev/null 2>&1
+
+    local token
+    token="$(cat "${HOME}/.claude/.skill-session-token" 2>/dev/null)"
+    assert_equals "token equals session-<session_id>" "session-unit-test-stable-id-42" "${token}"
+
+    teardown_test_env
+}
+
+test_session_token_falls_back_when_no_session_id() {
+    echo "-- test: session-start falls back to epoch-pid-rand when stdin has no session_id --"
+    setup_test_env
+
+    # Run hook with empty stdin (no session_id available)
+    CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" _SKILL_TEST_MODE=1 bash "${PROJECT_ROOT}/hooks/session-start-hook.sh" >/dev/null 2>&1 < /dev/null
+
+    local token
+    token="$(cat "${HOME}/.claude/.skill-session-token" 2>/dev/null)"
+    # Fallback shape: <digits>-<digits>-<digits>
+    if printf '%s' "${token}" | grep -qE '^[0-9]+-[0-9]+-[0-9]+$'; then
+        echo "  PASS: fallback token has epoch-pid-rand shape"
+        TESTS_PASSED=$((${TESTS_PASSED:-0} + 1))
+    else
+        echo "  FAIL: fallback token shape unexpected: '${token}'"
+        TESTS_FAILED=$((${TESTS_FAILED:-0} + 1))
+    fi
+
+    teardown_test_env
+}
+
+test_session_token_stable_across_repeated_session_start() {
+    echo "-- test: same session_id → same token across repeated SessionStart fires --"
+    setup_test_env
+
+    local input='{"session_id":"reload-stability-test","hook_event_name":"SessionStart","source":"startup"}'
+
+    # First fire
+    printf '%s' "${input}" | CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" _SKILL_TEST_MODE=1 bash "${PROJECT_ROOT}/hooks/session-start-hook.sh" >/dev/null 2>&1
+    local token_a
+    token_a="$(cat "${HOME}/.claude/.skill-session-token" 2>/dev/null)"
+
+    # Second fire (simulate IDE reload — same session_id)
+    printf '%s' "${input}" | CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" _SKILL_TEST_MODE=1 bash "${PROJECT_ROOT}/hooks/session-start-hook.sh" >/dev/null 2>&1
+    local token_b
+    token_b="$(cat "${HOME}/.claude/.skill-session-token" 2>/dev/null)"
+
+    assert_equals "token unchanged across repeated SessionStart with same session_id" "${token_a}" "${token_b}"
+
+    teardown_test_env
+}
+
 test_lsp_capability_shape() {
     echo "-- test: context_capabilities has lsp key --"
     setup_test_env
@@ -1176,6 +1233,9 @@ test_auto_discovers_unknown_plugins
 test_health_check_reports_new_plugins
 test_fallback_registry_skill_coverage
 test_context_capabilities_detection
+test_session_token_uses_session_id_when_provided
+test_session_token_falls_back_when_no_session_id
+test_session_token_stable_across_repeated_session_start
 test_lsp_capability_shape
 test_context_capabilities_all_false
 test_context_capabilities_in_health_output


### PR DESCRIPTION
## Summary

Closes the root cause behind the openspec-guard push gate misfiring discovered while shipping #15. SessionStart was unconditionally rotating the session token on every fire, orphaning composition-state files keyed off the previous token.

**Symptom:** in a single conversation that ran `brainstorming → writing-plans → executing-plans → requesting-code-review → verification-before-completion → openspec-ship`, only `brainstorming` was recorded as completed. SessionStart re-fired during the conversation, rotated the token, and `skill-completion-hook.sh` wrote subsequent advances to a file the guard could no longer find.

**Fix:** prefer Claude Code's `session_id` from hook stdin as the token (`session-<session_id>`). Stable across every SessionStart fire within the same conversation (IDE reloads, panel restarts). Falls back to `<epoch>-<pid>-<rand>` only when stdin is absent, contains no `session_id`, or `jq` is missing — preserving collision defenses for environments without `session_id` delivery.

## Files

- `hooks/session-start-hook.sh` (Step 1c): read stdin once, extract `.session_id` via jq, derive `_SESSION_TOKEN="session-${session_id}"` if present, otherwise legacy fallback.
- `tests/test-registry.sh`: 3 new tests
  - `test_session_token_uses_session_id_when_provided`
  - `test_session_token_falls_back_when_no_session_id`
  - `test_session_token_stable_across_repeated_session_start`

## Test Plan

- [x] `bash tests/run-tests.sh` — 35/35 test files pass
- [x] Manual reproduction A: pipe `{"session_id":"abc123-stable"}` → token = `session-abc123-stable` ✓
- [x] Manual reproduction B: empty stdin (terminal) → token matches `^[0-9]+-[0-9]+-[0-9]+$` legacy shape ✓
- [x] Repeated SessionStart with same `session_id` → identical token (no rotation) ✓
- [ ] Live: install fix, restart session, run a multi-skill composition, push, verify openspec-guard sees accurate `.completed` state

## Behavioral impact

- Composition state survives SessionStart re-fires within a conversation
- `skill-completion-hook.sh` can reliably advance `.completed` mid-session
- `openspec-guard.sh` push gate's REVIEW/VERIFY/SHIP checks see accurate state
- Concurrent sessions still get distinct tokens (different `session_id`s)

## Related

- Discovered while shipping #15 (lsp-nudge hook). PR #15 push initially blocked by stale orphaned state; understanding the root cause produced this fix.
- Mentioned in CHANGELOG entry on PR #15 referencing #14, #15 — the cross-PR breadcrumb to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)