### PR TITLE
fix: only show setup hint when both SAST binaries are missing

### DIFF
--- a/hooks/session-start-hook.sh
+++ b/hooks/session-start-hook.sh
@@ -1141,7 +1141,7 @@ ${_OPENSPEC_LINE}"
 fi
 
 # Append security scanner capabilities (with setup hint if any are missing).
-# Treat semgrep and opengrep as a single SAST alternative — only hint when neither is installed.
+# Hint if no SAST (semgrep+opengrep interchangeable) or if trivy/gitleaks is missing.
 _SEC_HINT=""
 if [ "${_SEMGREP}" = "false" ] && [ "${_OPENGREP}" = "false" ]; then
     _SEC_HINT=" — run /setup to install missing tools"

--- a/hooks/session-start-hook.sh
+++ b/hooks/session-start-hook.sh
@@ -1140,11 +1140,14 @@ if [ -n "${_OPENSPEC_LINE}" ]; then
 ${_OPENSPEC_LINE}"
 fi
 
-# Append security scanner capabilities (with setup hint if any are missing)
+# Append security scanner capabilities (with setup hint if any are missing).
+# Treat semgrep and opengrep as a single SAST alternative — only hint when neither is installed.
 _SEC_HINT=""
-case "${SECURITY_CAPS}" in
-    *"=false"*) _SEC_HINT=" — run /setup to install missing tools" ;;
-esac
+if [ "${_SEMGREP}" = "false" ] && [ "${_OPENGREP}" = "false" ]; then
+    _SEC_HINT=" — run /setup to install missing tools"
+elif [ "${_TRIVY}" = "false" ] || [ "${_GITLEAKS}" = "false" ]; then
+    _SEC_HINT=" — run /setup to install missing tools"
+fi
 CONTEXT="${CONTEXT}
 Security tools: ${SECURITY_CAPS}${_SEC_HINT}"
 _OBS_HINT=""


### PR DESCRIPTION
## Summary

Follow-up to PR #31 (opengrep adoption). The session-start hint "run /setup to install missing tools" previously fired on any `=false` substring in `SECURITY_CAPS`. After PR #31 added opengrep detection, opengrep-only installs (or semgrep-only installs) saw the hint even though SAST was fully operational — the other binary's `=false` matched.

Fix: treat semgrep and opengrep as mutually exclusive SAST alternatives. Only emit the SAST portion of the hint when neither is installed. Trivy/gitleaks checks unchanged.

## Why this didn't make PR #31

The hint-logic regression was flagged in PR #31's re-review as a non-blocking recommendation. The fix was authored as commit `191598f` on the feature branch, but PR #31 auto-merged at `cae962c` before that commit was pushed. This PR carries the orphaned fix forward as a small, focused follow-up.

## Validation
- `bash tests/run-tests.sh` → 44/44 files pass
- `bash -n hooks/session-start-hook.sh` clean

## Test plan
- [ ] CI green on this branch
- [ ] Reviewer confirms opengrep-only installs no longer see the spurious hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)