### PR TITLE
docs: addy-adoption design + openspec change (DESIGN only)

### DIFF
--- a/docs/plans/2026-06-25-addy-adoption-design.md
+++ b/docs/plans/2026-06-25-addy-adoption-design.md
@@ -1,0 +1,80 @@
+# Addy agent-skills adoption — design & ranked portfolio
+
+**Date:** 2026-06-25
+**Status:** DESIGN persisted; awaiting build go/no-go
+**Source:** Re-evaluation of `addyosmani/agent-skills` @ `e0d2e43` (2026-06-23 state; 24 skills + 4 agents + references + hooks)
+**Prior pass:** PR #50 `adopt-doubt-discipline` (2026-06-11) — see `[[doubt-discipline-adoption]]`
+**Method:** phase-by-phase coverage matrix (4 parallel subagents) → Codex file-grounded validation (×2) → design-debate (architect / critic / pragmatist + Codex 4th voice)
+
+## Problem statement
+
+`addyosmani/agent-skills` is a 52k-star, MIT, prompt-text SDLC skill pack. We mined it once (PR #50). It has since reorganized into a clean DEFINE→…→SHIP lifecycle. Question: what *genuinely new* value can auto-claude-skills adopt, given our differentiator is a **regex routing engine + composition chain + hook-injected phase directives that wrap dependency skills and pass context skill→skill** — and that "their PDLC ⊂ ours" was re-confirmed at full breadth.
+
+## Key framing — three capture mechanisms
+
+We don't *own* superpowers skills (brainstorming, TDD, code-review, systematic-debugging, …) but we **own the orchestration**: when/why each skill fires and what context it hands the next. So three mechanisms exist for capturing an external mechanic:
+
+1. **Graft prompt-text into an OWNED skill** — for mechanics that fit one of our 21 skills.
+2. **Depend on addy's plugin** — **REJECTED**: `using-agent-skills` is a competing router (linear decision-tree + fixed 16-step lifecycle that contradicts our phase model); ~18/24 skills duplicate ours/superpowers and would collide with role-caps; the repo fully restructured in 12 days (version-drift risk on code we don't control); plugin-gated routing entries are dead unless the plugin is installed. Users who want addy's standalone skills (frontend-ui, performance) can **co-install** both plugins — they coexist, our routing ignores theirs, the model can still invoke them manually. No coupling, nothing required from us.
+3. **Hook-injected phase DIRECTIVE + inter-skill context contract** — wraps a dependency skill we can't edit AND threads context skill→skill. This is the unique-to-us mechanism (e.g. today's `DESIGN→PLAN CONTRACT`, `TRIFECTA CHECK`, `PERSIST DESIGN`, `EVAL STRATEGY` injected directives). The deepest value-add the exploration found: **context-handoff contracts between skills** (intent→brainstorming, scope-manifest IMPLEMENT→REVIEW, citations→REVIEW-verifies).
+
+## Capabilities affected
+
+- **`skill-routing`** (primary, MODIFIED via ADDED requirements) — new phase directives + inter-skill context handoffs + routing entries for any new skills.
+- **`unified-context-stack`** (content enrichment) — CITE/UNVERIFIED + inline-planning/confusion nuggets in External Truth consumption guidance.
+- **`security-scanner`** (content enrichment) — STRIDE threat-model-first pre-pass.
+- **`deploy-gate`** skill (content enrichment; no capability spec today) — staged-rollout/rollback thresholds.
+- **`batch-scripting`** skill (content enrichment) — Rule-of-500 cross-link.
+
+## Explicit out-of-scope
+
+- Taking addy's plugin as a hard dependency or routing at its skill names (mechanism 2, rejected).
+- T3a observability **composition** wiring (deploy-gate/incident-analysis) — deferred behind a revival trigger.
+- T3c api-and-interface-design until reframed for Kotlin/Spring.
+- All confirmed skips (below).
+- No implementation in this DESIGN artifact — build is a separate go decision.
+
+## Ranked portfolio (debate verdict)
+
+### DO NOW — PR 1 (grafts: owned SKILL.md prose, no routing/eval risk)
+1. **T2a** deploy-gate staged-rollout/rollback thresholds (canary %, error/latency triggers). *Also the consumer contract T3a later produces against.*
+2. **T2b** security-scanner STRIDE threat-model-first (compact checklist; composes with shipped TRIFECTA directive).
+3. **T2e** batch-scripting Rule-of-500 cross-link.
+4. **T2c + T2d** unified-context-stack CITE/UNVERIFIED + inline-planning/confusion nuggets (collapses T1c & T1e; placed in External Truth *consumption* guidance per Codex dissent).
+
+### DO NEXT — PR 2 (directives, each EVAL-GATED)
+5. **T1a** intent-extraction pre-brainstorming directive → writes `confirmed-intent` to session state → brainstorming reads it. Reuses PERSIST-DESIGN→PLAN-guard plumbing. Hard-gated: fires only when ask is underspecified AND no approved brief. Ships only after a red-first quality eval. Clears the standing PR #50 revival trigger for interview-me mechanics.
+6. **T1b** scope-manifest IMPLEMENT→REVIEW contract, consumed by agent-team-review / implementation-drift-check. Probationary, hard phase-gated, eval-gated.
+
+### DO LATER — new skills, standalone-first
+7. **T3a** thin observability/instrumentation skill, routes on BUILD/SHIP, absorbs T1d's multi-component mechanic. **Composition deferred** behind revival trigger (manual telemetry→deploy-gate handoff hit ≥2×). T2a ships the consumer contract so it exists when/if wired.
+8. **T3b** deprecation-and-migration skill — bounded, episodic, no composition.
+9. **T3c** api-and-interface-design skill — after T3b; needs Kotlin/Spring reframe.
+
+### SKIP / fold
+T1c, T1e, T1d standalone (collapsed/folded above); using-agent-skills (competing router); performance-optimization (frontend-heavy; backend latency covered by incident loop); ci-cd scaffolding (low freq); ADR-lifecycle (openspec covers traceability); frontend AI-aesthetic (belongs to frontend-design plugin).
+
+## Recommended approach
+
+Sequence by ROI: **PR1 first** (four paragraph-inserts, zero routing/eval risk, resolves both overlaps by claiming the SKILL.md home), then **PR2** (two directives behind red-first evals), then the new skills standalone-first. Each PR is independently shippable through the normal composition chain.
+
+## Dissenting views (recorded)
+
+- **Codex:** T1c/T1e belong as *directives*, not grafts — citation/inline-planning is execution behavior, and grafting it into a retrieval-tier skill violates that tier's boundary ("don't make the context stack a behavior dumping ground"). *Overridden on cost + low item-value; mitigated by placing the nuggets in External Truth consumption guidance rather than a generic behavior dump.*
+- **Critic:** T1a should be cut outright — duplicates brainstorming + product-discovery, risks double-interview, has no eval. *Overridden by gating T1a behind the red-first eval the Critic itself named as the only honest path to adoption.*
+- **Codex ranked T1b #1** (highest leverage). *Placed in PR2 behind T1a because T1a sits earlier in the chain and clears a standing trigger.*
+- **Architect:** rank by edges created, not capabilities added — hence T2a (the consumer contract) outranks the entire T3a observability skill. *Adopted as the sequencing rule.*
+
+## Trade-offs accepted
+
+- **Token/crowding cost** of new directives (PR2): mitigated by hard phase-gating + tight triggers; bounded to two new directives, both eval-gated. Honors the lean-injection rejection (PR #45) "no measured benefit" bar.
+- **Deferring T3a composition** may be wrong if the telemetry→deploy-gate handoff is the real point — accepted as an explicit revival criterion, not a silent drop.
+- **STRIDE graft** risks bloating security-scanner (already ~1600w) — kept to a compact checklist.
+
+## Acceptance scenarios
+
+See `openspec/changes/adopt-addy-mechanics/specs/skill-routing/spec.md`.
+
+## Decision
+
+Awaiting user go/no-go on PR1. No build started.

--- a/openspec/changes/adopt-addy-mechanics/design.md
+++ b/openspec/changes/adopt-addy-mechanics/design.md
@@ -1,0 +1,47 @@
+# Design — adopt addy agent-skills mechanics
+
+Full ranked portfolio and method in `docs/plans/2026-06-25-addy-adoption-design.md`.
+This file captures the architecture, dissents, and decisions from the design debate
+(architect / critic / pragmatist + Codex 4th voice, file-grounded).
+
+## Architecture
+
+Three capture mechanisms for an external mechanic:
+1. **Graft into an owned skill** (PR1 items) — prose in a SKILL.md we own; zero routing/token cost.
+2. **Depend on addy's plugin** — REJECTED (competing router, overlap, version drift).
+3. **Hook-injected phase directive + inter-skill context contract** (PR2 items) — the
+   unique-to-us mechanism. A `methodology_hints[]` entry, hard phase-gated, that wraps a
+   dependency skill we cannot edit and threads context to the next skill via session state.
+
+Sequencing rule (architect): **rank by edges created, not capabilities added.** The
+deploy-gate threshold graft (T2a) is the *consumer contract* that the deferred observability
+skill (T3a) must later produce against — so the contract ships before the producer.
+
+## Trade-offs
+
+- New directives cost UserPromptSubmit tokens and crowd the existing hint block. Mitigated
+  by hard phase-gating + tight triggers + capping PR2 to two directives, both eval-gated.
+  Honors the PR #45 lean-injection rejection ("no measured benefit" bar).
+- Deferring T3a composition risks under-delivering if the telemetry→deploy-gate handoff is
+  the real point. Accepted as an explicit revival criterion, not a silent drop.
+- STRIDE graft risks bloating security-scanner — kept to a compact checklist.
+
+## Dissenting views
+
+- **Codex:** T1c/T1e (citation, inline-planning) should be *directives*, not grafts —
+  they are execution behavior, and grafting them into a retrieval-tier skill violates that
+  tier's boundary. **Decision:** graft anyway (cost + low item-value) but place them in
+  External Truth *consumption* guidance, not a generic behavior dump, to respect the boundary.
+- **Critic:** cut T1a (intent-extraction) outright — duplicates brainstorming +
+  product-discovery, risks double-interview, has no eval. **Decision:** keep, but ship only
+  behind a red-first quality eval — the path the Critic named as the only honest one — and
+  hard-gate it to fire solely when the ask is underspecified AND no approved brief exists.
+- **Codex ranked T1b #1**; placed in PR2 behind T1a (earlier in chain, clears a standing trigger).
+
+## Decisions & rejected alternatives
+
+- **Rejected:** addy plugin as a dependency / routing at its skill names (mechanism 2).
+- **Rejected:** T1c, T1d, T1e as standalone directives (collapsed into grafts / folded into T3a).
+- **Rejected now, revivable:** T3a composition wiring; T3b; T3c (reframe-gated).
+- **Confirmed skip:** using-agent-skills, performance-optimization, ci-cd scaffolding,
+  ADR-lifecycle, frontend AI-aesthetic.

--- a/openspec/changes/adopt-addy-mechanics/proposal.md
+++ b/openspec/changes/adopt-addy-mechanics/proposal.md
@@ -1,0 +1,57 @@
+# Adopt addy agent-skills mechanics into the auto-claude-skills PDLC
+
+## Why
+
+A re-evaluation of `addyosmani/agent-skills` (@ `e0d2e43`, 2026-06-23) against our
+full stack re-confirmed "their PDLC ⊂ ours" at full breadth. The value is not new
+capabilities but a handful of specific mechanics, best captured through the one
+mechanism no competitor's flat skill list has: **hook-injected phase directives +
+inter-skill context contracts** that wrap dependency skills (superpowers) we cannot
+edit and pass context skill→skill. Full debate and dissents in
+`docs/plans/2026-06-25-addy-adoption-design.md`.
+
+Taking addy's plugin as a hard dependency is rejected (`using-agent-skills` is a
+competing router; ~18/24 skills duplicate ours; 12-day restructure = version-drift
+risk). Co-installation remains available to users who want addy's standalone skills.
+
+## What Changes
+
+A ranked, sequenced adoption. In scope for this change:
+
+**PR 1 — content grafts (owned SKILL.md prose; no routing/eval risk):**
+- deploy-gate gains staged-rollout/rollback thresholds (canary %, error/latency triggers).
+- security-scanner gains a STRIDE threat-model-first pre-pass.
+- batch-scripting gains a Rule-of-500 cross-link.
+- unified-context-stack External Truth gains CITE/UNVERIFIED + inline-planning/confusion nuggets.
+
+**PR 2 — phase directives (each eval-gated, hard phase-gated):**
+- Intent-extraction pre-brainstorming directive writing `confirmed-intent` to session state for brainstorming to consume.
+- Scope-manifest IMPLEMENT→REVIEW context contract consumed by agent-team-review / implementation-drift-check.
+
+## Capabilities
+
+### Modified
+- **skill-routing** — adds two phase directives and two inter-skill context handoffs (intent→brainstorming, scope-manifest IMPLEMENT→REVIEW); will add routing entries when DO-LATER skills land.
+
+### Content-enriched (no observable contract change to their capability specs)
+- **unified-context-stack** — External Truth consumption guidance (citation/planning nuggets).
+- **security-scanner** — design-time STRIDE pre-pass.
+- deploy-gate skill, batch-scripting skill — prose grafts (no capability spec today).
+
+## Impact
+
+- `config/default-triggers.json` + `config/fallback-registry.json` (PR2 directive entries, mirrored).
+- `hooks/skill-activation-hook.sh` reuses the existing `methodology_hints[]` walker — no hook code change expected; PR2 adds entries + `phases[]` gating.
+- `tests/test-routing.sh` (PR2 directive fixtures).
+- Skill prose: `skills/deploy-gate`, `skills/security-scanner`, `skills/batch-scripting`, `skills/unified-context-stack` (PR1).
+- Session state: a new `confirmed-intent` field (PR2, reusing PERSIST-DESIGN plumbing).
+
+## Deferred (out of scope, with revival triggers)
+- T3a observability skill (standalone-first; **composition** with deploy-gate/incident-analysis deferred until the manual handoff is hit ≥2×).
+- T3b deprecation-and-migration skill (episodic).
+- T3c api-and-interface-design skill (needs Kotlin/Spring reframe; gate behind T3b).
+
+## Skipped
+using-agent-skills (competing router), performance-optimization (frontend-heavy),
+ci-cd scaffolding (low freq), ADR-lifecycle (openspec covers traceability),
+frontend AI-aesthetic (frontend-design plugin), T1c/T1d/T1e standalone (collapsed/folded).

