### PR TITLE
fix: macOS shasum fallback + locale-robust grep for Serena hooks

### DIFF
--- a/hooks/serena-followthrough.sh
+++ b/hooks/serena-followthrough.sh
@@ -30,14 +30,19 @@ _TELEM="${HOME}/.claude/.serena-nudge-telemetry"
 [ -f "${_TELEM}" ] || exit 0
 
 # Hash CLAUDE_SESSION_TOKEN to a 12-char hex prefix for telemetry. Raw token
-# stays in env; only the hash is persisted. Fail-open: if sha256sum is
-# unavailable, fall back to the raw token.
+# stays in env; only the hash is persisted. Fail-open: if neither sha256sum
+# (Linux) nor shasum (macOS default) is available, fall back to the raw token.
 _TOKEN_RAW="${CLAUDE_SESSION_TOKEN:-unknown}"
-if [ "${_TOKEN_RAW}" = "unknown" ] || ! command -v sha256sum >/dev/null 2>&1; then
+if [ "${_TOKEN_RAW}" = "unknown" ]; then
     _TOKEN="${_TOKEN_RAW}"
-else
+elif command -v sha256sum >/dev/null 2>&1; then
     _TOKEN="$(printf '%s' "${_TOKEN_RAW}" | sha256sum 2>/dev/null | cut -c1-12)"
     [ -n "${_TOKEN}" ] || _TOKEN="${_TOKEN_RAW}"
+elif command -v shasum >/dev/null 2>&1; then
+    _TOKEN="$(printf '%s' "${_TOKEN_RAW}" | shasum -a 256 2>/dev/null | cut -c1-12)"
+    [ -n "${_TOKEN}" ] || _TOKEN="${_TOKEN_RAW}"
+else
+    _TOKEN="${_TOKEN_RAW}"
 fi
 _TURN="${CLAUDE_TURN_ID:-0}"
 _TS="$(date +%s 2>/dev/null || echo 0)"

--- a/hooks/serena-nudge.sh
+++ b/hooks/serena-nudge.sh
@@ -105,14 +105,19 @@ if [ "${SERENA_TELEMETRY:-1}" != "0" ]; then
     _TELEM="${HOME}/.claude/.serena-nudge-telemetry"
     _TS="$(date +%s 2>/dev/null || echo 0)"
     # Hash CLAUDE_SESSION_TOKEN to a 12-char hex prefix for telemetry. Raw token
-    # stays in env; only the hash is persisted. Fail-open: if sha256sum is
-    # unavailable, fall back to the raw token.
+    # stays in env; only the hash is persisted. Fail-open: if neither sha256sum
+    # (Linux) nor shasum (macOS default) is available, fall back to the raw token.
     _TOKEN_RAW="${CLAUDE_SESSION_TOKEN:-unknown}"
-    if [ "${_TOKEN_RAW}" = "unknown" ] || ! command -v sha256sum >/dev/null 2>&1; then
+    if [ "${_TOKEN_RAW}" = "unknown" ]; then
         _TOKEN="${_TOKEN_RAW}"
-    else
+    elif command -v sha256sum >/dev/null 2>&1; then
         _TOKEN="$(printf '%s' "${_TOKEN_RAW}" | sha256sum 2>/dev/null | cut -c1-12)"
         [ -n "${_TOKEN}" ] || _TOKEN="${_TOKEN_RAW}"
+    elif command -v shasum >/dev/null 2>&1; then
+        _TOKEN="$(printf '%s' "${_TOKEN_RAW}" | shasum -a 256 2>/dev/null | cut -c1-12)"
+        [ -n "${_TOKEN}" ] || _TOKEN="${_TOKEN_RAW}"
+    else
+        _TOKEN="${_TOKEN_RAW}"
     fi
     _TURN="${CLAUDE_TURN_ID:-0}"
     printf '%s\t%s\t%s\tnudge\t%s\tgrep_extension\n' "${_TS}" "${_TOKEN}" "${_TURN}" "${_CLASS}" >>"${_TELEM}" 2>/dev/null || true

--- a/hooks/serena-observer.sh
+++ b/hooks/serena-observer.sh
@@ -31,14 +31,19 @@ _SERENA="$(jq -r '.context_capabilities.serena // false' "${_CACHE}" 2>/dev/null
 _TELEM="${HOME}/.claude/.serena-nudge-telemetry"
 _TS="$(date +%s 2>/dev/null || echo 0)"
 # Hash CLAUDE_SESSION_TOKEN to a 12-char hex prefix for telemetry. Raw token
