### PR TITLE
docs: explicit simplification + readability lens in agent-team-review

### DIFF
--- a/openspec/changes/frontend-testing-improvements/design.md
+++ b/openspec/changes/frontend-testing-improvements/design.md
@@ -1,0 +1,97 @@
+# Design: Frontend-Testing Improvements
+
+## Architecture
+
+Three independent, reversible changes across two capabilities. **No hook-logic change** — all
+routing changes are config data; the only skill-doc change is additive.
+
+### 1. `frontend-quality-rules` advisory hint (`skill-routing`)
+
+A new `methodology_hints[]` entry in `config/default-triggers.json` (mirrored to
+`config/fallback-registry.json`, which session-start regenerates — both are touched per the
+canonical-source convention).
+
+- **Mechanism:** advisory-conditional wording, following the `firebase` (line 877) and
+  `playwright-mcp` (line 890) precedent — neither has a `.plugin` field; both say *"If X is
+  available, use it."* The model reads which skills are actually loaded at runtime and resolves the
+  invocation itself. We never emit a hardcoded `Skill(<plugin>:<skill>)` token, because we don't own
+  the Vercel namespace.
+- **Framework scoping:** two references, scoped separately. `web-interface-guidelines`
+  (framework-agnostic UI/a11y) is offered on general frontend signals; `react-best-practices`
+  (React/Next-specific perf) is offered only when React/Next signals are present. This prevents
+  routing React guidance onto Vue/Svelte/plain-DOM frontends.
+- **Regex self-anchoring:** hint-path triggers bypass the word-boundary post-filter, so triggers
+  must self-anchor `(^|[^a-z])…($|[^a-z])` (per the `frontend-playwright` entry and the
+  hint-path reference note).
+- **Phases:** `IMPLEMENT` (build-it-right) + `REVIEW` (audit).
+- **Fallback:** hint text names our own `frontend-design` + `runtime-validation` as the fallback,
+  so a stale/renamed external reference degrades to silence, not a broken instruction.
+
+### 2. `frontend-playwright` REVIEW-seam fix (`skill-routing`)
+
+Add `REVIEW` to the `frontend-playwright` hint's `phases` array so its own *"During REVIEW, use
+runtime-validation"* text can fire. One-line data change + a routing assertion.
+
+### 3. Visual-regression overlay (`runtime-validation`)
+
+A report-only overlay in the Browser Path of `skills/runtime-validation/SKILL.md`, structurally
+parallel to the existing Lighthouse perf overlay.
+
+- **Diff mechanism:** Playwright's built-in screenshot comparison. No `pixelmatch` or other new
+  dependency — the skill already assumes Playwright.
+- **Baseline storage:** gitignored, `tests/artifacts/validation/visual-baselines/<scenario>/<viewport>.png`;
+  actuals/diffs under `tests/artifacts/validation/visual-runs/`. **Not committed** — committed
+  snapshots belong in the *consumer's* own Playwright suite.
+- **First run:** `BASELINE_MISSING/SEEDED` — capture the screenshot as the new baseline, list it in
+  Coverage Gaps, do **not** pass/fail on it.
+- **Subsequent runs:** `MATCH` or `CHANGED` in a new report-only section.
+- **Report-only:** excluded from the fix-rescan loop and never hard-blocks REVIEW (screenshots are
+  environment-sensitive, same rationale as Lighthouse perf). Honesty note in the report:
+  session-scoped diffing detects change *within* a review session; durable cross-commit regression
+  is delegated to project-native committed snapshots.
+- **Routing:** add `visual.regress|layout.regress|screenshot` to `runtime-validation` triggers,
+  with negative fixtures guarding false positives (e.g. `tabulate`, `onboarding`).
+
+## Trade-offs
+
+- **Advisory hint emits even when the external skills are absent** (mild context noise). Accepted:
+  the conditional wording + explicit fallback bounds the cost to one line, and the model degrades to
+  our own skills. This is the same trade the `firebase`/`playwright-mcp` hints already make.
+- **Session-scoped visual diffing, not cross-commit.** Accepted: committed baselines would bloat our
+  repo and belong to the consumer's suite; we report the limitation explicitly.
+
+## Dissenting views (from the design debate)
+
+- **Critic argued for "do nothing" (option D)**, on the premise that naming absent tooling breaks a
+  routing invariant. **Adjudicated against:** the premise is factually wrong — `firebase` and
+  `playwright-mcp` already name possibly-absent tooling without a `.plugin` gate. The "do nothing"
+  case collapses.
+- **Critic's surviving concerns were folded into the design**, not dismissed: (1) React/Next
+  framework mismatch → framework-scoped references; (2) unknowable invocation surface → descriptive,
+  not hardcoded, skill references; (3) third-party staleness/supply-chain → generic wording +
+  explicit fallback, docs-only blast radius.
+- **Critic's "the gap may be imaginary" stands as a watch-item:** the hint only pays off for
+  React/Next users who have installed the Vercel skills; it is inert otherwise. Acceptable because
+  the cost of being inert is ~one advisory line.
+
+## Decisions & rejected alternatives
+
+- **Rejected B (build a `skills_any` hook-gating primitive now):** the ~50ms fail-open activation
+  hot path gates all routing; an unguarded non-zero there can bypass gates. Enormous blast radius
+  and speculative reuse (one consumer). Reversibility asymmetry is decisive — A is a config revert,
+  B is a hot-path amputation. **Deferred** with revival trigger: ≥2 external-skill hints needing
+  presence-gating, OR measured mis-routing.
+- **Rejected C (own thin `frontend-quality` orchestrator skill):** owns a checklist with no
+  enforceable floor (external skills may be absent), duplicates `frontend-playwright` /
+  `runtime-validation`, and adds maintenance.
+- **Rejected `dev-browser` adoption:** substrate swap on a vendor benchmark; not selected by the
+  user. Parked with revival trigger.
+- **Rejected `pixelmatch` for visual diffing:** violates "no new dependency"; Playwright's built-in
+  compare suffices.
+
+## Verification
+
+Deterministic feature → standard TDD + the acceptance scenarios below are the bar. No
+probabilistic/AI behavior, so no eval set. **Trifecta:** private_data Absent, untrusted_input Absent
+(screenshots of a local dev server the user already runs), outbound_action Absent → count 0; no
+`agent-safety-review` required.

