### PR TITLE
docs: incident-analysis 4xx/empty-resource blind-spot + knowledge capture

### DIFF
--- a/.claude/knowledge/index.md
+++ b/.claude/knowledge/index.md
@@ -2,3 +2,4 @@
 # Knowledge Index
 
 - [Bash 3.2 rejects quoted operands in arithmetic](bash32-arithmetic-quoting.md) — Quoted operands in $(( )) abort the script under macOS /bin/bash, breaking fail-open hooks.
+- [A "no resource yet" 404 is invisible to severity>=ERROR / status>=500 sweeps](no-resource-404-invisible-to-error-sweeps.md) — Persistent per-user failures with a clean 5xx sweep are often 4xx (esp. 404); query the gateway access-log layer and app-level response_status, not the app exception stream.

--- a/.claude/knowledge/no-resource-404-invisible-to-error-sweeps.md
+++ b/.claude/knowledge/no-resource-404-invisible-to-error-sweeps.md
@@ -1,0 +1,31 @@
+---
+type: gotcha
+title: A "no resource yet" 404 is invisible to severity>=ERROR / status>=500 sweeps
+description: Persistent per-user failures with a clean 5xx sweep are often 4xx (esp. 404); query the gateway access-log layer and app-level response_status, not the app exception stream.
+tags: [incident-analysis, logging, gcp, investigation, 4xx]
+source: skills/incident-analysis/SKILL.md:Step 2c
+timestamp: 2026-07-02T00:00:00Z
+---
+
+When a client-visible failure is **persistent and per-user** but a `severity>=ERROR` /
+`httpRequest.status>=500` sweep comes back clean, the failure is often a **4xx** — most
+commonly a **404 for a resource that does not exist yet** (e.g. a feature flag enabled before
+its backing record is provisioned).
+
+A 404 is a client-error (4xx) response that the app does not log at ERROR severity, so it is
+excluded by both `severity>=ERROR` and `status>=500`. It also surfaces at the **gateway /
+access-log layer** (reverse proxy, ingress, API gateway) or in an **app-level status field**
+(e.g. `jsonPayload.response_status`), NOT in the app container's exception stream.
+
+A clean 5xx/ERROR sweep therefore does not establish that the backend is healthy. When the sweep
+is clean but the user still fails reproducibly, "no 5xx" is itself a clue — the 4xx layer is the
+one worth querying: the gateway access logs and the app-level status field, before the failure is
+attributed to the client. A common trap is naming the blind spot ("can't see 4xx / access logs
+not captured") and stopping there rather than pivoting to the layer that holds it.
+
+**Real case (healthcare SaaS, 2026-07):** a mobile "overview" screen failed to load for users
+whose feature flag was enabled but whose backing record had never been provisioned. The owning
+service returned **404**; an ERROR/5xx sweep scoped to that service's container showed nothing on
+the reproduced day, and the 404 was visible only at the API-gateway layer via its `response_status`
+field. A first-pass "backend clean → client-side" conclusion had to be revised once the 4xx layer
+was queried.

--- a/skills/incident-analysis/SKILL.md
+++ b/skills/incident-analysis/SKILL.md
@@ -318,7 +318,7 @@ When live cluster access is unavailable for inventory or action item verificatio
 ### Step 2c: Quantify User-Facing Impact
 
 Before diving into root cause, establish the impact magnitude from available sources:
-- **From metrics (query):** HTTP 5xx error count/rate at the load balancer or ingress, SLI degradation (latency, availability), affected endpoint paths.
+- **From metrics (query):** HTTP 5xx **and 4xx** error count/rate at the load balancer or ingress (a persistent per-user failure is often a **404 for a not-yet-provisioned resource**, not a 5xx), SLI degradation (latency, availability), affected endpoint paths.
 - **From alerts (check):** If an SLO burn rate alert fired for this service in the time
   window, note the alert name, burn rate value, and error budget remaining. This provides
   severity context before the deep dive. Check via `list_alert_policies` (Tier 1) or
@@ -327,6 +327,8 @@ Before diving into root cause, establish the impact magnitude from available sou
 - **If neither is available:** state "user-facing impact not quantified" and proceed. Do not estimate.
 
 This frames severity before the deep dive — a 1,100-error incident gets different treatment than a 5-error incident.
+
+**Clean 5xx/ERROR sweep ≠ backend healthy.** `severity>=ERROR`/`status>=500` both exclude **4xx**; a persistent per-user failure with a clean 5xx sweep is often a **404 for a not-yet-provisioned resource**, visible only at the gateway/access-log layer or an app-level status field. See `references/4xx-sweep-blind-spot.md`.
 
 ### Step 2d: Baseline-First Gate — Skip Baseline Signals Early
 

--- a/skills/incident-analysis/references/4xx-sweep-blind-spot.md
+++ b/skills/incident-analysis/references/4xx-sweep-blind-spot.md
@@ -1,0 +1,16 @@
+# 4xx / Empty-Resource Blind Spot
+
+A `severity>=ERROR` or `status>=500` filter structurally excludes **4xx**. A **404 for a
+resource that does not exist yet** (e.g. a feature flag enabled before its backing record is
+provisioned) is a client-error the app does not log at ERROR severity: it surfaces at the
+**gateway / access-log layer** (reverse proxy, ingress, API gateway) or in an app-level status
+field (e.g. `jsonPayload.response_status`), not the app's exception stream.
+
+**Do not equate a clean 5xx/ERROR sweep with "backend healthy."** When the sweep is clean but the
+user still fails reproducibly, treat "no 5xx" as a positive clue: drop the severity floor, widen
+to **4xx**, and query the gateway access logs + the app-level status field **before** concluding
+"client-side." The trap is naming the blind spot ("can't see 4xx / access logs not captured") and
+stopping, rather than pivoting to the layer that holds it.
+
+Applies at Step 2c (Quantify User-Facing Impact) and any point where a "backend clean" conclusion
+is about to be drawn from an ERROR/5xx-only query.


### PR DESCRIPTION
## Why

An incident investigation (healthcare SaaS, 2026-07) first concluded "backend clean → client-side" for a mobile "overview" screen that failed to load — when the real cause was a **404** for users whose feature flag was enabled but whose backing record had never been provisioned. The 404 was invisible to `severity>=ERROR` / `status>=500` sweeps and surfaced only at the **API-gateway layer** via a `response_status` field. This change encodes that lesson so the next investigation doesn't repeat it.

## Changes (4 files)

- **`skills/incident-analysis/SKILL.md`** (Step 2c): impact-metrics query now covers **5xx and 4xx**; a one-line "Clean 5xx/ERROR sweep ≠ backend healthy" callout links to the new reference.
- **`skills/incident-analysis/references/4xx-sweep-blind-spot.md`** (new): full guidance, extracted to keep `SKILL.md` under the 11,500-word CI guard.
- **`.claude/knowledge/no-resource-404-invisible-to-error-sweeps.md`** (new) + `index.md`: the gotcha as committed team knowledge (anonymized — no client/service/env identifiers).

## Verification

- `tests/test-incident-analysis-content.sh` — **242/242 pass**, word guard **11,434 / 11,500** (extraction restored headroom).
- `scripts/knowledge-validate.sh` exit 0; `tests/test-knowledge.sh` pass.
- Grep-scanned all changed files for client/service/env identifiers — **clean**.

## Review history

Opened, reviewed by a code-review subagent (verdict: ready to merge; 3 minor items applied). A follow-up review flagged (a) thin word-guard headroom → **fixed** by extracting to `references/`, and (b) real internal service/env/flag names in a public repo → **fixed** by anonymizing the case study to "healthcare SaaS." Two other flagged items (PR already merged; working tree mid-rollback) did not reproduce — PR was OPEN and the tree was clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)