### PR TITLE
test: add subagent-propagation behavioral fixture for Serena routing

### DIFF
--- a/tests/fixtures/serena/README.md
+++ b/tests/fixtures/serena/README.md
@@ -1,0 +1,62 @@
+# Serena routing behavioral evals
+
+Opt-in fixtures that exercise the Serena triggering redesign (PR #25) end-to-end via `claude -p`. Currently one scenario: **subagent-propagation**.
+
+## What this tests
+
+The redesign's subagent strategy delegates Serena-guidance propagation to Claude itself: the SessionStart banner instructs the parent context to include `Serena available — prefer find_symbol over Grep for symbol lookups` in any Task spawn prompt for code work. That delegation is the most untested claim in the design — bash hermetic tests cover "the banner contains the instruction," not "Claude follows the instruction in practice."
+
+This fixture asks Claude to spawn a subagent and to print the spawn prompt before invoking Task. Three assertions then check, against the printed prompt:
+1. Claude actually planned a Task spawn,
+2. The spawn prompt contains a Serena reference (banner copy or close paraphrase),
+3. The user's symbol-search task is carried into the subagent.
+
+If the second assertion fails repeatedly across variance runs, the propagation strategy is failing in practice. That is high-signal input for the 14-day revival evaluation — it would mean the parked Read / Glob matchers' "subagent inheritance via banner" assumption is wishful thinking and any future revival decision should weight in-band Grep-nudge coverage more heavily.
+
+## How to run
+
+This pack is **not** in the default `tests/run-tests.sh` path. It costs real `claude -p` invocations and is non-deterministic. Trigger explicitly:
+
+```bash
+BEHAVIORAL_EVALS=1 SKILL_PATH=tests/fixtures/serena/skill-stub.md \
+    bash tests/run-behavioral-evals.sh \
+    --pack tests/fixtures/serena/behavioral.json \
+    --scenario subagent-propagation \
+    --variance 5
+```
+
+`SKILL_PATH` overrides the default (incident-analysis SKILL.md). The stub at `tests/fixtures/serena/skill-stub.md` is intentionally near-empty so the `<skill_guidance>` wrapper does not steer Claude into an unrelated workflow.
+
+`--variance 5` (or higher) is **strongly recommended**. Single-run results are noisy. The variance report classifies each assertion as `stable` (≥90% pass), `flaky` (50–89%), or `broken` (<50%). Project memory `project_cast_fixture_zero_signal` documents why single runs of behavioral fixtures can mislead — design the fixture so it can fail honestly, not just fail because the model derailed.
+
+## Required safety setup
+
+Two known runner caveats apply (project memory `feedback_inner_claude_p_tool_access`):
+
+1. **The runner does not pass `--disallowedTools` to the inner `claude -p` invocation.** The inner process has full Edit / Write / Bash access and **has reverted committed code in past fixture-authoring sessions**. Do not run this fixture from the live development repo — clone or worktree to a separate path first:
+   ```bash
+   git worktree add ../auto-claude-skills-evals fix/serena-telemetry-followups
+   cd ../auto-claude-skills-evals
+   BEHAVIORAL_EVALS=1 SKILL_PATH=tests/fixtures/serena/skill-stub.md \
+       bash tests/run-behavioral-evals.sh \
+       --pack tests/fixtures/serena/behavioral.json \
+       --scenario subagent-propagation \
+       --variance 5
+   # When done:
+   cd -; git worktree remove ../auto-claude-skills-evals
+   ```
+   The runner-level fix to add `--disallowedTools "Edit Write Bash"` is tracked separately; until it lands, sandbox via worktree.
+
+2. **`serena=true` must be true in the registry that the inner `claude -p` sees.** If the inner Claude session does not have Serena MCP installed and registered, the SessionStart banner will not include the Serena propagation line and the assertion will fail for the wrong reason. Verify Serena availability in the eval workspace before interpreting failures.
+
+## Interpreting results
+
+| Variance result | Interpretation |
+|---|---|
+| All 3 assertions `stable` | Subagent propagation works as designed. |
+| Assertion 1 (`task\|explore\|subagent\|spawn`) flaky/broken | Claude is not interpreting the prompt as a Task-spawn request. Reword the user prompt; the test is not measuring propagation yet. |
+| Assertion 2 (Serena reference) `flaky` | Propagation works some of the time. Treat as weak signal — banner instruction is not load-bearing on its own. |
+| Assertion 2 `broken` | Propagation is failing in practice. The 14-day revival evaluation should not assume subagent inheritance via banner; weight in-band Grep-nudge coverage instead. |
+| Assertion 3 (user task carried) flaky/broken | Spawn prompts are too generic. Independent of propagation but worth investigating. |
+
+Fixture is intentionally narrow — one scenario, one mechanism. Routing-correctness ("does Claude actually use Serena when nudged?") is left to telemetry rather than synthetic evals; see `scripts/serena-telemetry-report.sh`.

--- a/tests/fixtures/serena/behavioral.json
+++ b/tests/fixtures/serena/behavioral.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": "subagent-propagation",
+    "prompt": "I need to find every reference to UserService in this repo's src/ directory. Use the Task tool to spawn an Explore subagent to do this. Before invoking Task, print the full text of the prompt you plan to send to the subagent so I can review it. Format the printed prompt with a clearly delimited block (e.g. fenced code, or 'SPAWN PROMPT:' / 'END SPAWN PROMPT' markers). Then invoke Task.",
+    "expected_behavior": "When serena=true (registry capability), the SessionStart Serena banner instructs the parent to propagate Serena guidance into Task spawn prompts. The model's printed spawn prompt MUST mention Serena and find_symbol (or an equivalent paraphrase such as 'find_referencing_symbols' or 'prefer find_symbol over Grep'), AND MUST carry the user's symbol-search task (UserService / references) into the subagent. If the spawn prompt omits Serena guidance, the propagation strategy is failing in practice and the parked Read/Glob matchers' revival evaluation should not assume subagent inheritance works.",
+    "assertions": [
+      {
+        "text": "task|explore|subagent|spawn",
+        "description": "Mentions spawning a subagent or using the Task tool"
+      },
+      {
+        "text": "serena|find_symbol|find_referencing_symbols",
+        "description": "Spawn prompt contains a Serena reference (literal banner copy, find_symbol, or find_referencing_symbols paraphrase)"
+      },
+      {
+        "text": "userservice|references|symbol",
+        "description": "Spawn prompt carries the user's symbol-search task into the subagent"
+      }
+    ]
+  }
+]

