### PR TITLE
chore: gitignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ docs/superpowers-analysis.md
 .worktrees/
 __pycache__/
 *.pyc
+.DS_Store
 # Behavioral eval runner artifacts (opt-in, local-only)
 tests/artifacts/


### PR DESCRIPTION
## Summary
- Add `.DS_Store` to `.gitignore` so macOS Finder metadata stops appearing in `git status` and can't be committed by accident.

## Test plan
- [x] `git status` clean after deleting a stray `docs/.DS_Store` and adding the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)