### PR TITLE
docs: cross-reference canonical telemetry schema in observer/followthrough

### DIFF
--- a/hooks/serena-followthrough.sh
+++ b/hooks/serena-followthrough.sh
@@ -3,6 +3,8 @@
 # When a Serena MCP tool returns successfully, scans recent telemetry lines from
 # the same session and appends a `followup` record for each unmarked nudge or
 # observation within 3 turns. Used to compute follow-through % per matcher class.
+# Telemetry schema: see hooks/serena-nudge.sh (canonical reference). $5 is the
+# class field — the join key across nudge / observe / followup records.
 # Bash 3.2 compatible. Fail-open. jq required; no-op when unavailable.
 trap 'exit 0' ERR
 

--- a/hooks/serena-observer.sh
+++ b/hooks/serena-observer.sh
@@ -5,6 +5,8 @@
 # revival criteria documented in
 # docs/plans/archive/2026-05-07-serena-triggering-redesign-design.md
 # (also captured in openspec/specs/skill-routing/spec.md).
+# Telemetry schema: see hooks/serena-nudge.sh (canonical reference). $5 is the
+# class field — the join key across nudge / observe / followup records.
 #
 # Bash 3.2 compatible. Fail-open (exit 0 on any error). jq required; no-op when
 # jq is unavailable.


### PR DESCRIPTION
## Summary

Two-line maintenance comment fix from post-merge PR #26 review. Adds a pointer at the top of `serena-observer.sh` and `serena-followthrough.sh` referencing `serena-nudge.sh` as the canonical telemetry-schema reference, and noting that `$5` is the class join key across all record kinds.

Both files use `awk -F'\t' '$5 ...'` patterns without explaining why field 5 specifically. A future field-numbering audit (e.g. when adding a 7th observation class) shouldn't require file-system spelunking to find the schema.

## Why this is its own PR

The reviewer also suggested adding nanosecond entropy to the `mktemp` fallback in `serena-followthrough.sh`. Skipped that one — the proposed `date +%N` doesn't work on macOS BSD `date` (which this plugin targets), the trigger condition is triple-rare (`mktemp` failing + same-PID-modulo + `$RANDOM` collision), and the reviewer themselves graded the current state as "fine for production use."

## Test plan

- [x] `bash -n hooks/serena-followthrough.sh hooks/serena-observer.sh` — syntax OK
- [x] `bash tests/test-serena-followthrough.sh` — 11/11 pass
- [x] `bash tests/test-serena-observer.sh` — 15/15 pass
- No behavior change; comment-only edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)