--- a/tests/fixtures/serena/skill-stub.md
+++ b/tests/fixtures/serena/skill-stub.md
@@ -1,0 +1,10 @@
+# Routing-test stub
+
+Minimal placeholder used as `SKILL_PATH` for Serena routing/propagation evals.
+Behavioral-eval runner injects this into a `<skill_guidance>` wrapper around the
+user request. We pass a near-empty stub here because the test is about
+hook-driven routing, not skill-content compliance — we do not want
+incident-analysis or another rich skill steering Claude into an unrelated
+workflow during the eval.
+
+When given a request, use the most appropriate tools available to answer it.

--- a/tests/test-serena-behavioral-pack.sh
+++ b/tests/test-serena-behavioral-pack.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# test-serena-behavioral-pack.sh — Hermetic schema + structure validation for
+# the Serena routing behavioral pack at tests/fixtures/serena/behavioral.json.
+# Does NOT invoke claude — that path is opt-in via BEHAVIORAL_EVALS=1.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PACK="${PROJECT_ROOT}/tests/fixtures/serena/behavioral.json"
+STUB="${PROJECT_ROOT}/tests/fixtures/serena/skill-stub.md"
+README="${PROJECT_ROOT}/tests/fixtures/serena/README.md"
+
+# shellcheck source=tests/test-helpers.sh
+source "${SCRIPT_DIR}/test-helpers.sh"
+
+setup_test_env
+
+assert_file_exists "behavioral pack file exists" "${PACK}"
+assert_file_exists "skill stub file exists" "${STUB}"
+assert_file_exists "README documenting how to run exists" "${README}"
+
+assert_json_valid "pack is valid JSON" "${PACK}"
+
+# Pack must be a non-empty array.
+PACK_KIND="$(jq -r 'type' "${PACK}" 2>/dev/null)"
+assert_equals "pack root is an array" "array" "${PACK_KIND}"
+PACK_LEN="$(jq -r 'length' "${PACK}" 2>/dev/null)"
+[ "${PACK_LEN}" -ge 1 ] && _record_pass "pack has at least one scenario" \
+    || _record_fail "pack has at least one scenario" "got length ${PACK_LEN}"
+
+# Subagent-propagation scenario must exist by id.
+SCENARIO="$(jq '.[] | select(.id == "subagent-propagation")' "${PACK}" 2>/dev/null)"
+assert_not_empty "subagent-propagation scenario is present" "${SCENARIO}"
+
+# Required fields per the runner's schema (tests/run-behavioral-evals.sh:124).
+for field in id prompt expected_behavior assertions; do
+    has="$(printf '%s' "${SCENARIO}" | jq -e --arg f "${field}" 'has($f)' 2>/dev/null)"
+    assert_equals "scenario has required field '${field}'" "true" "${has}"
+done
+
+# Each assertion must have text and description.
+ASSERTION_COUNT="$(printf '%s' "${SCENARIO}" | jq '.assertions | length')"
+[ "${ASSERTION_COUNT}" -ge 1 ] && _record_pass "scenario has at least one assertion" \
+    || _record_fail "scenario has at least one assertion" "got ${ASSERTION_COUNT}"
+
+i=0
+while [ "${i}" -lt "${ASSERTION_COUNT}" ]; do
+    text="$(printf '%s' "${SCENARIO}" | jq -r ".assertions[${i}].text // empty")"
+    desc="$(printf '%s' "${SCENARIO}" | jq -r ".assertions[${i}].description // empty")"
+    assert_not_empty "assertion ${i} has 'text'" "${text}"
+    assert_not_empty "assertion ${i} has 'description'" "${desc}"
+    i=$((i + 1))
+done
+
+# Spot-check the assertion regexes are valid extended regex (case-insensitive).
+# A bad regex would silently fail at runtime; catch it now.
+i=0
+while [ "${i}" -lt "${ASSERTION_COUNT}" ]; do
+    text="$(printf '%s' "${SCENARIO}" | jq -r ".assertions[${i}].text")"
+    if printf 'sentinel test string' | grep -Eiq -- "${text}" 2>/dev/null; then
+        _record_pass "assertion ${i} regex compiles"
+    elif printf '' | grep -Eiq -- "${text}" 2>/dev/null; then
+        _record_pass "assertion ${i} regex compiles (no match on sentinel — fine)"
+    else
+        # Regex compiles only if grep doesn't error. Run grep once with the
+        # pattern; non-zero from a bad pattern is exit 2, not 1.
+        printf '' | grep -Ei -- "${text}" >/dev/null 2>&1
+        rc=$?
+        if [ "${rc}" -le 1 ]; then
+            _record_pass "assertion ${i} regex compiles"
+        else
+            _record_fail "assertion ${i} regex compiles" "grep returned exit ${rc} for pattern: ${text}"
+        fi
+    fi
+    i=$((i + 1))
+done
+
+# Skill stub should be intentionally short. The test guards against accidental
+# bloat that would steer claude into a real skill workflow.
+STUB_WORDS="$(wc -w <"${STUB}" | tr -d ' ')"
+[ "${STUB_WORDS}" -lt 200 ] && _record_pass "skill stub is concise (<200 words)" \
+    || _record_fail "skill stub is concise" "stub has ${STUB_WORDS} words; intentionally near-empty"
+
+# README must mention the worktree-sandboxing safety advice and variance mode —
+# both are load-bearing for honest interpretation of results.
+assert_contains "README warns about worktree sandboxing" "worktree" "$(cat "${README}")"
+assert_contains "README recommends --variance" "variance" "$(cat "${README}")"
+assert_contains "README warns about Edit/Write tool revert risk" "revert" "$(cat "${README}")"
+
+teardown_test_env
+
+if [ "${TESTS_FAILED}" -gt 0 ]; then
+    printf "\nFAILED: %d / %d\n" "${TESTS_FAILED}" "${TESTS_RUN}"
+    exit 1
+fi
+printf "\nPASSED: %d / %d\n" "${TESTS_PASSED}" "${TESTS_RUN}"
+exit 0