--- a/openspec/changes/frontend-testing-improvements/proposal.md
+++ b/openspec/changes/frontend-testing-improvements/proposal.md
@@ -1,0 +1,65 @@
+# Proposal: Frontend-Testing Improvements
+
+## Why
+
+The frontend-testing story our enforced PDLC hands downstream users has three gaps:
+
+1. **No prescriptive frontend-quality guidance.** We have `frontend-design` (aesthetics) and
+   `runtime-validation` (measures a11y/perf), but nothing routes users to prescriptive
+   *build-it-right* standards (UI interaction/a11y rules; React/Next performance rules like
+   async-waterfall elimination and bundle splitting). High-quality external skills exist for
+   this (`vercel-labs/web-interface-guidelines`, `vercel-labs/agent-skills` react-best-practices)
+   but nothing surfaces them.
+
+2. **No visual-regression evidence.** `runtime-validation` captures screenshots but never diffs
+   them, so unintended visual changes during REVIEW go undetected.
+
+3. **A routing seam bug.** The `frontend-playwright` methodology hint promises *"During REVIEW,
+   use runtime-validation"* but its `phases` are only `DESIGN`+`IMPLEMENT`, so that REVIEW
+   promise can never fire.
+
+## What Changes
+
+- **Add an advisory `frontend-quality-rules` methodology hint** that surfaces the external Vercel
+  frontend-quality skills *if installed*, following the established `firebase`/`playwright-mcp`
+  advisory-conditional precedent (no `.plugin` gate, no hardcoded invocation token). React/Next
+  guidance is scoped to React/Next signals; general UI guidance fires on generic frontend signals.
+  Explicit fallback to our own `frontend-design` + `runtime-validation` so a stale/absent reference
+  degrades to silence, not a broken instruction.
+- **Fix the `frontend-playwright` REVIEW seam** by adding `REVIEW` to its `phases`.
+- **Add a report-only visual-regression overlay** to `runtime-validation`'s Browser Path:
+  Playwright's built-in screenshot compare (no new dependency), gitignored baselines, first-run
+  `BASELINE_MISSING/SEEDED` handling, excluded from the fix-rescan loop (env-sensitive, same
+  rationale as the Lighthouse perf overlay).
+- **Add routing terms** (`visual.regress|layout.regress|screenshot`) to `runtime-validation`
+  triggers with negative regex fixtures.
+
+## Capabilities
+
+- **Modified: `skill-routing`** — new `frontend-quality-rules` hint; `frontend-playwright` phase
+  fix; new `runtime-validation` trigger terms. Config in `config/default-triggers.json` +
+  `config/fallback-registry.json`.
+- **Modified: `runtime-validation`** — visual-regression overlay section, report section, and
+  verification bullet in `skills/runtime-validation/SKILL.md`.
+
+## Impact
+
+- **Code/config:** `config/default-triggers.json`, `config/fallback-registry.json`,
+  `skills/runtime-validation/SKILL.md`.
+- **Tests:** new regex fixtures (positive + negative) for the new hint and trigger terms;
+  routing test for the `frontend-playwright` REVIEW phase; new
+  `tests/test-visual-regression-overlay.sh` content contract (mirrors `test-perf-overlay.sh`).
+- **Dependencies:** none added. Visual regression uses Playwright's built-in compare; the Vercel
+  skills are external and optional.
+- **No hook-logic change** — zero blast radius on the fail-open activation hot path.
+
+## Out of Scope
+
+- Adopting or racing `dev-browser` (parked; revival trigger: a named user hitting token/flakiness
+  pain → run the A/B against the `webapp-testing` baseline).
+- Copying Vercel rule content into this repo (context bloat; react-best-practices' AGENTS.md is
+  ~2975 lines).
+- Building a `skills_any` hook-gating primitive (deferred; revival trigger: ≥2 external-skill hints
+  needing presence-gating, OR measured mis-routing).
+- Committed visual baselines (belong in the consumer project's own Playwright suite, not our
+  gitignored review artifacts).

