### PR TITLE
docs: PR72 follow-up — clarify three skill descriptions

### DIFF
--- a/skills/deploy-gate/SKILL.md
+++ b/skills/deploy-gate/SKILL.md
@@ -121,8 +121,8 @@ A typical ladder — adjust to traffic and risk:
 | Stage | Traffic | Bake (target soak) | Advance when |
 |-------|---------|-----------------|--------------|
 | Canary | ~5% | long enough to cover peak + one full request mix | no trigger tripped |
-| Early | ~25% | shorter soak | no trigger tripped |
-| Half | ~50% | shorter soak | no trigger tripped |
+| Early | ~25% | shorter than canary — request mix already characterized | no trigger tripped |
+| Half | ~50% | shorter still | no trigger tripped |
 | Full | 100% | monitor | stable |
 
 **Rollback triggers (define BEFORE rollout, measured against the pre-deploy

--- a/skills/security-scanner/SKILL.md
+++ b/skills/security-scanner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-scanner
-description: Use when reviewing code changes for security issues — during REVIEW phase or on explicit security, vulnerability, SAST, or secret-scan requests — running available Semgrep/Opengrep, Trivy, and Gitleaks scanners with a self-healing fix loop
+description: Use when reviewing code changes for security issues — during REVIEW phase or on explicit security, vulnerability, SAST, or secret-scan requests — running a STRIDE threat-model pre-pass, then available Semgrep/Opengrep, Trivy, and Gitleaks scanners with a self-healing fix loop
 ---
 
 # Security Scanner

--- a/skills/unified-context-stack/SKILL.md
+++ b/skills/unified-context-stack/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unified-context-stack
-description: Tiered context retrieval across External Truth (docs), Internal Truth (dependencies), Historical Truth (memory), and Intent Truth (feature specs) with graceful degradation based on installed tools.
+description: Use when any SDLC phase needs external docs, dependency internals, cross-session memory, or feature specs — provides tiered context retrieval across External Truth (docs), Internal Truth (dependencies), Historical Truth (memory), and Intent Truth (feature specs) with graceful degradation based on installed tools.
 ---
 
 # Unified Context Stack


### PR DESCRIPTION
Follow-up to PR #72 review recommendations. Three catalog-text clarifications, doc-only.

## Changes
- **security-scanner** — frontmatter `description` now surfaces the STRIDE Step-0 threat-model pre-pass (`…running a STRIDE threat-model pre-pass, then available Semgrep/Opengrep, Trivy, and Gitleaks scanners…`). The pre-pass became Step 0 but was invisible in the catalog blurb.
- **deploy-gate** — canary table's two ambiguous `shorter soak` cells replaced with a self-contained descending ladder anchored against the Canary row (`shorter than canary — request mix already characterized` / `shorter still`). No invented numbers — the reviewer's "~25% of canary bake time" conflated the 25% *traffic* share with a soak ratio.
- **unified-context-stack** — frontmatter `description` reframed from a topic summary into a "Use when…" trigger condition (T4 skill-anatomy standard), preserving the four-Truth content.

## Risk
Frontmatter `description` is the **catalog surface only** — routing lives in `config/default-triggers.json`, so these edits carry zero routing risk by design. The deploy-gate change is a single table cell pair. No tests or config reference the changed strings.

## Verification
- `bash tests/run-tests.sh` → 60 files passed, 0 failed.
- Code review: ready to merge, no Critical/Important findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)