--- a/openspec/changes/adopt-addy-mechanics/specs/skill-routing/spec.md
+++ b/openspec/changes/adopt-addy-mechanics/specs/skill-routing/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Intent-extraction pre-brainstorming directive
+
+The activation hook SHALL provide a phase-gated directive that, when the DESIGN
+phase is entered with an underspecified ask and no approved discovery brief, instructs
+the model to run a one-question-at-a-time intent extraction before brainstorming and to
+persist a confirmed-intent statement that brainstorming consumes. The directive MUST be
+hard phase-gated and MUST NOT fire when an approved brief already exists or for mechanical
+asks. It MUST ship only after a red-first quality eval demonstrates a measurable intent-capture
+improvement over brainstorming alone.
+
+#### Scenario: Fires on an underspecified ask
+- **WHEN** a DESIGN-phase prompt is underspecified (missing who/why/success/constraint) and no approved brief is in session state
+- **THEN** the activation context MUST surface the intent-extraction directive instructing confidence-tracked, one-question-at-a-time extraction with an explicit "what would you actually want?" probe and an out-of-scope line
+- **AND** it MUST instruct writing a `confirmed-intent` statement to session state before brainstorming proceeds
+
+#### Scenario: Suppressed when a brief already exists
+- **WHEN** an approved discovery brief or confirmed intent is already present in session state, or the ask is mechanical (rename/typo/file move)
+- **THEN** the intent-extraction directive MUST NOT appear in the activation context
+
+#### Scenario: Brainstorming consumes confirmed intent
+- **WHEN** brainstorming activates and a `confirmed-intent` statement exists in session state
+- **THEN** the activation context MUST reference it so brainstorming builds on the confirmed intent rather than re-eliciting it
+
+### Requirement: Scope-manifest IMPLEMENT→REVIEW context contract
+
+The activation hook SHALL provide a phase-gated directive instructing the implementer to
+emit a scope manifest (files intended to change + an explicit "not touching" list) during
+IMPLEMENT, and instructing the REVIEW phase to consume that manifest for scope-creep
+detection. The directive MUST be hard-gated to the IMPLEMENT and REVIEW phases and MUST be
+advisory (it MUST NOT block the hook on absence of a manifest).
+
+#### Scenario: Implementer emits a scope manifest
+- **WHEN** the IMPLEMENT phase is active for a multi-file change
+- **THEN** the activation context MUST instruct emitting a scope manifest listing intended-change files and an explicit not-touching list
+
+#### Scenario: Review consumes the manifest for scope-creep
+- **WHEN** REVIEW activates (agent-team-review or implementation-drift-check) and a scope manifest exists
+- **THEN** the activation context MUST instruct diffing actually-changed files against the manifest and flagging out-of-scope changes
+
+#### Scenario: Degrades open when absent
+- **WHEN** no scope manifest exists at REVIEW
+- **THEN** the directive MUST degrade silently and MUST NOT block or error the hook


