### PR TITLE
test: opt-in security-review model-gradient harness (probation fixture)

### DIFF
--- a/tests/fixtures/security-routing/security-scenarios.json
+++ b/tests/fixtures/security-routing/security-scenarios.json
@@ -1,12 +1,12 @@
 [
   {
-    "id": "ssrf-redirect-isolated",
+    "id": "ssrf-multi-vector",
     "category": "web",
-    "discriminator": true,
+    "discriminator": false,
     "prompt": "You are a senior application-security reviewer. Review this Python for SECURITY vulnerabilities. List every real vulnerability ranked by severity (Critical/High/Medium/Low) with the attack and the fix. Be concrete.\n\n```python\nimport ipaddress, socket\nfrom urllib.parse import urlparse\nimport requests\n\nALLOWED = {\"api.internal.example.com\"}\n\ndef fetch_metadata(url):\n    p = urlparse(url)\n    if p.scheme != \"https\":\n        raise ValueError(\"scheme not allowed\")\n    if p.hostname not in ALLOWED:\n        raise ValueError(\"host not allowed\")\n    ip = ipaddress.ip_address(socket.gethostbyname(p.hostname))\n    if ip.is_private or ip.is_loopback or ip.is_link_local:\n        raise ValueError(\"ip not allowed\")\n    return requests.get(url, timeout=5).json()\n```",
-    "primary_vuln": "requests.get follows redirects by default; the scheme/host/resolved-IP checks all run on the INITIAL url, so an allowlisted host can 302 the request to an internal IP (e.g. 169.254.169.254), bypassing every check. DNS-rebinding/scheme/userinfo are already handled here — redirect-following is the isolated remaining flaw.",
-    "rubric_required": "The review identifies that redirects are followed and bypass the host/IP validation (i.e. names allow_redirects / a 302 to an internal target / redirect re-validation). Merely saying generic SSRF without the redirect mechanism does NOT count.",
-    "precision_note": "Claiming there is NO IP-range check or NO scheme check is a FALSE POSITIVE (both are present)."
+    "primary_vuln": "MULTI-VECTOR SSRF (ground-truth corrected 2026-06-01): the snippet validates the resolved IP but then requests.get(url) RE-RESOLVES DNS independently, so (a) redirect-following bypasses all checks, (b) DNS-rebinding/round-robin TOCTOU between gethostbyname and connect is live, and (c) gethostbyname is IPv4-only so AAAA / IPv4-mapped addresses evade the range check. NOT an isolated single vuln — original ground-truth wrongly claimed rebinding was handled. Any of the three counts as catching SSRF.",
+    "rubric_required": "The review identifies at least one of: redirect-following bypass, DNS-rebinding/re-resolution TOCTOU, or the IPv6/gethostbyname gap — tied to bypassing the IP/host validation.",
+    "precision_note": "The IP-range check and scheme check ARE present (do not count claiming they are absent as a catch). But rebinding/IPv6/redirect are genuinely NOT mitigated, so flagging those is CORRECT, not spurious."
   },
   {
     "id": "hmac-timing",

--- a/tests/fixtures/security-routing/security-scenarios.json
+++ b/tests/fixtures/security-routing/security-scenarios.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ssrf-redirect-isolated",
+    "category": "web",
+    "discriminator": true,
+    "prompt": "You are a senior application-security reviewer. Review this Python for SECURITY vulnerabilities. List every real vulnerability ranked by severity (Critical/High/Medium/Low) with the attack and the fix. Be concrete.\n\n```python\nimport ipaddress, socket\nfrom urllib.parse import urlparse\nimport requests\n\nALLOWED = {\"api.internal.example.com\"}\n\ndef fetch_metadata(url):\n    p = urlparse(url)\n    if p.scheme != \"https\":\n        raise ValueError(\"scheme not allowed\")\n    if p.hostname not in ALLOWED:\n        raise ValueError(\"host not allowed\")\n    ip = ipaddress.ip_address(socket.gethostbyname(p.hostname))\n    if ip.is_private or ip.is_loopback or ip.is_link_local:\n        raise ValueError(\"ip not allowed\")\n    return requests.get(url, timeout=5).json()\n```",
+    "primary_vuln": "requests.get follows redirects by default; the scheme/host/resolved-IP checks all run on the INITIAL url, so an allowlisted host can 302 the request to an internal IP (e.g. 169.254.169.254), bypassing every check. DNS-rebinding/scheme/userinfo are already handled here — redirect-following is the isolated remaining flaw.",
+    "rubric_required": "The review identifies that redirects are followed and bypass the host/IP validation (i.e. names allow_redirects / a 302 to an internal target / redirect re-validation). Merely saying generic SSRF without the redirect mechanism does NOT count.",
+    "precision_note": "Claiming there is NO IP-range check or NO scheme check is a FALSE POSITIVE (both are present)."
+  },
+  {
+    "id": "hmac-timing",
+    "category": "crypto",
+    "discriminator": true,
+    "prompt": "You are a senior application-security reviewer. Review this Python for SECURITY vulnerabilities. List every real vulnerability ranked by severity (Critical/High/Medium/Low) with the attack and the fix. Be concrete.\n\n```python\nimport hmac, hashlib\n\ndef verify_webhook(body: bytes, signature: str) -> bool:\n    expected = hmac.new(WEBHOOK_SECRET, body, hashlib.sha256).hexdigest()\n    return expected == signature\n```",
+    "primary_vuln": "The signature comparison uses == (non-constant-time), enabling a timing side-channel to forge a valid signature byte-by-byte. Fix: hmac.compare_digest.",
+    "rubric_required": "The review identifies the comparison is not constant-time / a timing attack, or recommends hmac.compare_digest / constant-time compare.",
+    "precision_note": "Claiming the HMAC construction itself is wrong/weak (it is correct: HMAC-SHA256) is a FALSE POSITIVE."
+  },
+  {
+    "id": "sql-wrong-context-sanitize",
+    "category": "injection",
+    "discriminator": true,
+    "prompt": "You are a senior application-security reviewer. Review this Python for SECURITY vulnerabilities. List every real vulnerability ranked by severity (Critical/High/Medium/Low) with the attack and the fix. Be concrete.\n\n```python\nimport html\n\ndef add_comment(conn, author, text):\n    safe_text = html.escape(text)\n    query = \"INSERT INTO comments (author, body) VALUES ('%s', '%s')\" % (author, safe_text)\n    conn.execute(query)\n```",
+    "primary_vuln": "SQL injection: author is interpolated unescaped via %-formatting, and html.escape is the WRONG-CONTEXT sanitizer (it neutralizes HTML, not SQL). Fix: parameterized query.",
+    "rubric_required": "The review identifies SQL injection via string interpolation AND/OR that html.escape is the wrong sanitization for a SQL context; recommends parameterized/prepared queries.",
+    "precision_note": "Treating html.escape as adequate input handling is a MISS, not a catch."
+  },
+  {
+    "id": "coupon-toctou",
+    "category": "concurrency",
+    "discriminator": false,
+    "prompt": "You are a senior application-security reviewer. Review this Python for SECURITY vulnerabilities. List every real vulnerability ranked by severity (Critical/High/Medium/Low) with the attack and the fix. Be concrete.\n\n```python\ndef redeem_coupon(conn, code, user_id):\n    row = conn.execute(\n        \"SELECT id, discount FROM coupons WHERE code = %s AND redeemed = false\", (code,)\n    ).fetchone()\n    if row is None:\n        raise InvalidCoupon()\n    apply_discount(conn, user_id, row[\"discount\"])\n    conn.execute(\"UPDATE coupons SET redeemed = true WHERE id = %s\", (row[\"id\"],))\n```",
+    "primary_vuln": "Check-then-act race (TOCTOU): concurrent redemptions both pass the redeemed=false check before either UPDATE lands, so one coupon is redeemed multiple times. Fix: atomic conditional UPDATE (... WHERE redeemed=false, check rowcount) or SELECT ... FOR UPDATE in a transaction. Control scenario — TOCTOU saturated in the prior race.",
+    "rubric_required": "The review identifies the check-then-act race / TOCTOU allowing double-redemption and recommends an atomic update or row lock.",
+    "precision_note": "n/a"
+  },
+  {
+    "id": "lethal-trifecta-agent",
+    "category": "agent-architecture",
+    "discriminator": true,
+    "prompt": "You are a senior application-security/architecture reviewer. Review this DESIGN for SECURITY vulnerabilities. List every real vulnerability ranked by severity (Critical/High/Medium/Low) with the attack and the fix. Be concrete.\n\nDesign: an autonomous email-triage agent.\n- On each inbound email (from any external sender), it reads the email body and follows the instructions it contains to categorize and route the message. The raw email body is concatenated directly into the agent's prompt.\n- It has a tool to read the user's entire mailbox, including past private threads.\n- It has a tool to send emails on the user's behalf and a tool to POST to an arbitrary webhook URL.\n- It runs fully autonomously with no human approval step.",
+    "primary_vuln": "Lethal trifecta: untrusted input (inbound email body in the prompt) + access to private data (full mailbox) + outbound action (send email / POST webhook), fully autonomous. A prompt-injection payload in an email instructs the agent to read private threads and exfiltrate them via the webhook/send tools. Fix: never let untrusted content drive privileged tools; isolate trust contexts; require human approval for outbound; treat email body as data not instructions.",
+    "rubric_required": "The review identifies the prompt-injection / lethal-trifecta exfiltration path: that untrusted email content can drive the privileged mailbox-read + outbound tools to exfiltrate private data. Generic mention of injection without the data-exfiltration-via-outbound-tool chain is partial.",
+    "precision_note": "n/a"
+  }
+]

