### PR TITLE
docs: addy-adoption round-3 additions (T4 + idea-refine)

### DIFF
--- a/docs/plans/2026-06-25-addy-adoption-design.md
+++ b/docs/plans/2026-06-25-addy-adoption-design.md
@@ -51,8 +51,36 @@ We don't *own* superpowers skills (brainstorming, TDD, code-review, systematic-d
 8. **T3b** deprecation-and-migration skill — bounded, episodic, no composition.
 9. **T3c** api-and-interface-design skill — after T3b; needs Kotlin/Spring reframe.
 
+### DO ALONGSIDE PR1 — PR-T4: skill-authoring anatomy standard (reshaped per Codex round 3)
+Adopt addy's consistent skill anatomy (anti-rationalization / Red Flags / Verification) where it
+bears weight. Grounded audit of our 21 owned skills (corrected; headings only, not inline mentions):
+- Anti-rationalization sections: **0/21**
+- Red Flags sections: **2/21** (agent-team-execution, agent-team-review)
+- Verification sections: **1/21** — load-bearing for our evidence-before-assertions philosophy, yet near-absent.
+
+**Scope (reshaped):** add OPTIONAL Rationalizations / Red Flags / Verification sections to the
+`skill-scaffold` emitted skeleton (Step 2), to be included where a skill bears discipline or makes a
+readiness claim — NOT blanket-mandated on tool/domain skills where they would be filler. Backfill
+**Verification** sections only on owned skills that make completion/readiness claims.
+**Explicitly excluded:** no behavioral-eval enforcement (the runner asserts output regex / tool calls,
+not section quality → would be a checkbox); no extension of `docs/skill-frontmatter-schema.md` (that is
+routing metadata, not body anatomy). Small standalone PR, low risk.
+
 ### SKIP / fold
 T1c, T1e, T1d standalone (collapsed/folded above); using-agent-skills (competing router); performance-optimization (frontend-heavy; backend latency covered by incident loop); ci-cd scaffolding (low freq); ADR-lifecycle (openspec covers traceability); frontend AI-aesthetic (belongs to frontend-design plugin).