--- a/openspec/changes/frontend-testing-improvements/specs/runtime-validation/spec.md
+++ b/openspec/changes/frontend-testing-improvements/specs/runtime-validation/spec.md
@@ -1,0 +1,47 @@
+# Spec Delta: runtime-validation
+
+## ADDED Requirements
+
+### Requirement: Report-only visual-regression overlay
+
+The `runtime-validation` skill SHALL provide a visual-regression overlay in its Browser Path that
+uses Playwright's built-in screenshot comparison (no new dependency), is self-gated on Playwright
+availability, and is **report-only** — excluded from the fix-rescan loop and never hard-blocking
+REVIEW, consistent with the existing Lighthouse perf overlay.
+
+#### Scenario: First run seeds a baseline instead of failing
+
+- **GIVEN** a browser scenario with no existing baseline screenshot
+- **WHEN** the visual-regression overlay runs
+- **THEN** it SHALL capture the current screenshot as the baseline under
+  `tests/artifacts/validation/visual-baselines/<scenario>/<viewport>.png`
+- **AND** report the result as `BASELINE_MISSING/SEEDED`, listing it in Coverage Gaps rather than
+  as PASS or FAIL
+
+#### Scenario: Subsequent run diffs against the baseline
+
+- **GIVEN** an existing baseline for a scenario
+- **WHEN** the visual-regression overlay runs and the rendered page differs
+- **THEN** it SHALL report `CHANGED` in a dedicated report-only section with the diff artifact path
+- **AND** the change SHALL NOT enter the fix-rescan loop or hard-block REVIEW
+
+#### Scenario: Baselines are gitignored, not committed
+
+- **GIVEN** the visual-regression artifact paths
+- **WHEN** the repository ignore rules are evaluated
+- **THEN** baselines, actuals, and diffs under `tests/artifacts/validation/` SHALL be gitignored
+- **AND** the skill SHALL direct users to project-native committed snapshots for durable
+  cross-commit regression
+
+### Requirement: Visual-regression overlay is documented with an honesty note
+
+The skill documentation SHALL state that the overlay performs session-scoped diffing (detecting
+change within a review session), not cross-commit field regression, mirroring the "lab, not field"
+honesty convention of the Lighthouse perf overlay.
+
+#### Scenario: Report carries the session-scope caveat
+
+- **GIVEN** the visual-regression report section in `skills/runtime-validation/SKILL.md`
+- **WHEN** the section is inspected
+- **THEN** it SHALL include a note that diffing is session-scoped and that durable regression is
+  delegated to the consumer's committed snapshot suite

