### PR TITLE
feat: imperative consolidation nudge in Stop hook

### DIFF
--- a/hooks/consolidation-stop.sh
+++ b/hooks/consolidation-stop.sh
@@ -78,7 +78,7 @@ if [ -f "${_CACHE}" ] && command -v jq >/dev/null 2>&1; then
     fi
 fi
 
-_MSG="CONSOLIDATION REMINDER: Session ending without memory consolidation. Learnings from this session may be lost. ${_GUIDANCE}"
+_MSG="CONSOLIDATION: Session ending. Before you stop, enumerate the durable, team-relevant learnings from this session, route each to the correct backend (auto-memory for project-local facts; .claude/knowledge for durable team gotchas/decisions/conventions; Forgetful for cross-session architecture), and persist them now. Skip transient or personal context. ${_GUIDANCE}"
 if command -v jq >/dev/null 2>&1; then
     jq -n --arg msg "${_MSG}" '{"stopReason":$msg}'
 else


### PR DESCRIPTION
## What

Reword the session-end `consolidation-stop.sh` message from a passive *"learnings may be lost"* reminder to an imperative self-enumerate: enumerate the durable, team-relevant learnings, route each to the correct backend (auto-memory / `.claude/knowledge` / Forgetful), persist now, skip transient context.

**Message string only — no gate logic, routing, or guardrail changed.** Governance-neutral hooks/ touch: does not weaken any safety gate/HITL/approval, add bypass patterns, or expand autonomous scope.

## Why

This is the **"A1"** outcome of an evaluation of [claude-mem](https://github.com/thedotmack/claude-mem) against our memory stack:

- **claude-mem rejected wholesale** — Bun worker + Chroma + port 37777 conflict with the bash-3.2/200ms/min-deps architecture; passive capture-everything conflicts with our curated + no-dual-write + memory-poisoning discipline; its vector layer overlaps Forgetful.
- The one gap worth addressing was **consolidation loss** (the Stop hook only *reminded*). A frozen A/B race pitted the current reminder (A0) vs this reword (A1) vs an expensive draft-capture subsystem (A2), with a pre-committed build gate (A2 ≥ A1 + 25 recall pts).
- **A2 rejected** — never beat A0 in any probe; the arms don't cleanly separate (a capable model already consolidates clear learnings from a weak nudge). A1 ships on **reasoning + harmlessness** (strictly more actionable, zero added cost/risk), *not* a clean empirical win over A0.

Frozen spec + full outcome: `docs/plans/2026-07-01-memory-nudge-race-design.md` (gitignored session scratch).

## Verification

- `bash -n hooks/consolidation-stop.sh` ✓
- `jq -n --arg msg "$_MSG" '{stopReason:$msg}'` emits valid JSON ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)