+
+### DEFER — idea-refine divergent-lens framework (corrected per Codex round 3)
+SKIP idea-refine as a standalone skill: low-frequency for backend feature work; output (~80%) covered by
+the Out-of-Scope contract + brainstorming + prototype-lab + the new T1a intent-extraction. The one
+uncovered nugget is its **divergent-lens framework** (inversion / constraint-removal / audience-shift /
+10x / simplification / expert-lens → 5-8 variations, cluster to 2-3). The real gap is narrow: **no
+systematic divergent-lens expansion step before options exist.** (Correction: design-debate is NOT
+"purely convergent" — its architect proposes and its critic proposes alternatives; the gap is the
+absence of structured *divergent generation before any option is on the table*, not convergence.)
+**Defer** with a revival trigger: a genuinely greenfield / novel-product ideation task where
+brainstorming's 2-3-approaches visibly under-delivers. If revived, do NOT bloat the opt-in, approval-gated
+`design-debate` — prefer a separate lightweight divergent mode. Ranks below T1a (which clears a standing
+PR #50 trigger and has no equivalent).
 
 ## Recommended approach
 
@@ -64,6 +92,7 @@ Sequence by ROI: **PR1 first** (four paragraph-inserts, zero routing/eval risk, 
 - **Critic:** T1a should be cut outright — duplicates brainstorming + product-discovery, risks double-interview, has no eval. *Overridden by gating T1a behind the red-first eval the Critic itself named as the only honest path to adoption.*
 - **Codex ranked T1b #1** (highest leverage). *Placed in PR2 behind T1a because T1a sits earlier in the chain and clears a standing trigger.*
 - **Architect:** rank by edges created, not capabilities added — hence T2a (the consumer contract) outranks the entire T3a observability skill. *Adopted as the sequencing rule.*
+- **Codex (round 3) caught load-bearing audit errors** before they reached this doc: my initial anatomy counts (Red Flags 3/21, Verification 9/21) were inflated by matching inline word-mentions instead of section headings — corrected to 2/21 and 1/21. It also flagged a non-existent `behavioral-evaluation/SKILL.md` and the wrong path for the frontmatter schema, which forced T4 to be reshaped (scaffold-only, no eval enforcement, no schema extension), and corrected the false "design-debate is purely convergent" rationale for the idea-refine deferral. *Re-derive load-bearing numbers cross-model — the recurring lesson.*
 
 ## Trade-offs accepted
 

--- a/openspec/changes/adopt-addy-mechanics/design.md
+++ b/openspec/changes/adopt-addy-mechanics/design.md
@@ -38,10 +38,28 @@ skill (T3a) must later produce against — so the contract ships before the prod
   hard-gate it to fire solely when the ask is underspecified AND no approved brief exists.
 - **Codex ranked T1b #1**; placed in PR2 behind T1a (earlier in chain, clears a standing trigger).
 
+## Round 3 additions (meta-axis: anatomy, references, personas)
+
+- **PR-T4 skill-authoring anatomy standard — RESHAPED (Codex round 3).** Adopt anti-rationalization /
+  Red Flags / Verification anatomy as OPTIONAL `skill-scaffold` template sections + backfill Verification
+  on readiness-claim skills. Grounded audit (headings only): anti-rationalization 0/21, Red Flags 2/21,
+  Verification 1/21. **Excludes** behavioral-eval enforcement (the runner asserts regex/tool-calls, not
+  section quality) and any frontmatter-schema extension (`docs/skill-frontmatter-schema.md` is routing
+  metadata). Codex caught that my initial counts (3/21, 9/21) were inflated by inline-word matches.
+- **Agent personas (test-engineer, code-reviewer) — SKIP.** Covered by pr-review-toolkit + agent-team-review;
+  our structured FINDING + evidence/confidence/severity-floor contract is stronger than their freeform templates.
+- **Reference checklists — mostly captured/skip.** observability-checklist → folded into T3a; security-checklist
+  → feeds the PR1 STRIDE graft; performance/accessibility → frontend (skip/low); definition-of-done &
+  orchestration-patterns → mild, optional consolidation, LOW. The progressive-disclosure *pattern* is already
+  ours (references/ in incident-analysis, project-verification, supply-chain).
+- **idea-refine — DEFER (corrected).** Skip standalone; the uncovered nugget is systematic divergent-lens
+  expansion before options exist. The "design-debate is purely convergent" rationale was false (it has an
+  architect proposing + a critic proposing alternatives) and is removed. Revival trigger recorded in proposal.
+
 ## Decisions & rejected alternatives
 
 - **Rejected:** addy plugin as a dependency / routing at its skill names (mechanism 2).
 - **Rejected:** T1c, T1d, T1e as standalone directives (collapsed into grafts / folded into T3a).
-- **Rejected now, revivable:** T3a composition wiring; T3b; T3c (reframe-gated).
+- **Rejected now, revivable:** T3a composition wiring; T3b; T3c (reframe-gated); idea-refine divergent nugget.
 - **Confirmed skip:** using-agent-skills, performance-optimization, ci-cd scaffolding,
-  ADR-lifecycle, frontend AI-aesthetic.
+  ADR-lifecycle, frontend AI-aesthetic, addy agent personas.

--- a/openspec/changes/adopt-addy-mechanics/proposal.md
+++ b/openspec/changes/adopt-addy-mechanics/proposal.md
@@ -28,6 +28,14 @@ A ranked, sequenced adoption. In scope for this change:
 - Intent-extraction pre-brainstorming directive writing `confirmed-intent` to session state for brainstorming to consume.
 - Scope-manifest IMPLEMENT→REVIEW context contract consumed by agent-team-review / implementation-drift-check.
 
+**PR-T4 — skill-authoring anatomy standard (small, standalone, alongside PR1):**
+- Add OPTIONAL Rationalizations / Red Flags / Verification sections to the `skill-scaffold` emitted
+  skeleton, included where a skill bears discipline or makes a readiness claim (not blanket-mandated).
+- Backfill Verification sections only on owned skills that make completion/readiness claims.
+- Grounded audit (headings only): anti-rationalization 0/21, Red Flags 2/21, Verification 1/21.
+- Excludes: behavioral-eval enforcement (runner asserts regex/tool-calls, not section quality) and any
+  extension of `docs/skill-frontmatter-schema.md` (routing metadata, not body anatomy).
+
 ## Capabilities
 
 ### Modified
@@ -50,6 +58,7 @@ A ranked, sequenced adoption. In scope for this change:
 - T3a observability skill (standalone-first; **composition** with deploy-gate/incident-analysis deferred until the manual handoff is hit ≥2×).
 - T3b deprecation-and-migration skill (episodic).
 - T3c api-and-interface-design skill (needs Kotlin/Spring reframe; gate behind T3b).
+- idea-refine divergent-lens framework — skip the standalone skill (low-freq for backend; output ~80% covered by Out-of-Scope contract + brainstorming + prototype-lab + T1a). Revival trigger: a greenfield/novel ideation task where brainstorming's 2-3-approaches under-delivers. If revived, prefer a separate lightweight divergent mode, NOT a graft into the opt-in approval-gated design-debate.
 
 ## Skipped
 using-agent-skills (competing router), performance-optimization (frontend-heavy),


### PR DESCRIPTION
## Summary

Recovers the **round-3 design additions** that were orphaned by PR #70's merge timing: PR #70 squash-merged its first commit (`a39f027`) at 13:30 UTC; the round-3 commit was pushed ~20 min later onto the already-merged branch and never reached `main`. This PR re-applies that content (docs only) on top of the merged design record.

**Docs only — no implementation.** Purely additive (58 insertions across 3 files).

## What's added
- **PR-T4 — skill-authoring anatomy standard (reshaped per Codex round 3):** add OPTIONAL Rationalizations / Red Flags / Verification sections to the `skill-scaffold` template, included where a skill bears discipline or makes a readiness claim; backfill Verification on readiness-claim skills. **Excludes** behavioral-eval enforcement (the runner asserts regex/tool-calls, not section quality) and any `docs/skill-frontmatter-schema.md` extension (routing metadata). Grounded audit (headings only): anti-rationalization **0/21**, Red Flags **2/21**, Verification **1/21**.
- **idea-refine — deferred:** skip the standalone skill (low-freq for backend; output ~80% covered by Out-of-Scope contract + brainstorming + prototype-lab + T1a). Defer the divergent-lens nugget with a revival trigger. Removed the factually wrong "design-debate is purely convergent" rationale.
- **Agent personas / reference checklists** — recorded as covered/skip in `design.md`.

## Process note
Codex sparring (round 3) caught load-bearing errors before they hardened: my initial anatomy counts (Red Flags 3/21, Verification 9/21) were inflated by matching inline word-mentions instead of section headings — corrected to 2/21 and 1/21 — plus a non-existent `behavioral-evaluation/SKILL.md` and a wrong schema path.

## Scope / review note
Additive markdown only. Touches no `hooks/`, `config/`, routing, safety gates, or permissions. `openspec validate` passes (`PASS: adopt-addy-mechanics`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)