### PR DESCRIPTION
## Summary

Adds one opt-in behavioral-eval scenario that tests whether the parent's SessionStart Serena banner instruction actually causes Claude to propagate Serena guidance into Task spawn prompts. This is the most untested claim in PR #25's subagent strategy — bash hermetic tests cover banner content, but nothing covers whether Claude follows the instruction.

The fixture asks Claude to print its planned spawn prompt before invoking Task, then asserts:
1. Claude actually planned a Task spawn,
2. The spawn prompt contains a Serena reference (`find_symbol` / `find_referencing_symbols` / banner copy paraphrase),
3. The user's symbol-search task is carried into the subagent.

If assertion #2 fails repeatedly across variance runs, the propagation strategy is failing in practice — high-signal input for the 14-day revival evaluation, since the parked Read/Glob matchers' "subagent inheritance via banner" assumption would be wishful thinking.

## What this is NOT

Routing correctness ("does Claude actually reach for Serena when given a symbol-lookup task?") is **not** tested here. The behavioral-eval runner only inspects `claude -p`'s text output (`.result` field), not tool-call sequences — text-based assertions on routing would produce noisy false negatives. Telemetry (`scripts/serena-telemetry-report.sh`) measures the same question with real-world data and is already wired up for the 14-day kill-criterion check.

## Files

- `tests/fixtures/serena/behavioral.json` — single scenario (`subagent-propagation`).
- `tests/fixtures/serena/skill-stub.md` — neutral `SKILL_PATH` override; the runner's default (incident-analysis SKILL.md) would steer Claude into an unrelated workflow.
- `tests/fixtures/serena/README.md` — how to run, variance recommendation, worktree-sandboxing safety, result-interpretation table.
- `tests/test-serena-behavioral-pack.sh` — hermetic schema/regex validation (NOT a live `claude -p` run).

## Safety caveats (documented in fixture README)

Two known runner caveats from project memory:

1. The runner does not pass `--disallowedTools` to the inner `claude -p`. The inner process has full Edit/Write/Bash access and **has reverted committed code in past fixture-authoring sessions**. README instructs users to run from a separate worktree, not the live development repo. Runner-level fix tracked separately.

2. Single-run results are noisy. README requires `--variance 5` minimum and includes an interpretation table for stable / flaky / broken assertion classifications.

Pack is opt-in via `BEHAVIORAL_EVALS=1` — not in the default `tests/run-tests.sh` path.

## Test plan

- [x] `bash tests/test-serena-behavioral-pack.sh` — 25/25 pass (hermetic, no claude invocation)
- [x] `bash tests/run-tests.sh` — 44/44 files pass (one new file: test-serena-behavioral-pack.sh)
- [ ] Manual variance run from a worktree post-merge to baseline subagent-propagation behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)