--- a/openspec/changes/frontend-testing-improvements/specs/skill-routing/spec.md
+++ b/openspec/changes/frontend-testing-improvements/specs/skill-routing/spec.md
@@ -1,0 +1,63 @@
+# Spec Delta: skill-routing
+
+## ADDED Requirements
+
+### Requirement: Advisory routing to external frontend-quality skills
+
+The routing config SHALL include a `frontend-quality-rules` methodology hint that advises using the
+external Vercel frontend-quality skills when they are installed, without gating on a `.plugin`
+field and without emitting a hardcoded `Skill(<plugin>:<skill>)` invocation token. The hint SHALL
+name our own `frontend-design` and `runtime-validation` skills as the fallback. React/Next-specific
+guidance (`react-best-practices`) SHALL be offered only on React/Next signals; framework-agnostic
+guidance (`web-interface-guidelines`) MAY be offered on general frontend signals. The hint SHALL
+fire in the `IMPLEMENT` and `REVIEW` phases, and its triggers SHALL self-anchor word boundaries
+`(^|[^a-z])…($|[^a-z])`.
+
+#### Scenario: Hint surfaces on a React frontend prompt in IMPLEMENT
+
+- **GIVEN** a session in the `IMPLEMENT` phase
+- **WHEN** the user prompt matches a React/Next frontend signal (e.g. "add a React component")
+- **THEN** the routing context SHALL include the `frontend-quality-rules` advisory hint text
+- **AND** the hint SHALL reference `react-best-practices` and name `frontend-design` /
+  `runtime-validation` as the fallback
+
+#### Scenario: Hint does not hardcode an unknowable invocation token
+
+- **GIVEN** the `frontend-quality-rules` hint definition in `config/default-triggers.json`
+- **WHEN** the hint text is inspected
+- **THEN** it SHALL NOT contain a literal `Skill(` invocation for the external Vercel skills
+- **AND** it SHALL phrase the reference conditionally ("if installed")
+
+#### Scenario: Config is mirrored to the fallback registry
+
+- **GIVEN** the `frontend-quality-rules` hint added to `config/default-triggers.json`
+- **WHEN** the fallback registry is regenerated
+- **THEN** `config/fallback-registry.json` SHALL contain the same hint, keeping the two files in sync
+
+### Requirement: frontend-playwright hint fires in REVIEW
+
+The `frontend-playwright` methodology hint SHALL include `REVIEW` in its `phases` so that its
+"During REVIEW, use runtime-validation" guidance can fire in the REVIEW phase.
+
+#### Scenario: frontend-playwright surfaces in REVIEW
+
+- **GIVEN** a session in the `REVIEW` phase
+- **WHEN** the user prompt matches a frontend signal (e.g. "review the login form")
+- **THEN** the routing context SHALL include the `frontend-playwright` hint text
+
+### Requirement: runtime-validation routes on visual-regression terms
+
+The `runtime-validation` skill triggers SHALL match `visual regression`, `layout regression`, and
+`screenshot` terms, without matching unrelated substrings (e.g. `tabulate`, `onboarding`).
+
+#### Scenario: Visual-regression prompt routes to runtime-validation
+
+- **GIVEN** a session in the `REVIEW` phase
+- **WHEN** the user prompt contains "visual regression" or "screenshot" in a validation context
+- **THEN** `runtime-validation` SHALL be surfaced in the routing context
+
+#### Scenario: Negative terms do not false-trigger
+
+- **GIVEN** the `runtime-validation` trigger regex
+- **WHEN** matched against `tabulate the results` or `user onboarding flow`
+- **THEN** the visual-regression terms SHALL NOT match those substrings