### PR DESCRIPTION
## Summary

Persists the **design + decision record** from a re-evaluation of [`addyosmani/agent-skills`](https://github.com/addyosmani/agent-skills) (@ `e0d2e43`, 2026-06-23) against the full auto-claude-skills stack. **Docs only — no implementation.** PR1 (content grafts) and PR2 (eval-gated directives) are scoped here but built in follow-up PRs.

Method: phase-by-phase coverage matrix (4 parallel subagents) → Codex file-grounded validation (×2) → design-debate (architect / critic / pragmatist + Codex 4th voice).

## Key framing — three capture mechanisms
We don't own the superpowers skills but we own the orchestration. So an external mechanic can be captured by:
1. **Graft** prompt-text into an owned skill.
2. **Depend** on addy's plugin — **REJECTED** (competing router, ~18/24 skills duplicate ours, 12-day restructure = drift). Co-install remains available to users.
3. **Hook-injected phase directive + inter-skill context contract** — the unique-to-us mechanism; the deepest value-add (intent→brainstorming, scope-manifest IMPLEMENT→REVIEW).

Sequencing rule (architect): **rank by edges created, not capabilities added.**

## Ranked portfolio
- **PR1 (grafts, no routing/eval risk):** deploy-gate rollout/rollback thresholds · security-scanner STRIDE pre-pass · batch-scripting Rule-of-500 link · unified-context-stack CITE/UNVERIFIED + inline-planning/confusion nuggets.
- **PR2 (directives, each eval-gated, hard phase-gated):** intent-extraction pre-brainstorming (writes confirmed-intent→brainstorming) · scope-manifest IMPLEMENT→REVIEW contract.
- **Later, standalone-first:** thin observability skill (composition deferred) · deprecation-and-migration (episodic) · api-and-interface-design (after Kotlin/Spring reframe).
- **Skip:** using-agent-skills, performance-optimization, ci-cd scaffolding, ADR-lifecycle, frontend AI-aesthetic.

Dissents recorded in `design.md` (Codex on directive-vs-graft home; Critic on cutting intent-extraction).

## Files
- `docs/plans/2026-06-25-addy-adoption-design.md` — canonical design doc
- `openspec/changes/adopt-addy-mechanics/{proposal,design}.md` + `specs/skill-routing/spec.md` (2 ADDED requirements, 6 scenarios) — **`openspec validate` passes**

## Scope / review note
Pure additive markdown (228 insertions, 0 deletions). Touches no `hooks/`, `config/`, routing, safety gates, or permissions — no code or security surface to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)