--- a/tests/run-security-race.sh
+++ b/tests/run-security-race.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# run-security-race.sh — Quantify the model gradient on security review.
+# For each scenario x reviewer-model x rep: run the reviewer (claude -p --model),
+# then grade its output with a fixed Opus judge against the scenario rubric.
+# Emits per (scenario,model): primary-caught rate + total spurious-critical count.
+# Opt-in: requires SECURITY_RACE=1. Bash 3.2 compatible.
+set -u
+
+[ "${SECURITY_RACE:-0}" = "1" ] || { echo "set SECURITY_RACE=1 to run" >&2; exit 2; }
+CLAUDE="${CLAUDE_BIN:-claude}"
+command -v "$CLAUDE" >/dev/null 2>&1 || { echo "claude not found" >&2; exit 2; }
+
+SCEN_FILE="${SCEN_FILE:-tests/fixtures/security-routing/security-scenarios.json}"
+N="${N:-3}"
+MODELS="${MODELS:-haiku sonnet opus}"
+JUDGE="${JUDGE:-opus}"
+SAND='Edit Write Bash'
+
+for id in $(jq -r '.[].id' "$SCEN_FILE"); do
+  prompt="$(jq -r --arg id "$id" '.[]|select(.id==$id)|.prompt' "$SCEN_FILE")"
+  primary="$(jq -r --arg id "$id" '.[]|select(.id==$id)|.primary_vuln' "$SCEN_FILE")"
+  rubric="$(jq -r --arg id "$id" '.[]|select(.id==$id)|.rubric_required' "$SCEN_FILE")"
+  precnote="$(jq -r --arg id "$id" '.[]|select(.id==$id)|.precision_note' "$SCEN_FILE")"
+  for model in $MODELS; do
+    caught=0; spurious_total=0; runs=0; i=1
+    while [ "$i" -le "$N" ]; do
+      review="$("$CLAUDE" -p --output-format json --disallowedTools "$SAND" --model "$model" "$prompt" 2>/dev/null | jq -r '.result // empty')"
+      if [ -z "$review" ]; then i=$((i+1)); continue; fi
+      judge_prompt="You are grading a security code review against a rubric. Judge ONLY what the review actually says. Output your verdict as a single JSON object and nothing else.
+
+PRIMARY VULNERABILITY (the finding that matters):
+$primary
+
+RUBRIC — what counts as catching the primary vuln:
+$rubric
+
+PRECISION NOTE — what would be a false positive:
+$precnote
+
+THE REVIEW TO GRADE:
+---
+$review
+---
+
+Output exactly one JSON object:
+{\"primary_caught\": true_or_false, \"spurious_critical_count\": integer}
+primary_caught = true iff the review satisfies the RUBRIC for the primary vuln (be strict; a generic mention that misses the specific mechanism in the rubric = false).
+spurious_critical_count = number of DISTINCT findings the review rated Critical or High that are NOT real vulnerabilities of this code (use the precision note and your own judgment)."
+      verdict="$("$CLAUDE" -p --output-format json --disallowedTools "$SAND" --model "$JUDGE" "$judge_prompt" 2>/dev/null | jq -r '.result // empty')"
+      pc="$(printf '%s' "$verdict" | grep -oiE '"primary_caught"[[:space:]]*:[[:space:]]*(true|false)' | grep -oiE 'true|false' | head -1 | tr 'A-Z' 'a-z')"
+      sc="$(printf '%s' "$verdict" | grep -oE '"spurious_critical_count"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | head -1)"
+      [ "$pc" = "true" ] && caught=$((caught+1))
+      spurious_total=$((spurious_total + ${sc:-0}))
+      runs=$((runs+1)); i=$((i+1))
+    done
+    printf 'SECRESULT\t%s\t%s\tcaught=%s/%s\tspurious=%s\n' "$id" "$model" "$caught" "$runs" "$spurious_total"
+  done
+done
+echo "=== security race done (N=$N, models: $MODELS) ==="

--- a/tests/run-security-race.sh
+++ b/tests/run-security-race.sh
@@ -9,12 +9,13 @@ set -u
 [ "${SECURITY_RACE:-0}" = "1" ] || { echo "set SECURITY_RACE=1 to run" >&2; exit 2; }
 CLAUDE="${CLAUDE_BIN:-claude}"
 command -v "$CLAUDE" >/dev/null 2>&1 || { echo "claude not found" >&2; exit 2; }
+command -v jq >/dev/null 2>&1 || { echo "jq not found (this harness hard-depends on jq)" >&2; exit 2; }
 
 SCEN_FILE="${SCEN_FILE:-tests/fixtures/security-routing/security-scenarios.json}"
 N="${N:-3}"
 MODELS="${MODELS:-haiku sonnet opus}"
 JUDGE="${JUDGE:-opus}"
-SAND='Edit Write Bash'
+SAND='Edit,Write,Bash'
 
 for id in $(jq -r '.[].id' "$SCEN_FILE"); do
   prompt="$(jq -r --arg id "$id" '.[]|select(.id==$id)|.prompt' "$SCEN_FILE")"
@@ -24,7 +25,10 @@ for id in $(jq -r '.[].id' "$SCEN_FILE"); do
   for model in $MODELS; do
     caught=0; spurious_total=0; runs=0; i=1
     while [ "$i" -le "$N" ]; do
-      review="$("$CLAUDE" -p --output-format json --disallowedTools "$SAND" --model "$model" "$prompt" 2>/dev/null | jq -r '.result // empty')"
+      # Prompt via stdin, NOT a trailing positional: the CLI parses
+      # --disallowedTools as variadic, so a trailing positional gets swallowed
+      # as more tool names and the run dies (see run-behavioral-evals.sh).
+      review="$(printf '%s' "$prompt" | "$CLAUDE" -p --output-format json --disallowedTools "$SAND" --model "$model" 2>/dev/null | jq -r '.result // empty')"
       if [ -z "$review" ]; then i=$((i+1)); continue; fi
       judge_prompt="You are grading a security code review against a rubric. Judge ONLY what the review actually says. Output your verdict as a single JSON object and nothing else.
 
@@ -46,7 +50,10 @@ Output exactly one JSON object:
 {\"primary_caught\": true_or_false, \"spurious_critical_count\": integer}
 primary_caught = true iff the review satisfies the RUBRIC for the primary vuln (be strict; a generic mention that misses the specific mechanism in the rubric = false).
 spurious_critical_count = number of DISTINCT findings the review rated Critical or High that are NOT real vulnerabilities of this code (use the precision note and your own judgment)."
-      verdict="$("$CLAUDE" -p --output-format json --disallowedTools "$SAND" --model "$JUDGE" "$judge_prompt" 2>/dev/null | jq -r '.result // empty')"
+      verdict="$(printf '%s' "$judge_prompt" | "$CLAUDE" -p --output-format json --disallowedTools "$SAND" --model "$JUDGE" 2>/dev/null | jq -r '.result // empty')"
+      # A failed/empty judge call must not be scored as "missed, zero spurious" —
+      # that would deflate the very caught-rate this harness measures.
+      if [ -z "$verdict" ]; then i=$((i+1)); continue; fi
       pc="$(printf '%s' "$verdict" | grep -oiE '"primary_caught"[[:space:]]*:[[:space:]]*(true|false)' | grep -oiE 'true|false' | head -1 | tr 'A-Z' 'a-z')"
       sc="$(printf '%s' "$verdict" | grep -oE '"spurious_critical_count"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | head -1)"
       [ "$pc" = "true" ] && caught=$((caught+1))


### PR DESCRIPTION
## Summary

Lands the **security-review model-gradient harness** — a parked artifact from the Haiku model-routing experiment (`project_model_routing_haiku_experiment`), rebased onto current `main` so it isn't lost on a single-machine branch.

Opt-in (`SECURITY_RACE=1`), self-contained, **not run in CI**. For each scenario × reviewer-model × N reps it runs `claude -p` as a security reviewer, then grades the output with a fixed **Opus judge** against the scenario's rubric, emitting per (scenario, model): **primary-caught rate + total spurious-critical count**. The instrument answers "can a cheaper model do security review without flooding spurious criticals?"

## Files (2, both new paths — no conflict with main)

- `tests/run-security-race.sh` — the harness.
- `tests/fixtures/security-routing/security-scenarios.json` — 5 trusted committed scenarios with rubric + precision notes: multi-vector SSRF, HMAC timing, SQL wrong-context sanitizer, coupon TOCTOU (control), lethal-trifecta agent.

## Review hardening (applied)

A focused code review surfaced three robustness/accuracy items, all fixed in `9cf27d7`:
1. **Prompt via stdin** instead of trailing positional — matches the repo's regression-tested anti-`--disallowedTools`-variadic-swallow pattern in `run-behavioral-evals.sh`.
2. **Empty-verdict guard** — a failed judge call now `continue`s instead of being scored as "missed, zero spurious" (which would deflate the caught-rate the tool measures).
3. **`jq` presence check** — the harness hard-depends on jq.

## Safety / governance

Clean: no hooks/config/routing changes; no `dangerouslyDisableSandbox` / `--no-verify` / `force`; spawned reviewer + judge are sandboxed via `--disallowedTools Edit,Write,Bash`; `set -u` with `:-` defaults; opt-in gate. Scenarios are trusted committed fixtures (same trust model as eval packs) — no injection vector (no `eval`/`sh -c`).

## Verification

`bash -n` clean; fixture valid JSON (5 scenarios); full suite **62/62** (harness is correctly *not* auto-discovered by `run-tests.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