--- a/openspec/changes/testing-rigor/design.md
+++ b/openspec/changes/testing-rigor/design.md
@@ -1,0 +1,134 @@
+# Design: testing-rigor sweep
+
+## Architecture
+
+Three parts, two phases.
+
+### Part 1 — Test-adequacy gate (A) [Phase 1, deterministic]
+
+Extends the skill we already own rather than adding a new review lens.
+
+- **Where:** `skills/project-verification/` + `skills/project-verification/scripts/`
+  (a new `coverage-adequacy-check.sh` sibling to `gate-gaming-check.sh`).
+- **Flow:** after `project-verification` runs the repo's declared test gate, discover
+  the coverage artifact the runner already emits — `coverage.xml`/`.coverage`
+  (pytest-cov), `lcov.info`/`coverage-final.json` (jest/nyc), `coverage.out`
+  (go test -cover), JaCoCo XML — via an ordered probe list. Compute two signals on
+  the diff:
+  1. **Changed-line coverage:** of lines added/modified in the diff, the fraction
+     covered ≥ a floor.
+  2. **Coverage regression:** total covered% did not drop vs the base ref.
+- **Output contract:** reuse the existing tri-state. `clean` (both signals pass),
+  `suspect` (a signal fails — surfaced as blocking evidence like gate-gaming),
+  `unverified` (no coverage artifact / unparseable / tool missing → fail-open, never
+  blocks). This mirrors the gate-gaming-status contract exactly, so the push-gate and
+  evidence plumbing need no new states.
+- **Degradation:** repos without coverage tooling see identical behavior to today.
+
+### Part 2 — Rigor Benchmark (B0) [Phase 1, the measurement instrument]
+
+The yardstick that makes B/C objectively decidable without felt pain.
+
+- **Where:** `tests/fixtures/rigor-benchmark/` (corpus) + `scripts/rigor-benchmark.sh`
+  (scorer).
+- **Case shape:** each case = a self-contained mini-repo diff + a JSON label
+  `{class, should_flag, rationale, source}`. Six classes:
+
+  | class | should_flag | who should catch |
+  |---|---|---|
+  | `untested-new-code` | yes | A (coverage) |
+  | `assertion-free-test` | yes | B-effectiveness (A passes it — coverage is green) |
+  | `bug-with-green-tests` | yes | B-mutation / C |
+  | `weakened-test` | yes | existing gate-gaming (regression floor) |
+  | `adequate-clean` | no | nobody (precision control) |
+  | `pure-refactor` | no | nobody (FP control) |
+
+- **Splits:** `dev/` (used to tune A) and `held-out/` (used only to score races).
+  Held-out cases are sourced from a *different* codebase/agent than A was tuned on,
+  to defeat the in-sample lie (a prior detector scored 93% in-sample, 14% held-out).
+- **Metrics per mechanism:** recall (`caught / should_flag`), precision
+  (`1 − FP on the two control classes`), **incremental recall over the cheapest
+  baseline** (does the mechanism catch what A / gate-gaming already miss?),
+  token+wall-time cost per change.
+- **Never-delete:** benchmark cases are deprecated with a dated rationale, never
+  deleted, so the yardstick can't be quietly weakened to pass a favored mechanism.
+
+### Part 3 — Pre-registered races (B/C) [Phase 2]
+
+Each escalation scored against `held-out/` on a rule **frozen before the race is run**;
+thresholds `T*/P*/C*/H*/FP*` are calibrated to the held-out set's measured difficulty
+at Phase-2 start (per user decision), then frozen. Each race emits a committed verdict
++ the measured numbers. Adopt rules:
+
+- **B-mutation:** incremental recall on `bug-with-green-tests` over A ≥ `T₁`,
+  precision on controls ≥ `P₁`, cost ≤ `C₁`. Ships opt-in (slow, language-specific) —
+  never a per-commit hard gate.
+- **B-testgen:** spec-derived red-first tests catch ≥ `T₂` of seeded bugs **and**
+  ≤ `FP₂` of generated tests pass against buggy code (pinning = auto-fail), human
+  accept ≥ `H₂`. Generated from openspec `GIVEN/WHEN/THEN` only.
+- **C-cross-model:** incremental recall over `A + agent-team-review` ≥ `T₃`, precision
+  ≥ `P₃` (must clear the prior refute-gate's FP bar), cost ≤ `C₃`. Precondition:
+  passes `agent-safety-review`.
+
+## Trade-offs
+
+- **Extend project-verification vs. new skill.** Extending keeps the tri-state/push-gate
+  plumbing and evidence contract intact; a new skill would duplicate discovery + evidence
+  wiring. Chosen: extend.
+- **Seeded benchmark vs. real-repo mining.** Seeding gives objective ground truth cheaply
+  and immediately; mining real repos gives realism but no reliable labels. Chosen: seed
+  for the labeled instrument, source held-out from a different real codebase for realism.
+- **Coverage as gate vs. advisory.** Changed-line coverage is deterministic enough to gate
+  (as `suspect`); total-regression is noisier and starts advisory. Both fail-open on
+  missing tooling.
+- **Cost of the races.** Phase 2 spends tokens/time up front to buy a durable conclusion —
+  which is the explicit goal (pre-empt pain with proof), not a cost to minimize away.
+
+## Dissenting views
+
+- **"Just ship A; skip the benchmark."** Rejected: without the yardstick the B/C
+  decisions revert to felt-pain parking — the exact failure mode the user called out.
+  The benchmark is load-bearing, not gold-plating.
+- **"Bundle C into this sweep as a headline feature."** Rejected as a *headline*: C is
+  orthogonal to test quality, carries a live prior rejection, and adds a trifecta leg.
+  It earns adoption only by beating its frozen bar on the same benchmark as everything
+  else — no special status.
+- **"Add code-derived test generation for speed."** Rejected (out-of-scope): tests
+  generated from current code pin current behavior and can *lower* rigor. Only
+  spec-derived, red-first generation is admissible.
+
+## Decisions
+
+- A and the Rigor Benchmark ship as a Phase-1 pair; the benchmark is what proves A.
+- Thresholds calibrated at Phase-2 start against held-out difficulty, then frozen.
+- Tri-state evidence contract reused verbatim; no new push-gate states.
+- Fail-open preserved everywhere; absent coverage tooling → `unverified`.
+- C is gated behind `agent-safety-review` and its frozen precision bar; not shipped by
+  this change unless it clears both.
+
+## Out-of-scope
+
+- Wholesale adoption of spartan-ai-toolkit or mattpocock skills (we have equivalents).
+- Cross-model peer review as a committed deliverable (it's a Phase-2 race candidate only).
+- Code-derived test generation that pins current behavior.
+- Rebuilding anything already enforced (TDD mandate, runtime-validation, security-scanner).
+- Quantitative coverage % as a universal hard block (changed-line `suspect` is the gate;
+  total-regression starts advisory).
+
+## Eval strategy
+
+- **A (deterministic):** standard TDD + the acceptance scenarios in `specs/`. The Rigor
+  Benchmark dev split is A's functional test bed.
+- **B-testgen and C (probabilistic):** eval *set* with an adversarial/safety subset,
+  a pinned judge model+version, never-delete cases, and a pre-registered safety-stop
+  (halt if held-out precision falls below the frozen bar; caller = design owner). Safety
+  dimensions are hard pass/fail, never averaged into a quality blend.
+
+## Trifecta classification
+
+- **A:** local-only. private_data Absent-relevant, untrusted_input Absent, outbound_action
+  Absent. No trifecta.
+- **B0/B-mutation/B-testgen:** local-only. No outbound egress. No trifecta.
+- **C-cross-model:** `private_data` Present (user code, possibly private repos) +
+  `outbound_action` Present (code sent to OpenAI Codex) = 2 legs. MUST pass
+  `agent-safety-review` before ship; unmitigated egress is a blocking governance finding.

--- a/openspec/changes/testing-rigor/proposal.md
+++ b/openspec/changes/testing-rigor/proposal.md
@@ -1,0 +1,82 @@
+# Testing-rigor sweep: adequacy gate + a benchmark that proves the escalations
+
+## Why
+
+A verified inventory of our PDLC (Explore agent, 2026-07-01) shows the testing
+stack is **deep on the left, shallow on the right**: we heavily enforce *does code
+get reviewed/verified* (TDD mandate, `requesting-code-review`, `agent-team-review`,
+`security-scanner`, `runtime-validation`, `implementation-drift-check`, push-gate)
+but barely touch *are the tests any good*. `gate-gaming-check.sh` catches tests
+getting **weaker** (removed asserts, skip/xfail); nothing catches new code shipping
+**untested** or tests that assert nothing.
+
+Three external repos were evaluated as priors, not sources:
+- `spartan-stratos/spartan-ai-toolkit` — a competing PDLC; ~90% redundant with ours.
+- `mattpocock/skills` — `tdd`/`diagnosing-bugs`/two-axis `code-review`/`to-issues`; we
+  already have an equivalent for each.
+- `jcputney/agent-peer-review` — the one novel mechanism: **cross-model (Claude vs
+  Codex) blind-pass + deterministic reconciliation**. Orthogonal to test *quality*
+  (it hardens *review*), and it carries a live prior rejection (the multi-agent
+  refute-gate killed on false-positive grounds).
+
+None of the three fill the real gap. So the strongest rigor improvement is one we
+**build** by extending code we own — and, per user direction, the higher-ambition
+escalations (mutation/effectiveness, spec→test generation, cross-model review) must
+reach an **objective, measured** adopt/reject conclusion rather than be parked on
+"no felt pain." The mechanism that makes that possible is a **seeded-defect Rigor
+Benchmark** that supplies objective ground truth independent of felt pain — so the
+pain is pre-empted by proof.
+
+## What Changes
+
+Two phases. Phase 1 is committed; Phase 2 races are committed to *run* (frozen
+adopt/reject criteria), not to *ship any particular escalation*.
+
+**Phase 1 — the gate + the yardstick (ship together):**
+- **A. Test-adequacy gate.** Extend `project-verification` + `gate-gaming-check.sh`
+  from "detect test weakening" → "detect test *inadequacy*." After the declared test
+  gate runs, parse coverage the runner already emits and assert (i) changed lines
+  covered above a floor, (ii) no coverage regression vs base. Folds into the existing
+  tri-state evidence (`clean`/`suspect`/`unverified`); missing coverage tooling →
+  `unverified`, fail-open. Deterministic; push-gate-compatible.
+- **B0. Rigor Benchmark harness.** A committed labeled corpus of seeded
+  `(diff, ground-truth-verdict)` cases across six classes (untested-new-code,
+  assertion-free-test, bug-with-green-tests, weakened-test, adequate-clean,
+  pure-refactor), split **dev** (tune A) vs **blind held-out** (score the races),
+  held-out sourced from a *different* codebase than A was tuned on. Metrics: recall,
+  precision on controls, incremental recall over the cheapest baseline, token/time
+  cost. This is the measurement instrument for everything downstream.
+
+**Phase 2 — the pre-registered races (frozen criteria calibrated at Phase-2 start):**
+- **B-mutation** — real mutation testing (Stryker/mutmut/PIT) as an opt-in REVIEW audit.
+- **B-testgen** — spec→acceptance-test generation seeded from openspec `GIVEN/WHEN/THEN`,
+  **red-first from intent, never from code** (a generated test that passes against the
+  seeded-buggy code is an automatic fail).
+- **C-cross-model** — adopt `agent-peer-review`'s Claude-vs-Codex blind-debate as a
+  REVIEW upgrade. Precision bar must specifically clear the prior refute-gate's FP
+  failure. `private_data` + `outbound_action` (code → OpenAI Codex) ⇒ MUST pass
+  `agent-safety-review` before it could ship.
+
+Each race emits a committed verdict + measured numbers on the held-out benchmark.
+
+## Capabilities
+
+### Added
+- **testing-rigor** — the test-adequacy gate, the Rigor Benchmark instrument, and the
+  frozen-criteria race protocol that governs whether B/C escalations are adopted.
+
+### Modified
+- **project-verification** — gains changed-line coverage + coverage-regression checks,
+  surfaced through its existing tri-state evidence contract.
+
+## Impact
+
+- Users get a deterministic signal when new code ships under-tested — the biggest
+  verified gap — without new felt-pain dependence.
+- Escalations (mutation, test-gen, cross-model review) get an objective yardstick, so
+  each is adopted or rejected on recorded evidence, not vibes.
+- Fail-open preserved end-to-end: absent coverage tooling degrades to `unverified`,
+  never a false block.
+- Out of scope (see design.md): wholesale adoption of the three external PDLCs;
+  code-derived test generation that pins current behavior; shipping any Phase-2
+  escalation before it clears its frozen bar.

--- a/openspec/changes/testing-rigor/specs/testing-rigor/spec.md
+++ b/openspec/changes/testing-rigor/specs/testing-rigor/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: Test-adequacy gate in project-verification
+
+`project-verification` SHALL, after running the repo's declared test gate, evaluate
+whether the change under review is adequately tested by parsing whatever coverage
+artifact the test runner already emits. It MUST assess (1) changed-line coverage
+against a floor and (2) coverage regression against the base ref, and MUST express
+the result through the existing tri-state evidence contract (`clean` / `suspect` /
+`unverified`). It MUST fail-open: absent, unparseable, or tool-less coverage MUST
+resolve to `unverified` and MUST NOT block. It MUST NOT introduce any new push-gate
+state.
+
+#### Scenario: New code shipped without covering tests
+- **GIVEN** a diff that adds executable logic and a coverage artifact exists
+- **WHEN** the adequacy check runs and the added lines fall below the changed-line floor
+- **THEN** the evidence status MUST be `suspect` with the uncovered changed lines cited
+- **AND** the status MUST surface as blocking evidence in the same manner as gate-gaming `suspect`
+
+#### Scenario: No coverage tooling present
+- **GIVEN** a repo whose test runner emits no discoverable coverage artifact
+- **WHEN** the adequacy check runs
+- **THEN** the status MUST be `unverified`
+- **AND** the check MUST NOT block the push gate or alter existing behavior
+
+#### Scenario: Adequately tested change passes
+- **GIVEN** a diff whose changed lines are covered above the floor with no coverage regression vs base
+- **WHEN** the adequacy check runs
+- **THEN** the status MUST be `clean`
+
+### Requirement: Rigor Benchmark measurement instrument
+
+The change SHALL provide a committed, labeled Rigor Benchmark of seeded
+`(diff, ground-truth-verdict)` cases that supplies objective ground truth for scoring
+any testing-rigor mechanism independent of felt production pain. It MUST cover the six
+case classes (untested-new-code, assertion-free-test, bug-with-green-tests,
+weakened-test, adequate-clean, pure-refactor), MUST be split into a `dev` set and a
+blind `held-out` set with the held-out set sourced from a different codebase than the
+gate was tuned on, and MUST report recall, control-set precision, incremental recall
+over the cheapest baseline, and cost per mechanism. Benchmark cases MUST NOT be deleted;
+they MUST be deprecated with a dated rationale.
+
+#### Scenario: Scoring a mechanism against held-out ground truth
+- **GIVEN** a rigor mechanism (the adequacy gate, mutation, test-gen, or cross-model review)
+- **WHEN** it is run over the held-out benchmark split
+- **THEN** the scorer MUST emit recall, precision on the two control classes, incremental recall over the cheapest baseline, and token+time cost
+- **AND** the two control classes (adequate-clean, pure-refactor) MUST count any flag as a false positive
+
+#### Scenario: Benchmark integrity is preserved
+- **WHEN** a benchmark case is retired
+- **THEN** it MUST be marked deprecated with a dated rationale rather than deleted
+- **AND** the held-out split MUST remain sourced independently from the gate's tuning corpus
+
+### Requirement: Frozen-criteria race protocol for escalations
+
+The change SHALL adopt or reject each Phase-2 escalation — mutation testing,
+spec-derived test generation, and cross-model peer review — only by scoring it against
+the held-out Rigor Benchmark under a decision rule whose numeric thresholds are
+calibrated to the held-out set's measured difficulty at the start of Phase 2 and then
+FROZEN before the race is run. Each race MUST emit a committed verdict alongside its
+measured numbers. Cross-model peer
+review MUST additionally pass `agent-safety-review` before it may ship, because it sends
+potentially private code to an external model (`private_data` + `outbound_action`).
+Spec-derived test generation MUST treat any generated test that passes against the
+seeded-buggy code as an automatic failure (behavior-pinning), and MUST NOT generate tests
+from existing code.
+
+#### Scenario: An escalation that fails its frozen bar is rejected with evidence
+- **GIVEN** a Phase-2 escalation scored on the held-out benchmark
+- **WHEN** it does not meet its frozen incremental-recall, precision, or cost threshold
+- **THEN** it MUST be recorded as rejected with the measured numbers
+- **AND** it MUST NOT ship
+
+#### Scenario: Cross-model review is blocked pending safety review
+- **GIVEN** the cross-model peer-review escalation has cleared its benchmark bar
+- **WHEN** adoption is considered
+- **THEN** it MUST NOT ship until `agent-safety-review` clears the code-egress data flow
+- **AND** unmitigated, unacknowledged egress MUST be treated as a blocking governance finding
+
+#### Scenario: Thresholds cannot be set after seeing results
+- **WHEN** a race is run
+- **THEN** its thresholds MUST have been frozen at Phase-2 start before results were observed

--- a/skills/agent-team-review/SKILL.md
+++ b/skills/agent-team-review/SKILL.md
@@ -176,6 +176,8 @@ Task tool (general-purpose):
     - Edge cases not covered
     - DRY violations
     - YAGNI violations (over-engineering)
+    - Simplification: can this logic be expressed more simply or with less code, without losing behavior?
+    - Readability: will a future maintainer understand this at a glance (control flow, nesting depth, clear intent)?
     - Performance concerns
     - Maintainability
 

--- a/skills/agent-team-review/SKILL.md
+++ b/skills/agent-team-review/SKILL.md
@@ -176,8 +176,8 @@ Task tool (general-purpose):
     - Edge cases not covered
     - DRY violations
     - YAGNI violations (over-engineering)
-    - Simplification: can this logic be expressed more simply or with less code, without losing behavior?
-    - Readability: will a future maintainer understand this at a glance (control flow, nesting depth, clear intent)?
+    - Simplification opportunities (logic expressible more simply or with less code, no behavior change)
+    - Readability (nesting depth, control flow clarity, intent legibility)
     - Performance concerns
     - Maintainability
 


### PR DESCRIPTION
## What

Adds two focus bullets — **Simplification** and **Readability** — to the `quality-reviewer` lens in `skills/agent-team-review/SKILL.md`.

## Why

Evaluated (with Codex as a sparring partner) whether the enforced PDLC needs a `code-simplifier`/readability skill. Finding: the capability already exists three ways — REVIEW conditionally routes `pr-review-toolkit:code-simplifier` (`config/default-triggers.json:1349`, `"when": "installed"`), the general reviewer flags over-complex code, and the harness has a built-in `/simplify`. The only real gap was that our **owned** reviewer named naming/DRY/YAGNI/maintainability but not explicit simplicity/readability.

## Why this shape (and not others)

- **Not a new skill** — massively over-scoped for zero felt pain; capability already covered.
- **Not an always-on REVIEW hint** — Codex's counter: a `hints[]` entry fires on *every* review, injecting subjective readability noise that competes with the phase's bug/security focus.
- **A gated lens bullet** — fires only for 5+ file / sensitive changes and inherits the reviewer's existing evidence/confidence/severity-floor discipline (PR #60). Owned, so it survives when `pr-review-toolkit` isn't installed.

## Verification

Full test suite green: **2667 pass / 0 fail / 67 files**.

## Scope

2-line prose change to one skill's reviewer checklist. No routing, hook, or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)