-# stays in env; only the hash is persisted. Fail-open: if sha256sum is
-# unavailable, fall back to the raw token.
+# stays in env; only the hash is persisted. Fail-open: if neither sha256sum
+# (Linux) nor shasum (macOS default) is available, fall back to the raw token.
 _TOKEN_RAW="${CLAUDE_SESSION_TOKEN:-unknown}"
-if [ "${_TOKEN_RAW}" = "unknown" ] || ! command -v sha256sum >/dev/null 2>&1; then
+if [ "${_TOKEN_RAW}" = "unknown" ]; then
     _TOKEN="${_TOKEN_RAW}"
-else
+elif command -v sha256sum >/dev/null 2>&1; then
     _TOKEN="$(printf '%s' "${_TOKEN_RAW}" | sha256sum 2>/dev/null | cut -c1-12)"
     [ -n "${_TOKEN}" ] || _TOKEN="${_TOKEN_RAW}"
+elif command -v shasum >/dev/null 2>&1; then
+    _TOKEN="$(printf '%s' "${_TOKEN_RAW}" | shasum -a 256 2>/dev/null | cut -c1-12)"
+    [ -n "${_TOKEN}" ] || _TOKEN="${_TOKEN_RAW}"
+else
+    _TOKEN="${_TOKEN_RAW}"
 fi
 _TURN="${CLAUDE_TURN_ID:-0}"
 

--- a/hooks/session-start-hook.sh
+++ b/hooks/session-start-hook.sh
@@ -806,7 +806,10 @@ fi
 # (off by default — registration remains the routing gate). Fail-open: any
 # error leaves serena_connected=false.
 if [ "${SERENA_CONNECTION_CHECK:-0}" = "1" ] && command -v claude >/dev/null 2>&1; then
-    if claude mcp list 2>/dev/null | grep -qE '^serena: .*✓ Connected'; then
+    # Use grep -F for the literal Unicode ✓ to avoid locale-collation issues
+    # under C/POSIX locale (where multi-byte regex matching may silently fail).
+    # Filter to the serena entry first via a literal grep, then check the marker.
+    if claude mcp list 2>/dev/null | grep '^serena: ' | grep -qF '✓ Connected'; then
         CONTEXT_CAPS="$(printf '%s' "${CONTEXT_CAPS}" | jq '.serena_connected = true' 2>/dev/null || printf '%s' "${CONTEXT_CAPS}")"
     fi
 fi


### PR DESCRIPTION
## Summary

Follow-up to PR #35. The Claude Plugin Review bot flagged two non-blocking Important recommendations on PR #35 that landed AFTER the merge; recovering them here as a small focused PR.

## Why now

These two recommendations from PR #35's bot review weren't applied before the merge:

1. **macOS \`sha256sum\` absence.** Stock macOS ships \`shasum\` (not \`sha256sum\`); \`sha256sum\` requires Homebrew \`coreutils\`. PR #35's single-tool guard fell back to writing raw \`CLAUDE_SESSION_TOKEN\` on the dominant user platform, silently negating the privacy improvement of Task 8. This PR adds a two-step chain: \`sha256sum\` (Linux) → \`shasum -a 256\` (macOS) → raw token (fail-open).
2. **Unicode \`✓\` in grep pattern.** Under C/POSIX locale, multi-byte regex matching may silently fail to match the literal Unicode CHECK MARK. This PR splits the grep into two stages: first filter by \`^serena: \` (ASCII regex), then check the marker with \`grep -F\` (fixed-string, bypasses locale regex collation). Matches the CLAUDE.md guidance on literal-string matching in runtime-output parsers.

Both fixes were authored as commit \`93e9a4a\` on the PR #35 feature branch, but PR #35 was merged at SHA \`4d8a45d\` before that commit was pulled in. This PR carries the orphaned fix forward.

## Changes

- \`hooks/serena-{nudge,observer,followthrough}.sh\` — \`sha256sum\` → \`shasum -a 256\` → raw fallback chain. Identical logic across all three hooks (telemetry correlation stays consistent within a session).
- \`hooks/session-start-hook.sh\` — \`grep '^serena: ' | grep -qF '✓ Connected'\` replaces the single-pass \`grep -qE '^serena: .*✓ Connected'\`.

## Validation

- \`bash tests/run-tests.sh\` → **46/46 files pass**
- Manual sanity check on macOS: \`printf 'abc' | shasum -a 256 | cut -c1-12\` returns the same 12-char hex as Linux's \`sha256sum\`.

## Test plan

- [ ] CI green
- [ ] Reviewer confirms shasum fallback chain on a stock macOS system (no Homebrew coreutils)

🤖 Generated with [Claude Code](https://claude.com/claude-code)