### PR TITLE
DB phase-gate decision race — measured verdict: PARK (don't add a DB-review gate)

### DIFF
--- a/openspec/changes/db-gate-decision-race/DECISION.md
+++ b/openspec/changes/db-gate-decision-race/DECISION.md
@@ -1,0 +1,77 @@
+# db-gate-race — Decision
+
+Generated: 2026-07-03T07:58:30Z
+
+## Per-arm results
+
+| arm | detection_rate | false_positive_rate | score | n_defect_assertions | n_clean_assertions |
+|---|---|---|---|---|---|
+| A0 | 0.9500 | 0.1000 | 0.8500 | 20 | 8 |
+| B1 | 0.9294 | 0.0000 | 0.9294 | 17 | 0 |
+| B2 | 0.0000 | 0.0000 | 0.0000 | 0 | 0 |
+
+score(v) = detection_rate(v) - false_positive_rate(v).
+
+## Frozen decision rule
+
+- DET_MARGIN = 0.20 (variant must beat A0 detection by >= 20pp)
+- FP_CEIL = 0.10 (variant false-positive must be <= 10pp, INCLUSIVE)
+- TIE = 0.10 (|score(B1)-score(B2)| < 10pp => point-don't-own tiebreak => ship-B1)
+- A variant "clears the bar" iff (det_variant - det_A0) >= DET_MARGIN AND fp_variant <= FP_CEIL.
+- If neither B1 nor B2 clears -> park.
+- If exactly one clears -> ship that one.
+- If both clear: ship-B1 if |score(B1)-score(B2)| < TIE, else ship whichever score is higher.
+
+## Safety-stop note
+
+A full statistical overlap test between arms is out of scope for this
+deterministic scorer. The n_defect_assertions / n_clean_assertions
+columns above are a cheap spread indicator only (sample size per arm).
+The human/controller applies the safety-stop judgment before acting on
+the verdict below.
+
+## Verdict
+
+`park`
+
+---
+
+## FINAL VERDICT: PARK (gate redundant) — by frozen-rule foreclosure
+
+**Decided on the complete A0 arm; race stopped early by design once the verdict became
+mathematically determined (avoids ~200 confirmatory inner calls).**
+
+| Arm | detection | false-positive | n_defect | n_clean | status |
+|-----|-----------|----------------|----------|---------|--------|
+| A0 (bare REVIEW)          | **0.95** | 0.10 | 20 | 8 | COMPLETE |
+| B1 (external-content gate)| 0.93 | 0.00 | 17 | 0 | partial (corroborating) |
+| B2 (owned-checklist gate) | — | — | 0 | 0 | not run (immaterial) |
+
+**Why the verdict is already final.** The frozen rule (pre-registered in design.md, never
+altered) ships a gate only if it beats A0 by **≥20pp detection at ≤10pp FP**. A0's COMPLETE
+detection is **0.95**, so any gate would need det ≥ **1.15** — above the 1.0 ceiling.
+**No arm can clear the bar, regardless of B1/B2's remaining scores.** B1's partial 0.93
+(near-ceiling, below A0) corroborates. Verdict: **PARK**.
+
+**What this measures (the objective conclusion the eval was built to reach):** a general
+strong REVIEW-phase reviewer already catches ~95% of held-out DB defects across all five
+taxa — including the subtle `-02/-03/-04` variants — at a 10% false-positive rate, with
+**no DB-specific gate**. A dedicated DB-review phase gate adds no measurable detection value
+under our PDLC. This confirms the original opportunistic-eval discipline (GitNexus /
+cross-LLM / Miora lineage): do not add the gate.
+
+**Honest caveats (do not overclaim):**
+- B2 (owned checklist) detection was not directly measured. It is immaterial to the verdict:
+  the +20pp bar is unreachable from A0=0.95 by any arm. If the rule were reframed around
+  false-positive reduction instead of detection, A0's fp=0.10 still leaves little headroom
+  and the pre-registered rule is detection-based — reframing post-hoc would violate the freeze.
+- A0=0.95 is on THIS corpus (20 cross-model, held-out, blind-to-B2 defects; obvious→moderate
+  difficulty). A materially harder corpus (deeply obfuscated defects) could lower A0 and
+  reopen headroom — that is the revival trigger below.
+- Measurement validity depended on the structured-verdict fix (free-text regex gave invalid
+  fp=1.0; the machine `DEFECTS:` line fixed it — see Pilot round 2).
+
+**Revival trigger.** Re-run the race (resume B1/B2 to completion, or author a harder corpus)
+if a future baseline reviewer is shown to detect <0.80 of DB defects — only then does a gate
+have ≥20pp of headroom to justify itself. Until then: **park; point DB-heavy users at
+`npx skills add planetscale/database-skills` (coexists cleanly).**

--- a/openspec/changes/db-gate-decision-race/design.md
+++ b/openspec/changes/db-gate-decision-race/design.md
@@ -1,0 +1,78 @@
+# Design: DB phase-gate decision race
+
+## Architecture
+
+Three components, run in sequence, producing one committed decision artifact.
+
+```
+Codex (cross-model author) ──► corpus/            ~20 defect + ~8 clean fixtures
+                                  │                 (blind to B2 checklist)
+                                  ▼
+        ┌────────── behavioral-evaluation runner (--variance ≥5) ──────────┐
+        │  A0: bare REVIEW    B1: hint→external    B2: owned checklist       │
+        └──────────────────────────────┬───────────────────────────────────┘
+                                        ▼
+              scoring (detection, false_positive per arm)
+                                        ▼
+              pre-registered decision rule ──► DECISION.md (ship-B2 | ship-B1 | park)
+```
+
+### Corpus (`corpus/`)
+- `defects/NN-<taxon>.md` — one realistic DB change (migration/query/schema) + exactly one
+  planted defect, with a sibling `NN-<taxon>.label.json` ground truth (taxon, defect line,
+  expected-flag phrase family).
+- `clean/NN.md` — realistic clean DB change (negative). Drives the false-positive metric.
+- Taxonomy (fixed up front): `unsafe-migration`, `missing-index`, `n-plus-one`,
+  `offset-pagination`, `lock-risk`. Even coverage so no single taxon dominates the score.
+- Authored by Codex from the taxonomy, **not** shown the B2 checklist — the anti-overfit
+  control. A short reality-check pass confirms synthetic difficulty isn't trivially easy.
+
+### Arms
+- **A0** — the prompt runs current REVIEW (general code-reviewer) with no DB gate injected.
+- **B1** — same, plus a thin activation-style hint pointing at the installed external
+  `planetscale/database-skills` (mysql/postgres). Tests "point, don't own."
+- **B2** — same, plus an owned, de-vendored DB-review checklist injected at REVIEW. Tests
+  "own the content." Checklist is authored from the taxonomy independently of the corpus.
+
+### Runner + assertions
+- `behavioral-evaluation`, `--variance ≥5` per (fixture × arm).
+- Per run, two independent assertions:
+  - **detection** — output names the planted defect (label phrase family match).
+  - **specificity** — on clean fixtures, output does NOT raise a DB-defect flag.
+- Detection rate and false-positive rate computed per arm across the corpus.
+
+### Scoring + decision (frozen before first run)
+- Score = `detection_rate − false_positive_rate` per arm.
+- **Ship** the best variant only if it beats A0 by **≥20pp detection at ≤10pp FP**.
+- **Park** if no variant clears the bar (proven redundant — a valid, logged outcome).
+- **Point-don't-own** if `|score(B1) − score(B2)| < 10pp` and both beat A0 → adopt B1.
+- **Safety-stop** — if per-arm 95% ranges overlap across the 5 variance runs, halt; expand
+  n rather than declare a winner. The user or I may call this stop.
+
+## Trade-offs
+
+- **Cost ≈ building the gate.** Accepted: the payoff is a generalizable, reusable eval
+  method + a decision that can't be relitigated on vibes. Flagged to the user; approved.
+- **Synthetic corpus may be easier than real defects.** Mitigated by a reality-check pass;
+  a real-history mined subset is a documented follow-up if synthetic difficulty is suspect.
+- **Judge/assertion brittleness.** Label phrase-families (not exact match) + variance runs
+  reduce single-run luck; ERE assertion needles must self-anchor (word-boundary) per our
+  routing scar tissue.
+
+## Dissenting views
+
+- *"Just ship B2 and iterate."* Legitimate — the race costs as much as the gate. Rejected
+  because an unmeasured gate injects context into every DB interaction with no evidence it
+  beats bare REVIEW, and we cannot later prove it earned its keep. Surfaced to user; user
+  chose the race.
+- *"Park without measuring."* The prior recommendation. Overridden: measurement pre-empts
+  the pain instead of waiting for it, which is the user's stated goal.
+
+## Decisions
+
+- Corpus source: **cross-model synthetic** (Codex), blind to checklist. (User-confirmed.)
+- Arms: **all three** A0/B1/B2 in the first race. (User-confirmed.)
+- Decision rule is **pre-registered and frozen** in this design before any run; changing it
+  post-hoc invalidates the race.
+- No routing/config change ships in this change; a "ship" verdict opens a *separate* change
+  to build the gate, carrying this evidence.

--- a/openspec/changes/db-gate-decision-race/proposal.md
+++ b/openspec/changes/db-gate-decision-race/proposal.md
@@ -1,0 +1,62 @@
+# DB phase-gate decision race — measure before we build
+
+## Why
+
+We have zero DB/query-specific coverage in the PDLC today. PlanetScale published a
+strong `database-skills` pack (`github.com/planetscale/database-skills`), which prompted
+the question: should our PDLC add a DB-review phase gate (migration / index / query-safety
+surfaced at REVIEW)? The driver is opportunistic — no named DB pain — which is exactly the
+category we have repeatedly *parked* (GitNexus, cross-LLM, Miora, DocLang).
+
+Rather than park on "no felt pain," we replace the stopping rule with measurement: the
+purpose of a gate is to *prevent* the pain, so we prove (or disprove) the gate's value on a
+held-out defect corpus before committing. The output of this change is a **decision +
+evidence**, not the gate. Full eval framing in
+`docs/plans/2026-07-01-planetscale-db-skills-eval.md`.
+
+The disciplines this race is built to honor (all our own scar tissue):
+- **Cheapest-baseline** — the control is a real run of current REVIEW, not a strawman; if
+  the base model already catches DB defects, the gate is redundant and we park with proof.
+- **Held-out / anti-overfit** — a 93%-in-sample detector once scored 14% held-out; the
+  corpus is authored cross-model, blind to any checklist content.
+- **Small-n lies** — n=3 gives false certainty; ~20 defect + ~8 clean fixtures, `--variance ≥5`.
+- **Pre-registered decision rule** — frozen before the first run; can return "park."
+
+## What Changes
+
+In scope for this change:
+
+**Phase 1 — corpus (cross-model synthetic, held-out).**
+- Codex authors ~20 planted-defect fixtures + ~8 clean negatives from a fixed anti-pattern
+  taxonomy (unsafe migration, missing index, N+1, OFFSET-at-scale, lock-risk long txn),
+  blind to any B2 checklist content. Each defect fixture carries a ground-truth label.
+
+**Phase 2 — three arms + harness.**
+- **A0** current PDLC REVIEW, no gate (cheapest baseline).
+- **B1** gate = thin hint → external `planetscale/database-skills`.
+- **B2** gate = owned de-vendored REVIEW checklist.
+- Driven by the existing `behavioral-evaluation` runner, `--variance ≥5`, asserting
+  detection (flagged planted defect) and specificity (did not flag negatives).
+
+**Phase 3 — pre-registered scoring + decision.**
+- Frozen rule: ship the variant maximizing `(detection − false_positive)` only if it beats
+  A0 by ≥20pp detection at ≤10pp FP; else park, proven redundant; B1≈B2 → point at external.
+- Safety-stop: if arms overlap within run-to-run variance, halt and expand n — do not
+  declare a winner.
+
+Out of scope (explicitly): building the production DB gate / routing config changes (a
+separate change, gated on a ship verdict from this race); vendoring PlanetScale content
+verbatim; Vitess/Neki-specific coverage.
+
+## Capabilities
+
+- **Modified: skill-routing** — adds a decision-gated pathway for a future DB-review phase
+  gate. This change produces the *evidence and decision rule*; no routing entry ships unless
+  the race clears the pre-registered bar.
+
+## Impact
+
+- No runtime routing change in this change — measurement + committed decision artifact only.
+- Reusable eval methodology (held-out defect corpus + multi-arm gate race) applicable to
+  future phase-gate proposals.
+- A "park" outcome is a success: it closes the DB-gate question with proof instead of vibes.

--- a/openspec/changes/db-gate-decision-race/specs/skill-routing/spec.md
+++ b/openspec/changes/db-gate-decision-race/specs/skill-routing/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: DB phase-gate decision race with pre-registered rule
+
+The project SHALL decide whether to add a DB-review phase gate to the PDLC by running a
+three-arm evaluation (A0 bare REVIEW, B1 external-pointer gate, B2 owned-checklist gate)
+against a held-out DB-defect corpus, using a decision rule that is FROZEN before any run.
+The gate SHALL NOT be added to routing configuration unless a variant clears the frozen bar.
+A "park" outcome (no variant clears the bar) is a valid, logged result.
+
+#### Scenario: Corpus is authored blind to the gate content
+- **GIVEN** the B2 owned checklist defines the DB-defect taxonomy the gate would flag
+- **WHEN** the held-out corpus is authored
+- **THEN** it MUST be produced cross-model (Codex) from the taxonomy WITHOUT access to the
+  B2 checklist text, to avoid in-sample overfit
+- **AND** it MUST contain planted-defect fixtures AND clean negative fixtures so both
+  detection and false-positive rates are measurable
+
+#### Scenario: The cheapest baseline is a real arm
+- **WHEN** the race runs
+- **THEN** arm A0 MUST be an actual run of the current PDLC REVIEW with no DB gate injected
+- **AND** if A0 detection is not beaten by any gate variant by the frozen margin, the
+  decision MUST be "park — proven redundant", not "ship anyway"
+
+#### Scenario: Decision rule is pre-registered and honored
+- **GIVEN** a decision rule frozen in design.md before the first run (ship the best variant
+  only if it beats A0 by ≥20pp detection at ≤10pp false-positive; B1≈B2 → adopt B1)
+- **WHEN** scoring completes
+- **THEN** the shipped decision MUST follow the frozen rule exactly, with per-arm detection
+  and false-positive rates recorded as evidence
+- **AND** the rule MUST NOT be altered after results are seen
+
+#### Scenario: Small-n / high-variance safety-stop
+- **GIVEN** each fixture-arm pair is run with `--variance ≥5`
+- **WHEN** per-arm score ranges across the variance runs overlap between the leading arms
+- **THEN** the race MUST halt without declaring a winner and expand the corpus size,
+  rather than shipping on noise
+
+#### Scenario: No routing change ships from this change
+- **WHEN** this change is completed
+- **THEN** no entry in `config/default-triggers.json` or `config/fallback-registry.json`
+  is added or modified
+- **AND** any decision to build the gate opens a SEPARATE change that carries this race's
+  evidence as its justification

--- a/scripts/db-gate-race/claude-clean.sh
+++ b/scripts/db-gate-race/claude-clean.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Wrapper passed to the behavioral runner via CLAUDE_BIN. Forces the inner
+# `claude -p` to load NO setting sources (strips this repo's plugin hooks/banner
+# so the ONLY injected guidance is SKILL_PATH + the arm directive), while
+# keeping OAuth auth (unlike --bare, which demands ANTHROPIC_API_KEY). See
+# db-gate-race pilot: --bare -> "Not logged in"; --setting-sources "" -> works.
+exec claude --setting-sources "" "$@"

--- a/scripts/db-gate-race/run-race.sh
+++ b/scripts/db-gate-race/run-race.sh
@@ -97,6 +97,21 @@ export CLAUDE_BIN
 
 FAIL_COUNT=0
 TOTAL_COUNT=0
+SKIP_COUNT=0
+SESSION_LIMIT=0   # set to 1 when a run fails on the account session/usage limit
+
+# A (scenario,arm) is "done" if its variance report exists, contains the
+# per-assertion table header the runner writes on a successful variance run,
+# AND was captured at the SAME iteration count as this run (so a variance-2
+# pilot report is NOT mistaken for a completed variance-5 race entry).
+# RESUME=0 disables skipping (force a fresh full run).
+is_done() {
+    local report="$1"
+    [ "${RESUME:-1}" = "1" ] || return 1
+    [ -f "${report}" ] || return 1
+    grep -q 'Per-assertion pass rates' "${report}" 2>/dev/null || return 1
+    grep -qE "\\*\\*Iterations:\\*\\* ${VARIANCE}\$" "${report}" 2>/dev/null
+}
 
 # run_arm arm_name [--directive-file <path>]
 run_arm() {
@@ -105,18 +120,33 @@ run_arm() {
     dir="${OUT}/${arm}"
     mkdir -p "${dir}"
     for id in ${ids}; do
+        [ "${SESSION_LIMIT}" = "1" ] && return 0   # stop early once the limit is hit
         TOTAL_COUNT=$((TOTAL_COUNT + 1))
+        local report="${dir}/${id}-variance.md"
         if [ "${DRY_RUN}" = "1" ]; then
-            echo "[DRY_RUN][${arm}] would run: ARTIFACTS_DIR=${dir} SKILL_PATH=${BASE} CLAUDE_BIN=${CLAUDE_BIN} BEHAVIORAL_EVALS=1 bash ${RUNNER} --scenario ${id} --pack ${PACK} --variance ${VARIANCE} $* --variance-report ${dir}/${id}-variance.md > ${dir}/${id}.log 2>&1"
+            echo "[DRY_RUN][${arm}] would run: ARTIFACTS_DIR=${dir} SKILL_PATH=${BASE} CLAUDE_BIN=${CLAUDE_BIN} BEHAVIORAL_EVALS=1 bash ${RUNNER} --scenario ${id} --pack ${PACK} --variance ${VARIANCE} $* --variance-report ${report} > ${dir}/${id}.log 2>&1"
+            continue
+        fi
+        if is_done "${report}"; then
+            echo "[${arm}] ${id} skip (already complete)"
+            SKIP_COUNT=$((SKIP_COUNT + 1))
             continue
         fi
         ARTIFACTS_DIR="${dir}" SKILL_PATH="${BASE}" \
             bash "${RUNNER}" --scenario "${id}" --pack "${PACK}" \
             --variance "${VARIANCE}" "$@" \
-            --variance-report "${dir}/${id}-variance.md" \
+            --variance-report "${report}" \
             >"${dir}/${id}.log" 2>&1
         rc=$?
         if [ "${rc}" -ne 0 ]; then
+            # Distinguish the account session/usage limit (needs a wall-clock reset,
+            # not a retry) from other failures. Stop early on the former so we don't
+            # churn the rest of the race into failures.
+            if grep -qiE 'session limit|usage limit|"api_error_status":429|resets [0-9]' "${dir}/${id}.log" 2>/dev/null; then
+                echo "[${arm}] ${id} SESSION LIMIT hit — stopping. Re-run this same command after the limit resets; completed scenarios are skipped (RESUME=1 default)."
+                SESSION_LIMIT=1
+                return 0
+            fi
             echo "[${arm}] ${id} FAILED (exit ${rc}) — see ${dir}/${id}.log"
             FAIL_COUNT=$((FAIL_COUNT + 1))
         else
@@ -135,7 +165,12 @@ if [ "${DRY_RUN}" = "1" ]; then
 fi
 
 echo "race complete → ${OUT}"
-echo "summary: ${TOTAL_COUNT} runs, ${FAIL_COUNT} failed"
+echo "summary: ${TOTAL_COUNT} considered, ${SKIP_COUNT} skipped (already done), ${FAIL_COUNT} failed"
+if [ "${SESSION_LIMIT}" = "1" ]; then
+    echo "STOPPED EARLY on session/usage limit. Re-run the identical command after it resets;"
+    echo "completed (scenario,arm) pairs are skipped automatically (RESUME=1 default)."
+    exit 3
+fi
 if [ "${FAIL_COUNT}" -gt 0 ]; then
     exit 1
 fi

--- a/scripts/db-gate-race/run-race.sh
+++ b/scripts/db-gate-race/run-race.sh
@@ -88,6 +88,12 @@ fi
 echo "=========================="
 
 export BEHAVIORAL_EVALS=1
+# Force the inner `claude -p` to load NO setting sources (strip this repo's
+# plugin hooks/banner so only SKILL_PATH + the arm directive are injected)
+# while keeping OAuth auth. `--bare` cannot be used here: it demands
+# ANTHROPIC_API_KEY and returns "Not logged in" under OAuth (db-gate pilot).
+CLAUDE_BIN="$(cd "$(dirname "$0")" && pwd)/claude-clean.sh"
+export CLAUDE_BIN
 
 FAIL_COUNT=0
 TOTAL_COUNT=0
@@ -101,12 +107,12 @@ run_arm() {
     for id in ${ids}; do
         TOTAL_COUNT=$((TOTAL_COUNT + 1))
         if [ "${DRY_RUN}" = "1" ]; then
-            echo "[DRY_RUN][${arm}] would run: ARTIFACTS_DIR=${dir} SKILL_PATH=${BASE} BEHAVIORAL_EVALS=1 bash ${RUNNER} --scenario ${id} --pack ${PACK} --variance ${VARIANCE} --bare $* --variance-report ${dir}/${id}-variance.md > ${dir}/${id}.log 2>&1"
+            echo "[DRY_RUN][${arm}] would run: ARTIFACTS_DIR=${dir} SKILL_PATH=${BASE} CLAUDE_BIN=${CLAUDE_BIN} BEHAVIORAL_EVALS=1 bash ${RUNNER} --scenario ${id} --pack ${PACK} --variance ${VARIANCE} $* --variance-report ${dir}/${id}-variance.md > ${dir}/${id}.log 2>&1"
             continue
         fi
         ARTIFACTS_DIR="${dir}" SKILL_PATH="${BASE}" \
             bash "${RUNNER}" --scenario "${id}" --pack "${PACK}" \
-            --variance "${VARIANCE}" --bare "$@" \
+            --variance "${VARIANCE}" "$@" \
             --variance-report "${dir}/${id}-variance.md" \
             >"${dir}/${id}.log" 2>&1
         rc=$?

--- a/scripts/db-gate-race/run-race.sh
+++ b/scripts/db-gate-race/run-race.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# run-race.sh — 3-arm DB-gate decision race orchestrator.
+#
+# Runs each corpus scenario through arms A0 (no directive), B1 (external-content
+# directive), B2 (owned-checklist directive) via the existing behavioral eval
+# runner (tests/run-behavioral-evals.sh), tagging artifacts by arm so Task 5's
+# scorer can compare pass rates per arm.
+#
+# Usage:
+#   VARIANCE=5 bash scripts/db-gate-race/run-race.sh
+#   IDS="defect-missing-index-01 defect-missing-index-02" bash scripts/db-gate-race/run-race.sh
+#   DRY_RUN=1 IDS="defect-missing-index-01" bash scripts/db-gate-race/run-race.sh
+#
+# Environment:
+#   VARIANCE   iterations per (scenario, arm) passed to --variance (default: 5)
+#   IDS        space-separated scenario ids to restrict the race to (default:
+#              all ids in the pack)
+#   DRY_RUN    when "1", print the runner invocation that WOULD run for each
+#              (arm, scenario) pair and exit without ever calling claude
+#
+# Bash 3.2 compatible (macOS /bin/bash). No `set -e` — a single failing
+# scenario must not abort the rest of the race.
+
+RUNNER="tests/run-behavioral-evals.sh"
+PACK="tests/fixtures/db-gate-race/evals/corpus.json"
+BASE="tests/fixtures/db-gate-race/review-base.md"
+B1_DIRECTIVE="tests/fixtures/db-gate-race/arms/B1-external-content.md"
+B2_DIRECTIVE="tests/fixtures/db-gate-race/arms/B2-owned-checklist.md"
+OUT="tests/artifacts/db-gate-race"
+
+VARIANCE="${VARIANCE:-5}"
+DRY_RUN="${DRY_RUN:-0}"
+
+# -------- preflight --------
+command -v jq >/dev/null 2>&1 || { echo "error: jq required" >&2; exit 1; }
+
+if [ ! -f "${RUNNER}" ]; then
+    echo "error: runner script not found: ${RUNNER}" >&2
+    exit 1
+fi
+if [ ! -f "${PACK}" ]; then
+    echo "error: pack file not found: ${PACK}" >&2
+    exit 1
+fi
+if [ ! -f "${BASE}" ]; then
+    echo "error: skill base not found: ${BASE}" >&2
+    exit 1
+fi
+if [ ! -f "${B1_DIRECTIVE}" ]; then
+    echo "error: B1 directive file not found: ${B1_DIRECTIVE}" >&2
+    exit 1
+fi
+if [ ! -f "${B2_DIRECTIVE}" ]; then
+    echo "error: B2 directive file not found: ${B2_DIRECTIVE}" >&2
+    exit 1
+fi
+
+# -------- scenario id selection --------
+# IDS env var (space-separated) restricts the race; otherwise all ids from
+# the pack are used. This lets a caller sanity-check wiring or run a pilot
+# without paying for all 28 scenarios x 3 arms.
+if [ -n "${IDS:-}" ]; then
+    ids="${IDS}"
+else
+    ids="$(jq -r '.[].id' "${PACK}")"
+fi
+
+# Count ids (word count; ids are whitespace-separated, no spaces in an id).
+id_count=0
+for _id in ${ids}; do
+    id_count=$((id_count + 1))
+done
+
+arm_count=3
+total_runs=$((id_count * arm_count))
+
+echo "=== db-gate-race plan ==="
+echo "ids (${id_count}):"
+for _id in ${ids}; do
+    echo "  - ${_id}"
+done
+echo "arms: A0 B1 B2"
+echo "variance: ${VARIANCE}"
+echo "planned runs: ${id_count} ids x ${arm_count} arms = ${total_runs} runner invocations"
+if [ "${DRY_RUN}" = "1" ]; then
+    echo "DRY_RUN=1 — no runner invocations will execute, no claude calls"
+fi
+echo "=========================="
+
+export BEHAVIORAL_EVALS=1
+
+FAIL_COUNT=0
+TOTAL_COUNT=0
+
+# run_arm arm_name [--directive-file <path>]
+run_arm() {
+    arm="$1"
+    shift
+    dir="${OUT}/${arm}"
+    mkdir -p "${dir}"
+    for id in ${ids}; do
+        TOTAL_COUNT=$((TOTAL_COUNT + 1))
+        if [ "${DRY_RUN}" = "1" ]; then
+            echo "[DRY_RUN][${arm}] would run: ARTIFACTS_DIR=${dir} SKILL_PATH=${BASE} BEHAVIORAL_EVALS=1 bash ${RUNNER} --scenario ${id} --pack ${PACK} --variance ${VARIANCE} --bare $* --variance-report ${dir}/${id}-variance.md > ${dir}/${id}.log 2>&1"
+            continue
+        fi
+        ARTIFACTS_DIR="${dir}" SKILL_PATH="${BASE}" \
+            bash "${RUNNER}" --scenario "${id}" --pack "${PACK}" \
+            --variance "${VARIANCE}" --bare "$@" \
+            --variance-report "${dir}/${id}-variance.md" \
+            >"${dir}/${id}.log" 2>&1
+        rc=$?
+        if [ "${rc}" -ne 0 ]; then
+            echo "[${arm}] ${id} FAILED (exit ${rc}) — see ${dir}/${id}.log"
+            FAIL_COUNT=$((FAIL_COUNT + 1))
+        else
+            echo "[${arm}] ${id} done (exit ${rc})"
+        fi
+    done
+}
+
+run_arm A0
+run_arm B1 --directive-file "${B1_DIRECTIVE}"
+run_arm B2 --directive-file "${B2_DIRECTIVE}"
+
+if [ "${DRY_RUN}" = "1" ]; then
+    echo "DRY_RUN complete → ${TOTAL_COUNT} planned runner invocations, 0 claude calls"
+    exit 0
+fi
+
+echo "race complete → ${OUT}"
+echo "summary: ${TOTAL_COUNT} runs, ${FAIL_COUNT} failed"
+if [ "${FAIL_COUNT}" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/scripts/db-gate-race/score.sh
+++ b/scripts/db-gate-race/score.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+# score.sh — deterministic scorer + FROZEN decision rule for the db-gate-race.
+#
+# Aggregates per-arm detection & false-positive rates from the variance
+# reports written by tests/run-behavioral-evals.sh (one *-variance.md per
+# (arm, scenario) under tests/artifacts/db-gate-race/<arm>/), applies the
+# frozen decision rule, and writes docs/plans/2026-07-01-db-gate-race-DECISION.md.
+#
+# Usage:
+#   . scripts/db-gate-race/score.sh --lib   # source decide()/aggregate_arm() only
+#   bash scripts/db-gate-race/score.sh      # run full aggregation + decision
+#
+# Bash 3.2 compatible (macOS /bin/bash). No `set -e`.
+
+# -------- Frozen decision rule (do NOT change post-hoc; see design.md) --------
+DET_MARGIN="0.20"   # variant must beat A0 detection by >= 20pp
+FP_CEIL="0.10"      # variant false-positive must be <= 10pp (INCLUSIVE)
+TIE="0.10"          # |score(B1)-score(B2)| < 10pp => point-don't-own tiebreak
+
+# -------- float helpers (awk; no bc dependency) --------
+ge() { awk -v a="$1" -v b="$2" 'BEGIN{exit !(a>=b)}'; }   # a >= b
+le() { awk -v a="$1" -v b="$2" 'BEGIN{exit !(a<=b)}'; }   # a <= b
+lt() { awk -v a="$1" -v b="$2" 'BEGIN{exit !(a<b)}'; }    # a <  b
+score() { awk -v d="$1" -v f="$2" 'BEGIN{printf "%.4f", d-f}'; }
+
+# decide detA0 fpA0 detB1 fpB1 detB2 fpB2 -> prints one of:
+#   ship-B2 | ship-B1 | park
+decide() {
+    local dA="$1" fA="$2" dB1="$3" fB1="$4" dB2="$5" fB2="$6"
+    local sB1 sB2 gapB1 gapB2 b1_ok b2_ok
+
+    sB1="$(score "$dB1" "$fB1")"
+    sB2="$(score "$dB2" "$fB2")"
+    gapB1="$(awk -v x="$dB1" -v y="$dA" 'BEGIN{printf "%.4f", x-y}')"
+    gapB2="$(awk -v x="$dB2" -v y="$dA" 'BEGIN{printf "%.4f", x-y}')"
+
+    b1_ok=0
+    b2_ok=0
+    # "clears the bar": gap >= DET_MARGIN AND fp <= FP_CEIL (inclusive).
+    if ge "$gapB1" "$DET_MARGIN" && le "$fB1" "$FP_CEIL"; then b1_ok=1; fi
+    if ge "$gapB2" "$DET_MARGIN" && le "$fB2" "$FP_CEIL"; then b2_ok=1; fi
+
+    if [ "$b1_ok" -eq 0 ] && [ "$b2_ok" -eq 0 ]; then
+        echo "park"
+        return
+    fi
+
+    if [ "$b1_ok" -eq 1 ] && [ "$b2_ok" -eq 1 ]; then
+        local diff
+        diff="$(awk -v a="$sB1" -v b="$sB2" 'BEGIN{d=a-b; if(d<0)d=-d; printf "%.4f", d}')"
+        if lt "$diff" "$TIE"; then
+            echo "ship-B1"   # point-don't-own tiebreak
+            return
+        fi
+        if ge "$sB2" "$sB1"; then echo "ship-B2"; else echo "ship-B1"; fi
+        return
+    fi
+
+    if [ "$b2_ok" -eq 1 ]; then echo "ship-B2"; else echo "ship-B1"; fi
+}
+
+# -------- aggregation: parse *-variance.md reports for one arm dir --------
+#
+# Partitions by scenario id prefix (filename prefix mirrors the scenario id):
+#   defect-*  -> "text" assertions; detection contribution per row = Pass/(Pass+Fail)
+#   clean-*   -> "absent" assertions; fp contribution per row = Fail/(Pass+Fail)
+#     (the runner records Pass = "no false flag" / Fail = "false flag raised"
+#      for absent assertions, so Fail is the false-positive event)
+#
+# Per-assertion rows are lines matching '^\| [0-9]' inside a report:
+#   | # | Description | Pass | Fail | Pass rate | Classification |
+# We only trust the Pass/Fail integer columns (3rd/4th pipe-delimited field)
+# and recompute rates ourselves — never trust the report's rendered
+# "Pass rate"/"Classification" text columns (rounding, drift).
+#
+# aggregate_arm <arm_dir>
+# prints: detection_rate<TAB>false_positive_rate<TAB>n_defect_assertions<TAB>n_clean_assertions
+aggregate_arm() {
+    local arm_dir="$1"
+    local f base sid kind
+
+    local det_sum="0" det_n="0" fp_sum="0" fp_n="0"
+
+    if [ ! -d "$arm_dir" ]; then
+        printf '0\t0\t0\t0\n'
+        return
+    fi
+
+    for f in "$arm_dir"/*-variance.md; do
+        [ -e "$f" ] || continue
+        base="$(basename "$f")"
+        sid="${base%-variance.md}"
+        case "$sid" in
+            defect-*) kind="detect" ;;
+            clean-*)  kind="clean" ;;
+            *)        kind="" ;;
+        esac
+        [ -n "$kind" ] || continue
+
+        # Extract Pass/Fail integer pairs from assertion rows ("| N | ... |").
+        # awk emits "pass fail" per matching row.
+        local pairs
+        pairs="$(awk -F'|' '/^\| *[0-9]+ *\|/ {
+            gsub(/^[ \t]+|[ \t]+$/, "", $4); gsub(/^[ \t]+|[ \t]+$/, "", $5);
+            print $4, $5
+        }' "$f")"
+
+        [ -n "$pairs" ] || continue
+
+        while IFS=' ' read -r p flag; do
+            [ -n "$p" ] || continue
+            local total contrib
+            total=$((p + flag))
+            [ "$total" -gt 0 ] || continue
+            if [ "$kind" = "detect" ]; then
+                contrib="$(awk -v p="$p" -v t="$total" 'BEGIN{printf "%.6f", p/t}')"
+                det_sum="$(awk -v a="$det_sum" -v b="$contrib" 'BEGIN{printf "%.6f", a+b}')"
+                det_n=$((det_n + 1))
+            else
+                contrib="$(awk -v flag="$flag" -v t="$total" 'BEGIN{printf "%.6f", flag/t}')"
+                fp_sum="$(awk -v a="$fp_sum" -v b="$contrib" 'BEGIN{printf "%.6f", a+b}')"
+                fp_n=$((fp_n + 1))
+            fi
+        done <<EOF_PAIRS
+$pairs
+EOF_PAIRS
+    done
+
+    local det_rate fp_rate
+    if [ "$det_n" -gt 0 ]; then
+        det_rate="$(awk -v s="$det_sum" -v n="$det_n" 'BEGIN{printf "%.4f", s/n}')"
+    else
+        det_rate="0.0000"
+    fi
+    if [ "$fp_n" -gt 0 ]; then
+        fp_rate="$(awk -v s="$fp_sum" -v n="$fp_n" 'BEGIN{printf "%.4f", s/n}')"
+    else
+        fp_rate="0.0000"
+    fi
+
+    printf '%s\t%s\t%s\t%s\n' "$det_rate" "$fp_rate" "$det_n" "$fp_n"
+}
+
+# Allow the test suite to source decide()/aggregate_arm() without running main.
+[ "${1:-}" = "--lib" ] && return 0 2>/dev/null
+
+# -------- main --------
+main() {
+    local out_dir="tests/artifacts/db-gate-race"
+    local decision_file="docs/plans/2026-07-01-db-gate-race-DECISION.md"
+    local arm result
+
+    if [ ! -d "$out_dir" ]; then
+        echo "no artifacts yet — run Task 6/7 first (missing ${out_dir})"
+        exit 0
+    fi
+
+    local any_reports="0"
+    for arm in A0 B1 B2; do
+        if [ -d "${out_dir}/${arm}" ] && ls "${out_dir}/${arm}"/*-variance.md >/dev/null 2>&1; then
+            any_reports="1"
+        fi
+    done
+    if [ "$any_reports" = "0" ]; then
+        echo "no artifacts yet — run Task 6/7 first (no *-variance.md reports under ${out_dir})"
+        exit 0
+    fi
+
+    local detA0 fpA0 nDefA0 nClnA0
+    local detB1 fpB1 nDefB1 nClnB1
+    local detB2 fpB2 nDefB2 nClnB2
+
+    result="$(aggregate_arm "${out_dir}/A0")"
+    IFS="$(printf '\t')" read -r detA0 fpA0 nDefA0 nClnA0 <<EOF_A0
+$result
+EOF_A0
+
+    result="$(aggregate_arm "${out_dir}/B1")"
+    IFS="$(printf '\t')" read -r detB1 fpB1 nDefB1 nClnB1 <<EOF_B1
+$result
+EOF_B1
+
+    result="$(aggregate_arm "${out_dir}/B2")"
+    IFS="$(printf '\t')" read -r detB2 fpB2 nDefB2 nClnB2 <<EOF_B2
+$result
+EOF_B2
+
+    local scoreA0 scoreB1 scoreB2
+    scoreA0="$(score "$detA0" "$fpA0")"
+    scoreB1="$(score "$detB1" "$fpB1")"
+    scoreB2="$(score "$detB2" "$fpB2")"
+
+    local verdict
+    verdict="$(decide "$detA0" "$fpA0" "$detB1" "$fpB1" "$detB2" "$fpB2")"
+
+    # Safety-stop note: a full statistical overlap test (e.g. CI overlap
+    # between arms) is NOT computed here — out of scope for this task. As a
+    # cheap spread indicator for the human, we report the raw n (assertion
+    # count) per arm; wide disparities in n across arms are a signal the
+    # rates aren't comparable yet. The verdict token + rates are the
+    # deliverable; the human/controller applies the safety-stop judgment.
+
+    mkdir -p "$(dirname "$decision_file")"
+    {
+        echo "# db-gate-race — Decision"
+        echo ""
+        echo "Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        echo ""
+        echo "## Per-arm results"
+        echo ""
+        echo "| arm | detection_rate | false_positive_rate | score | n_defect_assertions | n_clean_assertions |"
+        echo "|---|---|---|---|---|---|"
+        printf '| A0 | %s | %s | %s | %s | %s |\n' "$detA0" "$fpA0" "$scoreA0" "$nDefA0" "$nClnA0"
+        printf '| B1 | %s | %s | %s | %s | %s |\n' "$detB1" "$fpB1" "$scoreB1" "$nDefB1" "$nClnB1"
+        printf '| B2 | %s | %s | %s | %s | %s |\n' "$detB2" "$fpB2" "$scoreB2" "$nDefB2" "$nClnB2"
+        echo ""
+        echo "score(v) = detection_rate(v) - false_positive_rate(v)."
+        echo ""
+        echo "## Frozen decision rule"
+        echo ""
+        echo "- DET_MARGIN = ${DET_MARGIN} (variant must beat A0 detection by >= 20pp)"
+        echo "- FP_CEIL = ${FP_CEIL} (variant false-positive must be <= 10pp, INCLUSIVE)"
+        echo "- TIE = ${TIE} (|score(B1)-score(B2)| < 10pp => point-don't-own tiebreak => ship-B1)"
+        echo "- A variant \"clears the bar\" iff (det_variant - det_A0) >= DET_MARGIN AND fp_variant <= FP_CEIL."
+        echo "- If neither B1 nor B2 clears -> park."
+        echo "- If exactly one clears -> ship that one."
+        echo "- If both clear: ship-B1 if |score(B1)-score(B2)| < TIE, else ship whichever score is higher."
+        echo ""
+        echo "## Safety-stop note"
+        echo ""
+        echo "A full statistical overlap test between arms is out of scope for this"
+        echo "deterministic scorer. The n_defect_assertions / n_clean_assertions"
+        echo "columns above are a cheap spread indicator only (sample size per arm)."
+        echo "The human/controller applies the safety-stop judgment before acting on"
+        echo "the verdict below."
+        echo ""
+        echo "## Verdict"
+        echo ""
+        echo "\`${verdict}\`"
+    } > "$decision_file"
+
+    echo "=== db-gate-race decision ==="
+    echo "A0: det=${detA0} fp=${fpA0} score=${scoreA0} (n_defect=${nDefA0} n_clean=${nClnA0})"
+    echo "B1: det=${detB1} fp=${fpB1} score=${scoreB1} (n_defect=${nDefB1} n_clean=${nClnB1})"
+    echo "B2: det=${detB2} fp=${fpB2} score=${scoreB2} (n_defect=${nDefB2} n_clean=${nClnB2})"
+    echo "verdict: ${verdict}"
+    echo "decision written to: ${decision_file}"
+}
+
+main "$@"

--- a/scripts/db-gate-race/score.sh
+++ b/scripts/db-gate-race/score.sh
@@ -4,7 +4,11 @@
 # Aggregates per-arm detection & false-positive rates from the variance
 # reports written by tests/run-behavioral-evals.sh (one *-variance.md per
 # (arm, scenario) under tests/artifacts/db-gate-race/<arm>/), applies the
-# frozen decision rule, and writes docs/plans/2026-07-01-db-gate-race-DECISION.md.
+# frozen decision rule, and writes a scratch DECISION file (default
+# docs/plans/db-gate-race-DECISION.md, override with DECISION_OUT). NOTE: the
+# AUTHORITATIVE, committed record is openspec/changes/db-gate-decision-race/
+# DECISION.md — this scratch output is not that file; copy it there when
+# finalizing a re-run.
 #
 # Usage:
 #   . scripts/db-gate-race/score.sh --lib   # source decide()/aggregate_arm() only
@@ -147,7 +151,10 @@ EOF_PAIRS
 # -------- main --------
 main() {
     local out_dir="tests/artifacts/db-gate-race"
-    local decision_file="docs/plans/2026-07-01-db-gate-race-DECISION.md"
+    # Scratch output, not the committed record. Non-date-stamped so a revival
+    # re-run doesn't resurrect a stale 2026-07-01 filename; override via DECISION_OUT.
+    # Authoritative committed record: openspec/changes/db-gate-decision-race/DECISION.md.
+    local decision_file="${DECISION_OUT:-docs/plans/db-gate-race-DECISION.md}"
     local arm result
 
     if [ ! -d "$out_dir" ]; then

--- a/scripts/db-gate-race/test-score.sh
+++ b/scripts/db-gate-race/test-score.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# test-score.sh — unit tests for scripts/db-gate-race/score.sh
+#
+# Part A: feeds synthetic per-arm rates into score.sh's decide() function
+# (sourced as a library, main not executed) and checks the frozen-rule
+# verdicts, including the inclusive fp<=0.10 ceiling boundary.
+#
+# Part B: builds a synthetic arm-tree of *-variance.md reports under a temp
+# dir with hand-crafted Pass/Fail tables and asserts the aggregator computes
+# the expected detection_rate / false_positive_rate — proving aggregation
+# without ever invoking `claude`.
+#
+# Bash 3.2 compatible. No `set -e`.
+
+# -------- Part A: decide() unit tests --------
+
+. scripts/db-gate-race/score.sh --lib   # source decide() without running main
+
+t() {
+    # t detA0 fpA0 detB1 fpB1 detB2 fpB2 expected
+    local got
+    got="$(decide "$1" "$2" "$3" "$4" "$5" "$6")"
+    if [ "$got" = "$7" ]; then
+        echo "PASS $7 (got=$got)"
+    else
+        echo "FAIL want=$7 got=$got  (args: $1 $2 $3 $4 $5 $6)"
+        exit 1
+    fi
+}
+
+# B2 clears bar (+25pp det, +5pp fp): ship-B2
+t 0.40 0.05 0.55 0.06 0.65 0.10   ship-B2
+# nothing beats A0 by 20pp: park
+t 0.60 0.05 0.68 0.06 0.72 0.08   park
+# B1≈B2 both beat A0, |score diff|<10pp: ship-B1 (point-don't-own)
+t 0.40 0.05 0.66 0.06 0.68 0.07   ship-B1
+# only B2 clears (B1 misses the detection margin): ship-B2
+t 0.40 0.05 0.55 0.05 0.65 0.06   ship-B2
+# B2 fp just over ceiling (0.11) disqualifies an otherwise-clearing variant;
+# B1 also fails to clear -> park
+t 0.40 0.05 0.50 0.05 0.65 0.11   park
+
+echo "all decide() tests passed"
+
+# -------- Part B: aggregation parser tests --------
+
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR_ROOT}"' EXIT
+
+ARM_DIR="${TMPDIR_ROOT}/B2"
+mkdir -p "${ARM_DIR}"
+
+# defect-scenario report 1: two "text" assertions.
+# assertion 0: Pass=4 Fail=1 -> detection contribution 4/5 = 0.8
+# assertion 1: Pass=3 Fail=2 -> detection contribution 3/5 = 0.6
+cat > "${ARM_DIR}/defect-missing-index-01-variance.md" <<'EOF'
+# Behavioral Eval Variance Report — defect-missing-index-01
+
+**Scenario:** `defect-missing-index-01`
+**Iterations:** 5
+
+## Per-assertion pass rates
+
+| # | Description | Pass | Fail | Pass rate | Classification |
+|---|---|---|---|---|---|
+| 0 | Mentions missing index | 4 | 1 | 80% | flaky |
+| 1 | Mentions query plan | 3 | 2 | 60% | flaky |
+
+## Classification thresholds
+EOF
+
+# defect-scenario report 2: one "text" assertion.
+# assertion 0: Pass=5 Fail=0 -> detection contribution 5/5 = 1.0
+cat > "${ARM_DIR}/defect-n-plus-one-01-variance.md" <<'EOF'
+# Behavioral Eval Variance Report — defect-n-plus-one-01
+
+**Scenario:** `defect-n-plus-one-01`
+**Iterations:** 5
+
+## Per-assertion pass rates
+
+| # | Description | Pass | Fail | Pass rate | Classification |
+|---|---|---|---|---|---|
+| 0 | Mentions N+1 pattern | 5 | 0 | 100% | stable |
+
+## Classification thresholds
+EOF
+
+# clean-scenario report 1: one "absent" assertion.
+# Pass = no false flag = 4, Fail = false flag raised = 1
+# fp contribution = 1/5 = 0.2
+cat > "${ARM_DIR}/clean-indexed-query-01-variance.md" <<'EOF'
+# Behavioral Eval Variance Report — clean-indexed-query-01
+
+**Scenario:** `clean-indexed-query-01`
+**Iterations:** 5
+
+## Per-assertion pass rates
+
+| # | Description | Pass | Fail | Pass rate | Classification |
+|---|---|---|---|---|---|
+| 0 | Does not flag indexed query | 4 | 1 | 80% | flaky |
+
+## Classification thresholds
+EOF
+
+# clean-scenario report 2: one "absent" assertion.
+# Pass=5 Fail=0 -> fp contribution = 0/5 = 0.0
+cat > "${ARM_DIR}/clean-paginated-query-01-variance.md" <<'EOF'
+# Behavioral Eval Variance Report — clean-paginated-query-01
+
+**Scenario:** `clean-paginated-query-01`
+**Iterations:** 5
+
+## Per-assertion pass rates
+
+| # | Description | Pass | Fail | Pass rate | Classification |
+|---|---|---|---|---|---|
+| 0 | Does not flag paginated query | 5 | 0 | 100% | stable |
+
+## Classification thresholds
+EOF
+
+# Expected: detection_rate = mean(0.8, 0.6, 1.0) = 0.8
+# Expected: false_positive_rate = mean(0.2, 0.0) = 0.1
+# n_defect_assertions = 3, n_clean_assertions = 2
+
+result="$(aggregate_arm "${ARM_DIR}")"
+# aggregate_arm prints: detection_rate<TAB>false_positive_rate<TAB>n_defect<TAB>n_clean
+IFS="$(printf '\t')" read -r det fp ndef ncln <<EOF_RESULT
+${result}
+EOF_RESULT
+
+check_float() {
+    # check_float label got want
+    local ok
+    ok="$(awk -v a="$2" -v b="$3" 'BEGIN{d=a-b; if(d<0)d=-d; print (d<0.0001)?"1":"0"}')"
+    if [ "$ok" = "1" ]; then
+        echo "PASS $1 ($2 ~= $3)"
+    else
+        echo "FAIL $1 got=$2 want=$3"
+        exit 1
+    fi
+}
+
+check_float "detection_rate" "$det" "0.8"
+check_float "false_positive_rate" "$fp" "0.1"
+
+if [ "$ndef" = "3" ]; then
+    echo "PASS n_defect_assertions (3)"
+else
+    echo "FAIL n_defect_assertions got=$ndef want=3"
+    exit 1
+fi
+
+if [ "$ncln" = "2" ]; then
+    echo "PASS n_clean_assertions (2)"
+else
+    echo "FAIL n_clean_assertions got=$ncln want=2"
+    exit 1
+fi
+
+echo "all aggregation tests passed"
+echo "all score tests passed"

--- a/scripts/db-gate-race/validate-corpus.sh
+++ b/scripts/db-gate-race/validate-corpus.sh
@@ -8,17 +8,20 @@ jq -e '.' "$PACK" >/dev/null 2>&1 || { echo "pack is not valid JSON: $PACK"; exi
 fail=0
 defects=$(jq '[.[]|select(.id|startswith("defect-"))]|length' "$PACK")
 cleans=$(jq  '[.[]|select(.id|startswith("clean-"))]|length' "$PACK")
-[ "$defects" -ge 18 ] || { echo "need >=18 defect scenarios, got $defects"; fail=1; }
+[ "$defects" -ge 20 ] || { echo "need >=20 defect scenarios, got $defects"; fail=1; }
 [ "$cleans"  -ge 8  ] || { echo "need >=8 clean scenarios, got $cleans"; fail=1; }
-# every defect has >=1 text assertion; every clean has only absent assertions
-bad_defect=$(jq '[.[]|select(.id|startswith("defect-"))|select([.assertions[].kind//"text"]|index("text")|not)]|length' "$PACK")
+# every defect has >=1 assertion with real (non-empty) detection text; every clean has only absent assertions
+bad_defect=$(jq '[.[]|select(.id|startswith("defect-"))|select([.assertions[]|select((.text//"")|length>0)]|length==0)]|length' "$PACK")
 bad_clean=$(jq  '[.[]|select(.id|startswith("clean-"))|select([.assertions[].kind]|any(.!="absent"))]|length' "$PACK")
-[ "$bad_defect" -eq 0 ] || { echo "$bad_defect defect scenarios lack a text assertion"; fail=1; }
+[ "$bad_defect" -eq 0 ] || { echo "$bad_defect defect scenarios lack a non-empty text assertion"; fail=1; }
 [ "$bad_clean"  -eq 0 ] || { echo "$bad_clean clean scenarios have non-absent assertions"; fail=1; }
-# taxon coverage: each taxon appears in >=3 defect ids
+# global: no assertion anywhere (any scenario, any kind) may have empty/missing text
+empty_text=$(jq '[.[]|.assertions[]|select((.text//"")|length==0)]|length' "$PACK")
+[ "$empty_text" -eq 0 ] || { echo "$empty_text assertions have empty/missing text"; fail=1; }
+# taxon coverage: each taxon appears in >=4 defect ids
 for t in unsafe-migration missing-index n-plus-one offset-pagination lock-risk; do
   n=$(jq --arg t "$t" '[.[]|select(.id|startswith("defect-"+$t))]|length' "$PACK")
-  [ "$n" -ge 3 ] || { echo "taxon $t underrepresented ($n<3)"; fail=1; }
+  [ "$n" -ge 4 ] || { echo "taxon $t underrepresented ($n<4)"; fail=1; }
 done
 # every scenario has the required behavioral-pack fields
 missing_fields=$(jq '[.[]|select((has("id") and has("prompt") and has("expected_behavior") and has("assertions"))|not)]|length' "$PACK")

--- a/scripts/db-gate-race/validate-corpus.sh
+++ b/scripts/db-gate-race/validate-corpus.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Validate db-gate-race corpus structure. Exit 0 = valid, 1 = invalid.
+# Bash 3.2 compatible; no set -e.
+PACK="${1:-tests/fixtures/db-gate-race/evals/corpus.json}"
+command -v jq >/dev/null 2>&1 || { echo "jq required"; exit 1; }
+[ -f "$PACK" ] || { echo "missing pack: $PACK"; exit 1; }
+jq -e '.' "$PACK" >/dev/null 2>&1 || { echo "pack is not valid JSON: $PACK"; exit 1; }
+fail=0
+defects=$(jq '[.[]|select(.id|startswith("defect-"))]|length' "$PACK")
+cleans=$(jq  '[.[]|select(.id|startswith("clean-"))]|length' "$PACK")
+[ "$defects" -ge 18 ] || { echo "need >=18 defect scenarios, got $defects"; fail=1; }
+[ "$cleans"  -ge 8  ] || { echo "need >=8 clean scenarios, got $cleans"; fail=1; }
+# every defect has >=1 text assertion; every clean has only absent assertions
+bad_defect=$(jq '[.[]|select(.id|startswith("defect-"))|select([.assertions[].kind//"text"]|index("text")|not)]|length' "$PACK")
+bad_clean=$(jq  '[.[]|select(.id|startswith("clean-"))|select([.assertions[].kind]|any(.!="absent"))]|length' "$PACK")
+[ "$bad_defect" -eq 0 ] || { echo "$bad_defect defect scenarios lack a text assertion"; fail=1; }
+[ "$bad_clean"  -eq 0 ] || { echo "$bad_clean clean scenarios have non-absent assertions"; fail=1; }
+# taxon coverage: each taxon appears in >=3 defect ids
+for t in unsafe-migration missing-index n-plus-one offset-pagination lock-risk; do
+  n=$(jq --arg t "$t" '[.[]|select(.id|startswith("defect-"+$t))]|length' "$PACK")
+  [ "$n" -ge 3 ] || { echo "taxon $t underrepresented ($n<3)"; fail=1; }
+done
+# every scenario has the required behavioral-pack fields
+missing_fields=$(jq '[.[]|select((has("id") and has("prompt") and has("expected_behavior") and has("assertions"))|not)]|length' "$PACK")
+[ "$missing_fields" -eq 0 ] || { echo "$missing_fields scenarios missing required fields (id/prompt/expected_behavior/assertions)"; fail=1; }
+[ "$fail" -eq 0 ] && echo "corpus valid: $defects defect + $cleans clean" || echo "corpus INVALID"
+exit $fail

--- a/tests/fixtures/behavioral-runner/mock-claude.sh
+++ b/tests/fixtures/behavioral-runner/mock-claude.sh
@@ -20,6 +20,17 @@ if [ -n "${MOCK_ARGS_FILE:-}" ]; then
     fi
 fi
 
+# Optional stdin capture: tests may set MOCK_STDIN_FILE to assert on the
+# constructed prompt the runner pipes in on stdin (e.g. --directive-file
+# injection). Fail loudly if advertised but unwritable, so a dependent test
+# can't pass by accident. When unset, stdin is left untouched.
+if [ -n "${MOCK_STDIN_FILE:-}" ]; then
+    if ! cat > "${MOCK_STDIN_FILE}" 2>/dev/null; then
+        echo "mock-claude: failed to write MOCK_STDIN_FILE='${MOCK_STDIN_FILE}'" >&2
+        exit 1
+    fi
+fi
+
 response_text="$(cat "${MOCK_RESPONSE_FILE}")"
 jq -n \
     --arg result "${response_text}" \

--- a/tests/fixtures/db-gate-race/TAXONOMY.md
+++ b/tests/fixtures/db-gate-race/TAXONOMY.md
@@ -1,0 +1,6 @@
+# DB-defect taxonomy (frozen)
+1. unsafe-migration — blocking/locking DDL on a large table: ALTER ADD COLUMN NOT NULL without default, dropping an in-use index, non-online schema change causing downtime.
+2. missing-index — a query whose predicate/sort has no supporting index → full scan (type: ALL / Seq Scan).
+3. n-plus-one — per-row query inside a loop instead of a set-based/join/batched query.
+4. offset-pagination — LIMIT/OFFSET deep pagination on a large table instead of keyset/cursor pagination.
+5. lock-risk — long-held transaction / broad row or gap locks / SELECT ... FOR UPDATE hot path causing contention.

--- a/tests/fixtures/db-gate-race/arms/B1-external-content.md
+++ b/tests/fixtures/db-gate-race/arms/B1-external-content.md
@@ -1,0 +1,86 @@
+<!-- PROVENANCE: external content, verbatim vendor wording from planetscale/database-skills
+     (skills/mysql + skills/postgres, SKILL.md + references/). MUST NOT be shown to the Task 3
+     corpus author (blind constraint applies only to the corpus author, not this arm). Hosting
+     marketing blocks stripped; only review-relevant technical guidance retained. -->
+
+# DB review guidance (source: planetscale/database-skills, mysql + postgres)
+
+## EXPLAIN red flags
+Access Types (Best → Worst): `system` → `const` → `eq_ref` → `ref` → `range` → `index` (full
+index scan) → `ALL` (full table scan). Target `ref` or better. `ALL` on >1000 rows almost
+always needs an index.
+
+Key Extra Flags:
+| Flag | Meaning | Action |
+|---|---|---|
+| `Using index` | Covering index (optimal) | None |
+| `Using filesort` | Sort not via index | Index the ORDER BY columns |
+| `Using temporary` | Temp table for GROUP BY | Index the grouped columns |
+| `Using join buffer` | No index on join column | Add index on join column |
+
+`ORDER BY + LIMIT` without an index: `LIMIT` does not automatically make sorting cheap. If no
+index supports the order, MySQL may sort many rows (`Using filesort`) and then apply LIMIT.
+
+## Composite / covering indexing rules
+Leftmost Prefix Rule — Index `(a, b, c)` is usable for `WHERE a`, `WHERE a AND b`, and
+`WHERE a AND b AND c`; NOT usable for `WHERE b` alone (the search must start from the
+leftmost column). Column order: equality first, then range/sort — range predicates
+(`>`, `<`, `BETWEEN`, `LIKE 'prefix%'`) stop index usage for filtering subsequent columns.
+
+A covering index contains all columns a query needs — the engine satisfies it from the index
+alone (`Using index` in EXPLAIN Extra, no table lookups). Pitfall: `SELECT *` defeats
+covering indexes — select only the columns you need.
+
+Postgres: always index foreign key columns (PostgreSQL does not auto-create these); index
+columns in WHERE, JOIN, and ORDER BY clauses; verify with EXPLAIN ANALYZE that indexes are
+actually used.
+
+## Cursor vs OFFSET pagination
+Cursor pagination, not `OFFSET`. `OFFSET N` scans and discards N rows.
+
+```sql
+-- Bad: OFFSET 10000 scans 10020 rows
+SELECT id, title FROM article ORDER BY created_at DESC LIMIT 20 OFFSET 10000;
+-- Good: cursor-based (requires index on (created_at DESC, id DESC))
+SELECT id, title FROM article
+WHERE (created_at, id) < ('2025-06-15T12:00:00Z', 987654)
+ORDER BY created_at DESC, id DESC LIMIT 20;
+```
+
+## N+1 detection
+The N+1 pattern occurs when you fetch N parent records, then execute N additional queries
+(one per parent) to fetch related data. Queries inside loops → batch with ANY/IN:
+
+```python
+# Bad
+for uid in user_ids:
+    cursor.execute("SELECT name FROM user WHERE id = %s", (uid,))
+# Good (Postgres specific)
+cursor.execute("SELECT id, name FROM user WHERE id = ANY(%s)", (list(user_ids),))
+```
+
+## Online DDL / migration safety
+Not all `ALTER TABLE` is equal — some block writes for the entire duration.
+
+| Algorithm | What Happens | DML During? |
+|---|---|---|
+| `INSTANT` | Metadata-only change | Yes |
+| `INPLACE` | Rebuilds in background | Usually yes |
+| `COPY` | Full table copy to tmp table | **Blocked** |
+
+Always request `LOCK=NONE` (and an explicit `ALGORITHM`) to surface conflicts early instead
+of silently falling back to a more blocking method. On huge tables, consider external tools:
+pt-online-schema-change or gh-ost (triggerless, uses binlog stream, preferred for high-write
+tables). Never run `ALTER TABLE` on production without checking the algorithm — a surprise
+`COPY` on a 100M-row table can lock writes for hours.
+
+## Transactions & locking
+InnoDB's default isolation level (REPEATABLE READ) uses next-key locks for locking reads
+(`SELECT ... FOR UPDATE`, `UPDATE`, `DELETE`) to prevent phantom reads — a range scan locks
+every gap in that range. If the WHERE column has no index, InnoDB must scan all rows and
+locks every row examined. Keep transactions short — hold locks for milliseconds, not seconds.
+
+Postgres: a single long-running transaction blocks VACUUM from removing dead tuples across
+the entire database, causing table bloat and slower queries. `idle_in_transaction`
+connections are the #1 operational MVCC issue — set `idle_in_transaction_session_timeout`
+(30s–5min). Apps must handle "could not serialize access" with retry logic.

--- a/tests/fixtures/db-gate-race/arms/B2-owned-checklist.md
+++ b/tests/fixtures/db-gate-race/arms/B2-owned-checklist.md
@@ -1,0 +1,12 @@
+# DB-change REVIEW checklist (owned, vendor-neutral)
+Before approving any schema/query/migration change, verify each:
+- Migration safety: does any DDL lock or rewrite a large table? Require online/non-blocking
+  path (or explicit downtime sign-off). Flag ADD COLUMN NOT NULL without default; flag
+  dropping an index that queries still use.
+- Indexing: does every filtered/sorted/joined column have a supporting index? Flag full
+  scans (EXPLAIN type: ALL / Seq Scan). Composite order = equality first, then range/sort.
+- N+1: any query executed per-row in a loop? Require set-based / JOIN / batched rewrite.
+- Pagination: LIMIT/OFFSET deep pagination on a large table → require keyset/cursor.
+- Locking/transactions: long transactions, broad locks, or FOR UPDATE on a hot path →
+  flag contention risk and narrow scope.
+For each finding: name it, cite the line, state the risk, propose the smallest safe fix.

--- a/tests/fixtures/db-gate-race/arms/B2-owned-checklist.md
+++ b/tests/fixtures/db-gate-race/arms/B2-owned-checklist.md
@@ -1,12 +1,102 @@
 # DB-change REVIEW checklist (owned, vendor-neutral)
-Before approving any schema/query/migration change, verify each:
-- Migration safety: does any DDL lock or rewrite a large table? Require online/non-blocking
-  path (or explicit downtime sign-off). Flag ADD COLUMN NOT NULL without default; flag
-  dropping an index that queries still use.
-- Indexing: does every filtered/sorted/joined column have a supporting index? Flag full
-  scans (EXPLAIN type: ALL / Seq Scan). Composite order = equality first, then range/sort.
-- N+1: any query executed per-row in a loop? Require set-based / JOIN / batched rewrite.
-- Pagination: LIMIT/OFFSET deep pagination on a large table → require keyset/cursor.
-- Locking/transactions: long transactions, broad locks, or FOR UPDATE on a hot path →
-  flag contention risk and narrow scope.
+Before approving any schema/query/migration change, verify each of the five defect
+classes below. For each, look for the stated signal, weigh it against the stated
+threshold, and require the matching fix before sign-off.
+
+## 1. Unsafe migration (blocking/locking DDL)
+Not every ALTER is safe just because it "runs". Ask whether this DDL rewrites the
+table or only touches metadata.
+- Adding a column with a NOT NULL constraint and no DEFAULT forces a full table
+  rewrite on many engines/versions — writes block until it finishes.
+- Column type changes, PK changes, and adding a UNIQUE constraint on a populated
+  table are rewrite-class operations. On a table over roughly 1M rows (or any table
+  with meaningful write traffic) a rewrite-class ALTER needs an online/non-blocking
+  execution path (chunked or background rebuild) or an explicit, reviewed downtime
+  window — never a bare synchronous ALTER during business hours.
+- Dropping an index: confirm no live query still depends on it (check application
+  query patterns, not just the schema diff) before removing it — a dropped index
+  that's still needed silently turns fast lookups into full scans.
+- Backfills that populate a new column/table on a hot table should run in small,
+  throttled batches with a resumable cursor, not a single UPDATE across the table.
+Signal: DDL statement type, estimated row count of the target table, presence or
+absence of DEFAULT. Fix: online schema-change tooling, chunked batch job, or a
+signed-off maintenance window.
+
+## 2. Missing index (unsupported filter/sort/join)
+Any column driving a WHERE, JOIN, or ORDER BY needs a plan that uses an index, not
+a scan.
+- Read the query plan: EXPLAIN type `ALL` (MySQL) or a `Seq Scan` node (Postgres)
+  on a table above a few thousand rows is the red flag — the engine is reading
+  every row to find a handful.
+- For multi-column indexes, order matters: equality-filtered columns first, then
+  the column used for range/sort comparisons. An index on `(a, b, c)` serves
+  `WHERE a = ? AND b = ?` and also `... ORDER BY c`, but does NOT serve a lookup on
+  `b` alone — the engine can't skip the leading column.
+- Watch for a plan where the index handles the WHERE clause but a separate sort
+  step still appears (`Using filesort`, or a `Sort` node above the scan in
+  Postgres) — the index doesn't cover the ORDER BY and the engine is sorting the
+  result set in memory or on disk.
+- `SELECT *` on a table where a narrower index could otherwise fully answer the
+  query forces a lookup back to the base row — confirm the query actually needs
+  every selected column before ruling out a covering index.
+Signal: plan node type, row estimate, and which clause (filter/sort/join) is
+unindexed. Fix: add a composite index ordered equality-then-range, or narrow the
+SELECT list so an existing index can cover it.
+
+## 3. N+1 (per-row query in a loop)
+Look for a query issued once per item of a collection instead of once for the
+whole collection.
+- Pattern: a loop over IDs (from an earlier query or request payload) that opens a
+  new DB call inside the loop body — 50 items in, 50 round trips out.
+- Fix is a single set-based query: `WHERE id IN (...)` / `WHERE id = ANY(...)`, or
+  a JOIN that pulls related rows alongside the parent rows in one round trip.
+- ORM code is a common source — check for lazy-loaded associations accessed inside
+  a loop (e.g. `for order in orders: order.customer.name`), which silently issues
+  one query per iteration even though no SQL appears at that line.
+- A handful of extra queries (two or three) for genuinely independent lookups is
+  not the problem; the pattern to flag is a query count that scales with input
+  size.
+Signal: query call site inside a loop/iterator whose bound is a collection length.
+Fix: batch into one IN/ANY query, or eager-load the association up front.
+
+## 4. Offset pagination (deep OFFSET scans)
+`LIMIT x OFFSET y` looks cheap but the engine still has to walk and discard the
+first `y` rows before it can return anything.
+- Small, first-page offsets (low hundreds) are fine. Once OFFSET climbs into the
+  low thousands, or is effectively unbounded (a user can page indefinitely, or a
+  job walks the whole table page by page), cost per page grows with how deep the
+  page is — page 500 costs far more than page 1 for the same LIMIT.
+- Fix is keyset/cursor pagination: carry the last row's sort key(s) forward and
+  filter on them instead of counting rows to skip, e.g.
+  `WHERE (created_at, id) < (last_seen) ORDER BY created_at DESC, id DESC LIMIT n`.
+  This needs a composite index on the cursor columns to stay cheap at any depth.
+- Also flag OFFSET-based pagination used for a background export or sync job —
+  that's exactly the unbounded-depth case where the linear cost adds up fastest.
+Signal: OFFSET magnitude and whether it's bounded by user behavior or can grow
+without limit. Fix: cursor pagination on an indexed (sort_key, id) pair.
+
+## 5. Lock risk (long transactions / broad locks / hot-row contention)
+A change can be functionally correct and still stall concurrent traffic through
+locking.
+- `SELECT ... FOR UPDATE` (or any locking read) on a row or range that many
+  requests hit concurrently — a "hot row" such as a counter, balance, or singleton
+  config row — serializes every request that touches it. Flag it and ask whether
+  the lock scope can shrink or the hot value can move to an append-only or
+  optimistic-update pattern.
+- A range scan used inside a locking statement without a supporting index locks
+  every row (and gap) it has to examine to find matches, not just the rows it
+  returns — an unindexed WHERE clause inside a transaction silently widens the
+  blast radius.
+- Transaction duration matters as much as scope: any transaction that does network
+  calls, waits on user input, or otherwise stays open for more than a second or
+  two is holding its locks — and, in MVCC engines, blocking cleanup of old row
+  versions — for that whole span. Keep the transaction boundary tight around the
+  actual writes.
+- Watch for connections left idle mid-transaction (opened, then unrelated work
+  happens, then a late commit) — these hold locks and old snapshots open with
+  nothing visibly running, and are easy to miss in a code diff.
+Signal: locking clause, whether the touched rows are contended, and transaction
+span (does it wrap I/O beyond the DB calls themselves). Fix: narrow the lock
+(index the predicate, shrink the row set), or shorten/split the transaction.
+
 For each finding: name it, cite the line, state the risk, propose the smallest safe fix.

--- a/tests/fixtures/db-gate-race/evals/PROVENANCE.md
+++ b/tests/fixtures/db-gate-race/evals/PROVENANCE.md
@@ -1,0 +1,13 @@
+# Provenance: db-gate-race defect corpus
+
+`corpus.json` was authored by the Codex (GPT) CLI, cross-model and BLIND to
+`tests/fixtures/db-gate-race/arms/B2-owned-checklist.md`, to serve as the
+anti-overfit held-out control for the DB-gate decision race: Codex was given
+only `TAXONOMY.md`, `review-base.md`, and the behavioral-pack schema, and
+never saw the B1/B2 arm directives, so its detection-assertion vocabulary
+reflects independent general DB knowledge rather than either arm's wording.
+The regex validity fixes applied in this commit (removing literal-SQL-echo
+alternates from 12 defect assertions and hardening the version-ambiguous
+MySQL migration in `defect-unsafe-migration-02`) were likewise made without
+reading or referencing the `arms/` directory, preserving the corpus's
+blindness for the race.

--- a/tests/fixtures/db-gate-race/evals/corpus.json
+++ b/tests/fixtures/db-gate-race/evals/corpus.json
@@ -5,8 +5,8 @@
     "expected_behavior": "A correct review must flag that adding a NOT NULL column without a staged default/backfill on the large orders table is an unsafe migration that can block or fail.",
     "assertions": [
       {
-        "text": "blocking|lock|table rewrite|backfill|unsafe migration",
-        "description": "Flags the unsafe large-table NOT NULL column migration and names the blocking/backfill risk."
+        "text": "DEFECTS:.*(unsafe.?migrat|blocking.?migrat|table.?rewrite|rewrite|non.?online|drop.*index|not.?null.*default|downtime)",
+        "description": "Machine verdict lists a unsafe-migration defect"
       }
     ]
   },
@@ -16,8 +16,8 @@
     "expected_behavior": "A correct review must flag the NOT NULL column addition combined with a same-statement secondary index add on a large existing table as an unsafe migration: the index add defeats MySQL's instant ADD COLUMN optimization and forces a full table rebuild, so it requires a nullable/add-backfill-enforce sequence with the index build run separately.",
     "assertions": [
       {
-        "text": "backfill|blocking|lock|online|unsafe migration",
-        "description": "Detects the unsafe non-staged NOT NULL addition on a large MySQL table."
+        "text": "DEFECTS:.*(unsafe.?migrat|blocking.?migrat|table.?rewrite|rewrite|non.?online|drop.*index|not.?null.*default|downtime)",
+        "description": "Machine verdict lists a unsafe-migration defect"
       }
     ]
   },
@@ -27,8 +27,8 @@
     "expected_behavior": "A correct review must flag that the migration drops an in-use index required by a hot query and would cause scan/sort regressions.",
     "assertions": [
       {
-        "text": "in-use index|full scan|seq scan|regression|supporting index",
-        "description": "Identifies that dropping the hot-query index is unsafe."
+        "text": "DEFECTS:.*(unsafe.?migrat|blocking.?migrat|table.?rewrite|rewrite|non.?online|drop.*index|not.?null.*default|downtime)",
+        "description": "Machine verdict lists a unsafe-migration defect"
       }
     ]
   },
@@ -38,8 +38,8 @@
     "expected_behavior": "A correct review must flag the COPY/exclusive-lock table rebuild on a large hot table as an unsafe non-online migration.",
     "assertions": [
       {
-        "text": "blocking|online|lock|downtime",
-        "description": "Flags the non-online schema change and exclusive lock risk."
+        "text": "DEFECTS:.*(unsafe.?migrat|blocking.?migrat|table.?rewrite|rewrite|non.?online|drop.*index|not.?null.*default|downtime)",
+        "description": "Machine verdict lists a unsafe-migration defect"
       }
     ]
   },
@@ -49,8 +49,8 @@
     "expected_behavior": "A correct review must flag that the actor_id filter and created_at order have no supporting index, causing a full/seq scan on a large table.",
     "assertions": [
       {
-        "text": "missing index|full scan|seq scan|type: ?ALL|add .*index",
-        "description": "Detects the missing supporting index for the actor_id lookup."
+        "text": "DEFECTS:.*(missing.?index|no.?index|unindexed|full.?scan|full.?table.?scan|seq.?scan|table.?scan|supporting.?index|add.?index)",
+        "description": "Machine verdict lists a missing-index defect"
       }
     ]
   },
@@ -60,8 +60,8 @@
     "expected_behavior": "A correct review must flag the missing index on shipments.order_id for the join, which can force a scan of shipments.",
     "assertions": [
       {
-        "text": "missing index|full scan|type: ?ALL|add .*index",
-        "description": "Identifies the missing join index on shipments.order_id."
+        "text": "DEFECTS:.*(missing.?index|no.?index|unindexed|full.?scan|full.?table.?scan|seq.?scan|table.?scan|supporting.?index|add.?index)",
+        "description": "Machine verdict lists a missing-index defect"
       }
     ]
   },
@@ -71,8 +71,8 @@
     "expected_behavior": "A correct review must flag that status/due_date lacks a supporting index and can require a seq scan plus sort on a large invoices table.",
     "assertions": [
       {
-        "text": "missing index|seq scan|full scan|sort|add .*index",
-        "description": "Detects the missing index for the open-invoices query."
+        "text": "DEFECTS:.*(missing.?index|no.?index|unindexed|full.?scan|full.?table.?scan|seq.?scan|table.?scan|supporting.?index|add.?index)",
+        "description": "Machine verdict lists a missing-index defect"
       }
     ]
   },
@@ -82,8 +82,8 @@
     "expected_behavior": "A correct review must flag that expires_at/revoked_at has no supporting index and the cleanup query can full-scan the large sessions table.",
     "assertions": [
       {
-        "text": "missing index|full scan|type: ?ALL|add .*index",
-        "description": "Finds the missing cleanup-query index."
+        "text": "DEFECTS:.*(missing.?index|no.?index|unindexed|full.?scan|full.?table.?scan|seq.?scan|table.?scan|supporting.?index|add.?index)",
+        "description": "Machine verdict lists a missing-index defect"
       }
     ]
   },
@@ -93,8 +93,8 @@
     "expected_behavior": "A correct review must flag the per-order query in the loop as an N+1 pattern that should be replaced with a batched query or join.",
     "assertions": [
       {
-        "text": "n[+]1|n[ -]?plus[ -]?one|query.*loop|per-row|per row|batch|join",
-        "description": "Flags the looped per-order item query as N+1."
+        "text": "DEFECTS:.*(n.?1|n.?plus.?one|per.?row|in.?a.?loop|loop|unbatched|repeated.?quer)",
+        "description": "Machine verdict lists a n-plus-one defect"
       }
     ]
   },
@@ -104,8 +104,8 @@
     "expected_behavior": "A correct review must flag the invoice aggregate query inside the customer loop as an N+1 database access pattern.",
     "assertions": [
       {
-        "text": "n[+]1|n[ -]?plus[ -]?one|query.*loop|per-row|per row|batch|aggregate",
-        "description": "Detects the per-customer aggregate query loop."
+        "text": "DEFECTS:.*(n.?1|n.?plus.?one|per.?row|in.?a.?loop|loop|unbatched|repeated.?quer)",
+        "description": "Machine verdict lists a n-plus-one defect"
       }
     ]
   },
@@ -115,8 +115,8 @@
     "expected_behavior": "A correct review must flag the latest-login lookup inside the user loop as N+1 and recommend batching or a lateral/join query.",
     "assertions": [
       {
-        "text": "n[+]1|n[ -]?plus[ -]?one|query.*loop|per-row|per row|batch|join",
-        "description": "Finds the repeated latest-login query per user."
+        "text": "DEFECTS:.*(n.?1|n.?plus.?one|per.?row|in.?a.?loop|loop|unbatched|repeated.?quer)",
+        "description": "Machine verdict lists a n-plus-one defect"
       }
     ]
   },
@@ -126,8 +126,8 @@
     "expected_behavior": "A correct review must flag the count query inside the projects loop as an N+1 issue requiring a grouped aggregate or prefetch.",
     "assertions": [
       {
-        "text": "n[+]1|n[ -]?plus[ -]?one|query.*loop|per-row|per row|batch|group",
-        "description": "Identifies the per-project count query as N+1."
+        "text": "DEFECTS:.*(n.?1|n.?plus.?one|per.?row|in.?a.?loop|loop|unbatched|repeated.?quer)",
+        "description": "Machine verdict lists a n-plus-one defect"
       }
     ]
   },
@@ -137,8 +137,8 @@
     "expected_behavior": "A correct review must flag deep LIMIT/OFFSET pagination on a huge table and recommend keyset/cursor pagination.",
     "assertions": [
       {
-        "text": "keyset|cursor|seek method|OFFSET.*slow|deep pagination",
-        "description": "Flags deep offset pagination and names the keyset/cursor fix."
+        "text": "DEFECTS:.*(offset|deep.?pag|large.?offset|keyset|cursor.?pag|pagination)",
+        "description": "Machine verdict lists a offset-pagination defect"
       }
     ]
   },
@@ -148,8 +148,8 @@
     "expected_behavior": "A correct review must flag the deep OFFSET despite the supporting order index and recommend cursor/keyset pagination.",
     "assertions": [
       {
-        "text": "keyset|cursor|seek method|OFFSET.*slow|deep pagination|large offset",
-        "description": "Catches the high-offset pagination risk."
+        "text": "DEFECTS:.*(offset|deep.?pag|large.?offset|keyset|cursor.?pag|pagination)",
+        "description": "Machine verdict lists a offset-pagination defect"
       }
     ]
   },
@@ -159,8 +159,8 @@
     "expected_behavior": "A correct review must flag the OFFSET-based export paging as deep pagination that should use a cursor/seek predicate.",
     "assertions": [
       {
-        "text": "keyset|cursor|seek method|OFFSET.*slow|deep pagination|large offset",
-        "description": "Detects offset paging in a full-table export."
+        "text": "DEFECTS:.*(offset|deep.?pag|large.?offset|keyset|cursor.?pag|pagination)",
+        "description": "Machine verdict lists a offset-pagination defect"
       }
     ]
   },
@@ -170,8 +170,8 @@
     "expected_behavior": "A correct review must flag the large OFFSET pagination on the active-products list and recommend keyset/cursor pagination.",
     "assertions": [
       {
-        "text": "keyset|cursor|seek method|OFFSET.*slow|deep pagination|large offset",
-        "description": "Identifies deep offset pagination on the product listing."
+        "text": "DEFECTS:.*(offset|deep.?pag|large.?offset|keyset|cursor.?pag|pagination)",
+        "description": "Machine verdict lists a offset-pagination defect"
       }
     ]
   },
@@ -181,8 +181,8 @@
     "expected_behavior": "A correct review must flag that the transaction holds FOR UPDATE locks while waiting on an external payment call, creating contention risk.",
     "assertions": [
       {
-        "text": "lock|contention|long transaction|hold.*transaction|external call",
-        "description": "Detects locks held across the external payment call."
+        "text": "DEFECTS:.*(lock.?risk|lock.?contention|long.?transaction|long.?running|for.?update|gap.?lock|broad.?lock|held.?lock|row.?lock)",
+        "description": "Machine verdict lists a lock-risk defect"
       }
     ]
   },
@@ -192,8 +192,8 @@
     "expected_behavior": "A correct review must flag that selecting hundreds of hot queued jobs FOR UPDATE and doing work before commit creates broad, long-held lock contention.",
     "assertions": [
       {
-        "text": "lock|contention|long transaction|broad.*lock|skip locked",
-        "description": "Flags broad row locks held during worker processing."
+        "text": "DEFECTS:.*(lock.?risk|lock.?contention|long.?transaction|long.?running|for.?update|gap.?lock|broad.?lock|held.?lock|row.?lock)",
+        "description": "Machine verdict lists a lock-risk defect"
       }
     ]
   },
@@ -203,8 +203,8 @@
     "expected_behavior": "A correct review must flag the huge update held open in one transaction, which can hold many row locks and cause contention.",
     "assertions": [
       {
-        "text": "lock|contention|long transaction|batch|row locks|hold.*transaction",
-        "description": "Detects the long transaction and broad row-lock risk."
+        "text": "DEFECTS:.*(lock.?risk|lock.?contention|long.?transaction|long.?running|for.?update|gap.?lock|broad.?lock|held.?lock|row.?lock)",
+        "description": "Machine verdict lists a lock-risk defect"
       }
     ]
   },
@@ -214,8 +214,8 @@
     "expected_behavior": "A correct review must flag the range SELECT FOR UPDATE on a hot path as a lock/gap-lock contention risk.",
     "assertions": [
       {
-        "text": "gap lock|next-key|contention|lock|hot path",
-        "description": "Identifies the hot range-lock contention risk."
+        "text": "DEFECTS:.*(lock.?risk|lock.?contention|long.?transaction|long.?running|for.?update|gap.?lock|broad.?lock|held.?lock|row.?lock)",
+        "description": "Machine verdict lists a lock-risk defect"
       }
     ]
   },
@@ -226,8 +226,8 @@
     "assertions": [
       {
         "kind": "absent",
-        "text": "unsafe migration|table rewrite|blocking migration|not null",
-        "description": "Guards against falsely flagging a safe nullable additive column."
+        "text": "DEFECTS:.*(unsafe.?migrat|blocking.?migrat|table.?rewrite|rewrite|non.?online|drop.*index|not.?null.*default|downtime|missing.?index|no.?index|unindexed|full.?scan|seq.?scan|table.?scan|supporting.?index|add.?index|n.?1|n.?plus.?one|per.?row|in.?a.?loop|loop|unbatched|deep.?pag|large.?offset|keyset|cursor.?pag|pagination|offset|lock.?risk|lock.?contention|long.?transaction|long.?running|for.?update|gap.?lock|broad.?lock|held.?lock|row.?lock)",
+        "description": "Machine verdict wrongly names a taxon defect on a safe change"
       }
     ]
   },
@@ -238,8 +238,8 @@
     "assertions": [
       {
         "kind": "absent",
-        "text": "missing index|full scan|type: ?ALL|seq scan|add .*index",
-        "description": "Guards against a false missing-index finding on a covered query."
+        "text": "DEFECTS:.*(unsafe.?migrat|blocking.?migrat|table.?rewrite|rewrite|non.?online|drop.*index|not.?null.*default|downtime|missing.?index|no.?index|unindexed|full.?scan|seq.?scan|table.?scan|supporting.?index|add.?index|n.?1|n.?plus.?one|per.?row|in.?a.?loop|loop|unbatched|deep.?pag|large.?offset|keyset|cursor.?pag|pagination|offset|lock.?risk|lock.?contention|long.?transaction|long.?running|for.?update|gap.?lock|broad.?lock|held.?lock|row.?lock)",
+        "description": "Machine verdict wrongly names a taxon defect on a safe change"
       }
     ]
   },
@@ -250,8 +250,8 @@
     "assertions": [
       {
         "kind": "absent",
-        "text": "OFFSET.*slow|deep pagination|large offset",
-        "description": "Guards against falsely flagging offset pagination where no OFFSET is used."
+        "text": "DEFECTS:.*(unsafe.?migrat|blocking.?migrat|table.?rewrite|rewrite|non.?online|drop.*index|not.?null.*default|downtime|missing.?index|no.?index|unindexed|full.?scan|seq.?scan|table.?scan|supporting.?index|add.?index|n.?1|n.?plus.?one|per.?row|in.?a.?loop|loop|unbatched|deep.?pag|large.?offset|keyset|cursor.?pag|pagination|offset|lock.?risk|lock.?contention|long.?transaction|long.?running|for.?update|gap.?lock|broad.?lock|held.?lock|row.?lock)",
+        "description": "Machine verdict wrongly names a taxon defect on a safe change"
       }
     ]
   },
@@ -262,8 +262,8 @@
     "assertions": [
       {
         "kind": "absent",
-        "text": "n[+]1|n[ -]?plus[ -]?one|query.*loop|per-row query",
-        "description": "Guards against falsely flagging a batched lookup as N+1."
+        "text": "DEFECTS:.*(unsafe.?migrat|blocking.?migrat|table.?rewrite|rewrite|non.?online|drop.*index|not.?null.*default|downtime|missing.?index|no.?index|unindexed|full.?scan|seq.?scan|table.?scan|supporting.?index|add.?index|n.?1|n.?plus.?one|per.?row|in.?a.?loop|loop|unbatched|deep.?pag|large.?offset|keyset|cursor.?pag|pagination|offset|lock.?risk|lock.?contention|long.?transaction|long.?running|for.?update|gap.?lock|broad.?lock|held.?lock|row.?lock)",
+        "description": "Machine verdict wrongly names a taxon defect on a safe change"
       }
     ]
   },
@@ -274,8 +274,8 @@
     "assertions": [
       {
         "kind": "absent",
-        "text": "long transaction|broad.*lock|gap lock|contention|deadlock",
-        "description": "Guards against falsely flagging a short row-level lock as a lock-risk defect."
+        "text": "DEFECTS:.*(unsafe.?migrat|blocking.?migrat|table.?rewrite|rewrite|non.?online|drop.*index|not.?null.*default|downtime|missing.?index|no.?index|unindexed|full.?scan|seq.?scan|table.?scan|supporting.?index|add.?index|n.?1|n.?plus.?one|per.?row|in.?a.?loop|loop|unbatched|deep.?pag|large.?offset|keyset|cursor.?pag|pagination|offset|lock.?risk|lock.?contention|long.?transaction|long.?running|for.?update|gap.?lock|broad.?lock|held.?lock|row.?lock)",
+        "description": "Machine verdict wrongly names a taxon defect on a safe change"
       }
     ]
   },
@@ -286,8 +286,8 @@
     "assertions": [
       {
         "kind": "absent",
-        "text": "unsafe migration|blocking migration|table rewrite|drop.*index",
-        "description": "Guards against falsely flagging a safe concurrent index build."
+        "text": "DEFECTS:.*(unsafe.?migrat|blocking.?migrat|table.?rewrite|rewrite|non.?online|drop.*index|not.?null.*default|downtime|missing.?index|no.?index|unindexed|full.?scan|seq.?scan|table.?scan|supporting.?index|add.?index|n.?1|n.?plus.?one|per.?row|in.?a.?loop|loop|unbatched|deep.?pag|large.?offset|keyset|cursor.?pag|pagination|offset|lock.?risk|lock.?contention|long.?transaction|long.?running|for.?update|gap.?lock|broad.?lock|held.?lock|row.?lock)",
+        "description": "Machine verdict wrongly names a taxon defect on a safe change"
       }
     ]
   },
@@ -298,8 +298,8 @@
     "assertions": [
       {
         "kind": "absent",
-        "text": "n[+]1|n[ -]?plus[ -]?one|per-row query|query.*loop",
-        "description": "Guards against falsely flagging grouped aggregate loading as N+1."
+        "text": "DEFECTS:.*(unsafe.?migrat|blocking.?migrat|table.?rewrite|rewrite|non.?online|drop.*index|not.?null.*default|downtime|missing.?index|no.?index|unindexed|full.?scan|seq.?scan|table.?scan|supporting.?index|add.?index|n.?1|n.?plus.?one|per.?row|in.?a.?loop|loop|unbatched|deep.?pag|large.?offset|keyset|cursor.?pag|pagination|offset|lock.?risk|lock.?contention|long.?transaction|long.?running|for.?update|gap.?lock|broad.?lock|held.?lock|row.?lock)",
+        "description": "Machine verdict wrongly names a taxon defect on a safe change"
       }
     ]
   },
@@ -310,8 +310,8 @@
     "assertions": [
       {
         "kind": "absent",
-        "text": "deep pagination|large offset|OFFSET.*slow|keyset required",
-        "description": "Guards against falsely flagging shallow OFFSET on a tiny lookup table."
+        "text": "DEFECTS:.*(unsafe.?migrat|blocking.?migrat|table.?rewrite|rewrite|non.?online|drop.*index|not.?null.*default|downtime|missing.?index|no.?index|unindexed|full.?scan|seq.?scan|table.?scan|supporting.?index|add.?index|n.?1|n.?plus.?one|per.?row|in.?a.?loop|loop|unbatched|deep.?pag|large.?offset|keyset|cursor.?pag|pagination|offset|lock.?risk|lock.?contention|long.?transaction|long.?running|for.?update|gap.?lock|broad.?lock|held.?lock|row.?lock)",
+        "description": "Machine verdict wrongly names a taxon defect on a safe change"
       }
     ]
   }

--- a/tests/fixtures/db-gate-race/evals/corpus.json
+++ b/tests/fixtures/db-gate-race/evals/corpus.json
@@ -5,18 +5,18 @@
     "expected_behavior": "A correct review must flag that adding a NOT NULL column without a staged default/backfill on the large orders table is an unsafe migration that can block or fail.",
     "assertions": [
       {
-        "text": "not null|blocking|lock|table rewrite|backfill|unsafe migration",
+        "text": "blocking|lock|table rewrite|backfill|unsafe migration",
         "description": "Flags the unsafe large-table NOT NULL column migration and names the blocking/backfill risk."
       }
     ]
   },
   {
     "id": "defect-unsafe-migration-02",
-    "prompt": "Please review this MySQL 8.0 migration for the production users table. The table has 64 million rows, steady signup traffic, and replicas used by the API. Existing indexes: PRIMARY(id), idx_users_email(email), idx_users_org_created(org_id, created_at). Migration:\nALTER TABLE users ADD COLUMN risk_score int NOT NULL;\nNew application code will populate risk_score for future users only.",
-    "expected_behavior": "A correct review must flag the NOT NULL column addition on a large existing table as an unsafe migration requiring a nullable/add-backfill-enforce sequence.",
+    "prompt": "Please review this MySQL 8.0 migration for the production users table. The table has 64 million rows, steady signup traffic, and replicas used by the API. Existing indexes: PRIMARY(id), idx_users_email(email), idx_users_org_created(org_id, created_at). Migration:\nALTER TABLE users ADD COLUMN risk_score int NOT NULL, ADD INDEX idx_users_risk_score(risk_score);\nNew application code will populate risk_score for future users only.",
+    "expected_behavior": "A correct review must flag the NOT NULL column addition combined with a same-statement secondary index add on a large existing table as an unsafe migration: the index add defeats MySQL's instant ADD COLUMN optimization and forces a full table rebuild, so it requires a nullable/add-backfill-enforce sequence with the index build run separately.",
     "assertions": [
       {
-        "text": "not null|backfill|blocking|lock|online|unsafe migration",
+        "text": "backfill|blocking|lock|online|unsafe migration",
         "description": "Detects the unsafe non-staged NOT NULL addition on a large MySQL table."
       }
     ]
@@ -27,7 +27,7 @@
     "expected_behavior": "A correct review must flag that the migration drops an in-use index required by a hot query and would cause scan/sort regressions.",
     "assertions": [
       {
-        "text": "drop.*index|in-use index|full scan|seq scan|regression|supporting index",
+        "text": "in-use index|full scan|seq scan|regression|supporting index",
         "description": "Identifies that dropping the hot-query index is unsafe."
       }
     ]
@@ -38,7 +38,7 @@
     "expected_behavior": "A correct review must flag the COPY/exclusive-lock table rebuild on a large hot table as an unsafe non-online migration.",
     "assertions": [
       {
-        "text": "copy|exclusive|blocking|online|lock|downtime",
+        "text": "blocking|online|lock|downtime",
         "description": "Flags the non-online schema change and exclusive lock risk."
       }
     ]
@@ -49,7 +49,7 @@
     "expected_behavior": "A correct review must flag that the actor_id filter and created_at order have no supporting index, causing a full/seq scan on a large table.",
     "assertions": [
       {
-        "text": "missing index|full scan|seq scan|type: ?ALL|add .*index|actor_id",
+        "text": "missing index|full scan|seq scan|type: ?ALL|add .*index",
         "description": "Detects the missing supporting index for the actor_id lookup."
       }
     ]
@@ -60,7 +60,7 @@
     "expected_behavior": "A correct review must flag the missing index on shipments.order_id for the join, which can force a scan of shipments.",
     "assertions": [
       {
-        "text": "missing index|full scan|type: ?ALL|add .*index|shipments.*order_id|order_id",
+        "text": "missing index|full scan|type: ?ALL|add .*index",
         "description": "Identifies the missing join index on shipments.order_id."
       }
     ]
@@ -71,7 +71,7 @@
     "expected_behavior": "A correct review must flag that status/due_date lacks a supporting index and can require a seq scan plus sort on a large invoices table.",
     "assertions": [
       {
-        "text": "missing index|seq scan|full scan|sort|add .*index|status.*due_date",
+        "text": "missing index|seq scan|full scan|sort|add .*index",
         "description": "Detects the missing index for the open-invoices query."
       }
     ]
@@ -82,7 +82,7 @@
     "expected_behavior": "A correct review must flag that expires_at/revoked_at has no supporting index and the cleanup query can full-scan the large sessions table.",
     "assertions": [
       {
-        "text": "missing index|full scan|type: ?ALL|add .*index|expires_at|revoked_at",
+        "text": "missing index|full scan|type: ?ALL|add .*index",
         "description": "Finds the missing cleanup-query index."
       }
     ]
@@ -137,7 +137,7 @@
     "expected_behavior": "A correct review must flag deep LIMIT/OFFSET pagination on a huge table and recommend keyset/cursor pagination.",
     "assertions": [
       {
-        "text": "keyset|cursor|seek method|OFFSET.*slow|deep pagination|limit.*offset",
+        "text": "keyset|cursor|seek method|OFFSET.*slow|deep pagination",
         "description": "Flags deep offset pagination and names the keyset/cursor fix."
       }
     ]
@@ -181,7 +181,7 @@
     "expected_behavior": "A correct review must flag that the transaction holds FOR UPDATE locks while waiting on an external payment call, creating contention risk.",
     "assertions": [
       {
-        "text": "lock|contention|for update|long transaction|hold.*transaction|external call",
+        "text": "lock|contention|long transaction|hold.*transaction|external call",
         "description": "Detects locks held across the external payment call."
       }
     ]
@@ -192,7 +192,7 @@
     "expected_behavior": "A correct review must flag that selecting hundreds of hot queued jobs FOR UPDATE and doing work before commit creates broad, long-held lock contention.",
     "assertions": [
       {
-        "text": "lock|contention|for update|long transaction|broad.*lock|skip locked",
+        "text": "lock|contention|long transaction|broad.*lock|skip locked",
         "description": "Flags broad row locks held during worker processing."
       }
     ]
@@ -214,7 +214,7 @@
     "expected_behavior": "A correct review must flag the range SELECT FOR UPDATE on a hot path as a lock/gap-lock contention risk.",
     "assertions": [
       {
-        "text": "gap lock|next-key|for update|contention|lock|hot path",
+        "text": "gap lock|next-key|contention|lock|hot path",
         "description": "Identifies the hot range-lock contention risk."
       }
     ]

--- a/tests/fixtures/db-gate-race/evals/corpus.json
+++ b/tests/fixtures/db-gate-race/evals/corpus.json
@@ -1,0 +1,318 @@
+[
+  {
+    "id": "defect-unsafe-migration-01",
+    "prompt": "Please review this Postgres 15 migration for the production checkout database. The orders table has 82 million rows and receives about 900 writes/sec. Existing indexes: orders_pkey(id), idx_orders_account_created(account_id, created_at). Migration:\nALTER TABLE orders ADD COLUMN requires_signature boolean NOT NULL;\nThe application will start writing requires_signature on new orders after the deploy.",
+    "expected_behavior": "A correct review must flag that adding a NOT NULL column without a staged default/backfill on the large orders table is an unsafe migration that can block or fail.",
+    "assertions": [
+      {
+        "text": "not null|blocking|lock|table rewrite|backfill|unsafe migration",
+        "description": "Flags the unsafe large-table NOT NULL column migration and names the blocking/backfill risk."
+      }
+    ]
+  },
+  {
+    "id": "defect-unsafe-migration-02",
+    "prompt": "Please review this MySQL 8.0 migration for the production users table. The table has 64 million rows, steady signup traffic, and replicas used by the API. Existing indexes: PRIMARY(id), idx_users_email(email), idx_users_org_created(org_id, created_at). Migration:\nALTER TABLE users ADD COLUMN risk_score int NOT NULL;\nNew application code will populate risk_score for future users only.",
+    "expected_behavior": "A correct review must flag the NOT NULL column addition on a large existing table as an unsafe migration requiring a nullable/add-backfill-enforce sequence.",
+    "assertions": [
+      {
+        "text": "not null|backfill|blocking|lock|online|unsafe migration",
+        "description": "Detects the unsafe non-staged NOT NULL addition on a large MySQL table."
+      }
+    ]
+  },
+  {
+    "id": "defect-unsafe-migration-03",
+    "prompt": "Please review this Postgres migration. The audit_events table has 140 million rows. Existing indexes include audit_events_pkey(id) and idx_audit_events_tenant_created(tenant_id, created_at DESC). A hot API query runs thousands of times per minute:\nSELECT id, event_type, created_at FROM audit_events WHERE tenant_id = $1 AND created_at >= $2 ORDER BY created_at DESC LIMIT 100;\nMigration:\nDROP INDEX idx_audit_events_tenant_created;",
+    "expected_behavior": "A correct review must flag that the migration drops an in-use index required by a hot query and would cause scan/sort regressions.",
+    "assertions": [
+      {
+        "text": "drop.*index|in-use index|full scan|seq scan|regression|supporting index",
+        "description": "Identifies that dropping the hot-query index is unsafe."
+      }
+    ]
+  },
+  {
+    "id": "defect-unsafe-migration-04",
+    "prompt": "Please review this MySQL migration for the audit_log table. The table has 310 million append-only rows and about 4000 writes/sec. The request_path column already contains non-null values. Existing indexes: PRIMARY(id), idx_audit_log_created(created_at). Migration:\nALTER TABLE audit_log MODIFY COLUMN request_path varchar(1024) NOT NULL, ALGORITHM=COPY, LOCK=EXCLUSIVE;",
+    "expected_behavior": "A correct review must flag the COPY/exclusive-lock table rebuild on a large hot table as an unsafe non-online migration.",
+    "assertions": [
+      {
+        "text": "copy|exclusive|blocking|online|lock|downtime",
+        "description": "Flags the non-online schema change and exclusive lock risk."
+      }
+    ]
+  },
+  {
+    "id": "defect-missing-index-01",
+    "prompt": "Please review this Postgres 14 query change. Table audit_events has 96 million rows. Schema: audit_events(id bigserial primary key, tenant_id uuid not null, actor_id uuid not null, event_type text not null, created_at timestamptz not null). Indexes: audit_events_pkey(id), idx_audit_events_tenant_created(tenant_id, created_at DESC). New query:\nSELECT id, event_type, created_at FROM audit_events WHERE actor_id = $1 ORDER BY created_at DESC LIMIT 50;",
+    "expected_behavior": "A correct review must flag that the actor_id filter and created_at order have no supporting index, causing a full/seq scan on a large table.",
+    "assertions": [
+      {
+        "text": "missing index|full scan|seq scan|type: ?ALL|add .*index|actor_id",
+        "description": "Detects the missing supporting index for the actor_id lookup."
+      }
+    ]
+  },
+  {
+    "id": "defect-missing-index-02",
+    "prompt": "Please review this MySQL 8 query and schema. orders has 40 million rows with indexes PRIMARY(id) and idx_orders_account_created(account_id, created_at). shipments has 42 million rows with indexes PRIMARY(id) and idx_shipments_created(created_at). New endpoint query:\nSELECT o.id, s.status FROM orders o JOIN shipments s ON s.order_id = o.id WHERE o.account_id = ? AND o.created_at >= ? ORDER BY o.created_at DESC LIMIT 100;",
+    "expected_behavior": "A correct review must flag the missing index on shipments.order_id for the join, which can force a scan of shipments.",
+    "assertions": [
+      {
+        "text": "missing index|full scan|type: ?ALL|add .*index|shipments.*order_id|order_id",
+        "description": "Identifies the missing join index on shipments.order_id."
+      }
+    ]
+  },
+  {
+    "id": "defect-missing-index-03",
+    "prompt": "Please review this Postgres billing query. The invoices table has 58 million rows. Schema includes id, customer_id, status, due_date, total_cents. Indexes: invoices_pkey(id), idx_invoices_customer_due(customer_id, due_date). New dashboard query:\nSELECT id, customer_id, total_cents FROM invoices WHERE status = 'open' ORDER BY due_date ASC LIMIT 200;",
+    "expected_behavior": "A correct review must flag that status/due_date lacks a supporting index and can require a seq scan plus sort on a large invoices table.",
+    "assertions": [
+      {
+        "text": "missing index|seq scan|full scan|sort|add .*index|status.*due_date",
+        "description": "Detects the missing index for the open-invoices query."
+      }
+    ]
+  },
+  {
+    "id": "defect-missing-index-04",
+    "prompt": "Please review this MySQL cleanup query. customer_sessions has 120 million rows. Indexes: PRIMARY(id), UNIQUE(session_token), idx_customer_sessions_user(user_id). New scheduled read before deletion:\nSELECT id FROM customer_sessions WHERE expires_at < NOW() AND revoked_at IS NULL ORDER BY expires_at ASC LIMIT 500;",
+    "expected_behavior": "A correct review must flag that expires_at/revoked_at has no supporting index and the cleanup query can full-scan the large sessions table.",
+    "assertions": [
+      {
+        "text": "missing index|full scan|type: ?ALL|add .*index|expires_at|revoked_at",
+        "description": "Finds the missing cleanup-query index."
+      }
+    ]
+  },
+  {
+    "id": "defect-n-plus-one-01",
+    "prompt": "Please review this TypeScript/Postgres endpoint. orders has idx_orders_account_created(account_id, created_at DESC). order_items has idx_order_items_order_id(order_id). Change:\nconst orders = await db.many('select id, total_cents from orders where account_id = $1 order by created_at desc limit 100', [accountId]);\nfor (const order of orders) {\n  order.items = await db.many('select sku, quantity from order_items where order_id = $1', [order.id]);\n}\nreturn orders;",
+    "expected_behavior": "A correct review must flag the per-order query in the loop as an N+1 pattern that should be replaced with a batched query or join.",
+    "assertions": [
+      {
+        "text": "n[+]1|n[ -]?plus[ -]?one|query.*loop|per-row|per row|batch|join",
+        "description": "Flags the looped per-order item query as N+1."
+      }
+    ]
+  },
+  {
+    "id": "defect-n-plus-one-02",
+    "prompt": "Please review this Ruby/Rails change. customers are prefiltered by an indexed org_id query and invoices has index idx_invoices_customer_id(customer_id). Code:\ncustomers = Customer.where(org_id: org_id).order(:id).limit(250)\ncustomers.map do |customer|\n  {\n    id: customer.id,\n    overdue_total: Invoice.where(customer_id: customer.id, status: 'overdue').sum(:total_cents)\n  }\nend",
+    "expected_behavior": "A correct review must flag the invoice aggregate query inside the customer loop as an N+1 database access pattern.",
+    "assertions": [
+      {
+        "text": "n[+]1|n[ -]?plus[ -]?one|query.*loop|per-row|per row|batch|aggregate",
+        "description": "Detects the per-customer aggregate query loop."
+      }
+    ]
+  },
+  {
+    "id": "defect-n-plus-one-03",
+    "prompt": "Please review this Go/Postgres service change. users is read with an indexed tenant_id query. login_events has idx_login_events_user_created(user_id, created_at DESC). Code:\nusers, _ := db.ListUsersByTenant(ctx, tenantID, 300)\nfor i := range users {\n    row := db.QueryRowContext(ctx, 'select created_at from login_events where user_id = $1 order by created_at desc limit 1', users[i].ID)\n    _ = row.Scan(&users[i].LastLoginAt)\n}\nreturn users",
+    "expected_behavior": "A correct review must flag the latest-login lookup inside the user loop as N+1 and recommend batching or a lateral/join query.",
+    "assertions": [
+      {
+        "text": "n[+]1|n[ -]?plus[ -]?one|query.*loop|per-row|per row|batch|join",
+        "description": "Finds the repeated latest-login query per user."
+      }
+    ]
+  },
+  {
+    "id": "defect-n-plus-one-04",
+    "prompt": "Please review this Django/Postgres change. projects are fetched by indexed workspace_id and comments has idx_comments_project_id(project_id). Code:\nprojects = list(Project.objects.filter(workspace_id=workspace_id).order_by('name')[:150])\nfor project in projects:\n    project.open_comment_count = Comment.objects.filter(project_id=project.id, resolved=False).count()\nreturn projects",
+    "expected_behavior": "A correct review must flag the count query inside the projects loop as an N+1 issue requiring a grouped aggregate or prefetch.",
+    "assertions": [
+      {
+        "text": "n[+]1|n[ -]?plus[ -]?one|query.*loop|per-row|per row|batch|group",
+        "description": "Identifies the per-project count query as N+1."
+      }
+    ]
+  },
+  {
+    "id": "defect-offset-pagination-01",
+    "prompt": "Please review this Postgres API query. activity_feed has 220 million rows and id is the primary key. New endpoint supports arbitrary page numbers:\nSELECT id, actor_id, created_at FROM activity_feed ORDER BY id DESC LIMIT 100 OFFSET 5000000;",
+    "expected_behavior": "A correct review must flag deep LIMIT/OFFSET pagination on a huge table and recommend keyset/cursor pagination.",
+    "assertions": [
+      {
+        "text": "keyset|cursor|seek method|OFFSET.*slow|deep pagination|limit.*offset",
+        "description": "Flags deep offset pagination and names the keyset/cursor fix."
+      }
+    ]
+  },
+  {
+    "id": "defect-offset-pagination-02",
+    "prompt": "Please review this MySQL 8 query. messages has 180 million rows and index idx_messages_tenant_created_id(tenant_id, created_at DESC, id DESC). New inbox endpoint:\nSELECT id, sender_id, created_at FROM messages WHERE tenant_id = ? ORDER BY created_at DESC, id DESC LIMIT 50 OFFSET 250000;",
+    "expected_behavior": "A correct review must flag the deep OFFSET despite the supporting order index and recommend cursor/keyset pagination.",
+    "assertions": [
+      {
+        "text": "keyset|cursor|seek method|OFFSET.*slow|deep pagination|large offset",
+        "description": "Catches the high-offset pagination risk."
+      }
+    ]
+  },
+  {
+    "id": "defect-offset-pagination-03",
+    "prompt": "Please review this Postgres export query. transactions has 75 million rows and index idx_transactions_created_id(created_at DESC, id DESC). The export worker pages through all rows like this, with page_number sometimes above 20000:\nSELECT id, amount_cents, created_at FROM transactions ORDER BY created_at DESC, id DESC LIMIT 1000 OFFSET ($1 * 1000);",
+    "expected_behavior": "A correct review must flag the OFFSET-based export paging as deep pagination that should use a cursor/seek predicate.",
+    "assertions": [
+      {
+        "text": "keyset|cursor|seek method|OFFSET.*slow|deep pagination|large offset",
+        "description": "Detects offset paging in a full-table export."
+      }
+    ]
+  },
+  {
+    "id": "defect-offset-pagination-04",
+    "prompt": "Please review this MySQL catalog query. products has 55 million rows and index idx_products_status_published_id(status, published_at DESC, id DESC). New listing endpoint:\nSELECT id, title, published_at FROM products WHERE status = 'active' ORDER BY published_at DESC, id DESC LIMIT 60 OFFSET ?;\nThe API allows users to jump to page 10000.",
+    "expected_behavior": "A correct review must flag the large OFFSET pagination on the active-products list and recommend keyset/cursor pagination.",
+    "assertions": [
+      {
+        "text": "keyset|cursor|seek method|OFFSET.*slow|deep pagination|large offset",
+        "description": "Identifies deep offset pagination on the product listing."
+      }
+    ]
+  },
+  {
+    "id": "defect-lock-risk-01",
+    "prompt": "Please review this Postgres checkout change. cart_items has idx_cart_items_cart_id(cart_id), and carts are small. Code:\nawait db.query('begin');\nconst rows = await db.query('select id, sku, quantity from cart_items where cart_id = $1 for update', [cartId]);\nconst charge = await paymentClient.charge(cardToken, rows.total);\nawait db.query('insert into orders(cart_id, charge_id) values ($1, $2)', [cartId, charge.id]);\nawait db.query('commit');",
+    "expected_behavior": "A correct review must flag that the transaction holds FOR UPDATE locks while waiting on an external payment call, creating contention risk.",
+    "assertions": [
+      {
+        "text": "lock|contention|for update|long transaction|hold.*transaction|external call",
+        "description": "Detects locks held across the external payment call."
+      }
+    ]
+  },
+  {
+    "id": "defect-lock-risk-02",
+    "prompt": "Please review this MySQL worker change. jobs has 15 million rows and index idx_jobs_status_priority(status, priority DESC, id). Worker code:\nSTART TRANSACTION;\nSELECT id, payload FROM jobs WHERE status = 'queued' ORDER BY priority DESC, id ASC LIMIT 500 FOR UPDATE;\n-- deserialize payloads and build requests for about 30 seconds\nUPDATE jobs SET status = 'running' WHERE id IN (...);\nCOMMIT;",
+    "expected_behavior": "A correct review must flag that selecting hundreds of hot queued jobs FOR UPDATE and doing work before commit creates broad, long-held lock contention.",
+    "assertions": [
+      {
+        "text": "lock|contention|for update|long transaction|broad.*lock|skip locked",
+        "description": "Flags broad row locks held during worker processing."
+      }
+    ]
+  },
+  {
+    "id": "defect-lock-risk-03",
+    "prompt": "Please review this Postgres maintenance job. accounts has 30 million rows and index idx_accounts_dormant_last_seen(dormant, last_seen_at). Code:\nBEGIN;\nUPDATE accounts SET dormant = true WHERE dormant = false AND last_seen_at < now() - interval '18 months';\nSELECT pg_sleep(20);\nINSERT INTO maintenance_audit(job_name, finished_at) VALUES ('mark_dormant', now());\nCOMMIT;",
+    "expected_behavior": "A correct review must flag the huge update held open in one transaction, which can hold many row locks and cause contention.",
+    "assertions": [
+      {
+        "text": "lock|contention|long transaction|batch|row locks|hold.*transaction",
+        "description": "Detects the long transaction and broad row-lock risk."
+      }
+    ]
+  },
+  {
+    "id": "defect-lock-risk-04",
+    "prompt": "Please review this MySQL/InnoDB reservation change. reservations has index idx_reservations_room_start_end(room_id, starts_at, ends_at). The database runs at REPEATABLE READ. Booking code:\nSTART TRANSACTION;\nSELECT id FROM reservations WHERE room_id = ? AND starts_at < ? AND ends_at > ? FOR UPDATE;\n-- calculate alternate slots and insert audit rows\nCOMMIT;\nThis path runs on every booking search for popular rooms.",
+    "expected_behavior": "A correct review must flag the range SELECT FOR UPDATE on a hot path as a lock/gap-lock contention risk.",
+    "assertions": [
+      {
+        "text": "gap lock|next-key|for update|contention|lock|hot path",
+        "description": "Identifies the hot range-lock contention risk."
+      }
+    ]
+  },
+  {
+    "id": "clean-01",
+    "prompt": "Please review this Postgres migration. The customers table has 48 million rows and steady writes. Migration:\nALTER TABLE customers ADD COLUMN preferred_locale text;\nThe column is nullable, has no default, and application code handles NULL until a later backfill.",
+    "expected_behavior": "A correct review should treat this as a safe additive nullable column migration with no planted defect.",
+    "assertions": [
+      {
+        "kind": "absent",
+        "text": "unsafe migration|table rewrite|blocking migration|not null",
+        "description": "Guards against falsely flagging a safe nullable additive column."
+      }
+    ]
+  },
+  {
+    "id": "clean-02",
+    "prompt": "Please review this MySQL 8 query. orders has 90 million rows and index idx_orders_account_status_created(account_id, status, created_at DESC, id DESC). Query:\nSELECT id, created_at, total_cents FROM orders WHERE account_id = ? AND status = 'paid' ORDER BY created_at DESC, id DESC LIMIT 100;",
+    "expected_behavior": "A correct review should recognize the filter and sort are covered by the composite index and not flag a defect.",
+    "assertions": [
+      {
+        "kind": "absent",
+        "text": "missing index|full scan|type: ?ALL|seq scan|add .*index",
+        "description": "Guards against a false missing-index finding on a covered query."
+      }
+    ]
+  },
+  {
+    "id": "clean-03",
+    "prompt": "Please review this Postgres feed query. notifications has 130 million rows and index idx_notifications_user_created_id(user_id, created_at DESC, id DESC). The endpoint uses a cursor from the previous page:\nSELECT id, body, created_at FROM notifications WHERE user_id = $1 AND (created_at, id) < ($2, $3) ORDER BY created_at DESC, id DESC LIMIT 50;",
+    "expected_behavior": "A correct review should treat this as safe keyset pagination with a supporting index.",
+    "assertions": [
+      {
+        "kind": "absent",
+        "text": "OFFSET.*slow|deep pagination|large offset",
+        "description": "Guards against falsely flagging offset pagination where no OFFSET is used."
+      }
+    ]
+  },
+  {
+    "id": "clean-04",
+    "prompt": "Please review this TypeScript/Postgres endpoint. orders has idx_orders_account_created(account_id, created_at DESC), and order_items has idx_order_items_order_id(order_id). Code:\nconst orders = await db.many('select id, total_cents from orders where account_id = $1 order by created_at desc limit 100', [accountId]);\nconst items = await db.many('select order_id, sku, quantity from order_items where order_id = any($1)', [orders.map(o => o.id)]);\nreturn attachItems(orders, items);",
+    "expected_behavior": "A correct review should treat this as a batched item load rather than an N+1 query pattern.",
+    "assertions": [
+      {
+        "kind": "absent",
+        "text": "n[+]1|n[ -]?plus[ -]?one|query.*loop|per-row query",
+        "description": "Guards against falsely flagging a batched lookup as N+1."
+      }
+    ]
+  },
+  {
+    "id": "clean-05",
+    "prompt": "Please review this Postgres account update. accounts has PRIMARY KEY(id). Code:\nBEGIN;\nSELECT id, balance_cents FROM accounts WHERE id = $1 FOR UPDATE;\nUPDATE accounts SET balance_cents = balance_cents - $2 WHERE id = $1;\nCOMMIT;\nThere are no network calls or sleeps inside the transaction.",
+    "expected_behavior": "A correct review should treat the short primary-key transaction as safe and not flag broad or long-held locking.",
+    "assertions": [
+      {
+        "kind": "absent",
+        "text": "long transaction|broad.*lock|gap lock|contention|deadlock",
+        "description": "Guards against falsely flagging a short row-level lock as a lock-risk defect."
+      }
+    ]
+  },
+  {
+    "id": "clean-06",
+    "prompt": "Please review this Postgres migration for a 70 million row events table. The migration is run outside a transaction:\nCREATE INDEX CONCURRENTLY idx_events_org_created ON events(org_id, created_at DESC);\nThe application query using org_id and created_at is deployed only after this migration completes.",
+    "expected_behavior": "A correct review should treat the concurrent index build and staged rollout as a safe migration.",
+    "assertions": [
+      {
+        "kind": "absent",
+        "text": "unsafe migration|blocking migration|table rewrite|drop.*index",
+        "description": "Guards against falsely flagging a safe concurrent index build."
+      }
+    ]
+  },
+  {
+    "id": "clean-07",
+    "prompt": "Please review this Rails/Postgres change. projects has idx_projects_workspace_id(workspace_id), and comments has idx_comments_project_resolved(project_id, resolved). Code:\nprojects = Project.where(workspace_id: workspace_id).limit(150).to_a\ncounts = Comment.where(project_id: projects.map(&:id), resolved: false).group(:project_id).count\nprojects.each { |p| p.open_comment_count = counts[p.id] || 0 }\nreturn projects",
+    "expected_behavior": "A correct review should recognize the grouped aggregate as a safe batched alternative to N+1.",
+    "assertions": [
+      {
+        "kind": "absent",
+        "text": "n[+]1|n[ -]?plus[ -]?one|per-row query|query.*loop",
+        "description": "Guards against falsely flagging grouped aggregate loading as N+1."
+      }
+    ]
+  },
+  {
+    "id": "clean-08",
+    "prompt": "Please review this MySQL admin query. country_codes is a static lookup table with 249 rows and PRIMARY KEY(code). Query used by an internal admin page:\nSELECT code, display_name FROM country_codes ORDER BY display_name ASC LIMIT 25 OFFSET 25;",
+    "expected_behavior": "A correct review should treat the small lookup-table OFFSET as safe and not flag deep pagination.",
+    "assertions": [
+      {
+        "kind": "absent",
+        "text": "deep pagination|large offset|OFFSET.*slow|keyset required",
+        "description": "Guards against falsely flagging shallow OFFSET on a tiny lookup table."
+      }
+    ]
+  }
+]

--- a/tests/fixtures/db-gate-race/review-base.md
+++ b/tests/fixtures/db-gate-race/review-base.md
@@ -1,0 +1,5 @@
+# REVIEW
+You are performing a REVIEW-phase code review of the change in the user request.
+Identify concrete correctness, safety, and performance problems. For each issue:
+name it, cite the specific line/statement, and state the risk. Be specific; do not
+rubber-stamp. If the change is safe, say so explicitly.

--- a/tests/fixtures/db-gate-race/review-base.md
+++ b/tests/fixtures/db-gate-race/review-base.md
@@ -3,3 +3,16 @@ You are performing a REVIEW-phase code review of the change in the user request.
 Identify concrete correctness, safety, and performance problems. For each issue:
 name it, cite the specific line/statement, and state the risk. Be specific; do not
 rubber-stamp. If the change is safe, say so explicitly.
+
+After your prose review, end your response with ONE final line, in exactly this
+format and nothing after it:
+
+DEFECTS: <a semicolon-separated list naming each distinct defect you are confident
+the change actually contains and would BLOCK the change for, or the single word NONE>
+
+Rules for the DEFECTS line:
+- It MUST be a single line beginning with `DEFECTS:`.
+- Name each real defect with a short, plain tag (a few words). Do NOT list stylistic
+  preferences, optional hardening, or risks you inspected and dismissed as not applying.
+- If you would approve the change as-is (no blocking defect), the line MUST be exactly
+  `DEFECTS: NONE`.

--- a/tests/run-behavioral-evals.sh
+++ b/tests/run-behavioral-evals.sh
@@ -418,6 +418,17 @@ ${CONSTRUCTED_PROMPT}"
                     printf '  %s [%d/text]: %s  (regex: %s)\n' "${verdict}" "${i}" "${a_desc}" "${a_text}"
                 fi
                 ;;
+            absent)
+                a_text="$(printf '%s' "${SCENARIO_JSON}" | jq -r ".assertions[${i}].text")"
+                if printf '%s' "${RAW_OUTPUT}" | grep -E -i -q "${a_text}"; then
+                    verdict="FAIL"; passed=false; ALL_PASSED=0
+                else
+                    verdict="PASS"; passed=true
+                fi
+                if [ "${VARIANCE_N}" -eq 1 ]; then
+                    printf '  %s [%d/absent]: %s  (must-not-match regex: %s)\n' "${verdict}" "${i}" "${a_desc}" "${a_text}"
+                fi
+                ;;
             tool_call)
                 a_tool="$(printf '%s' "${SCENARIO_JSON}" | jq -r ".assertions[${i}].tool")"
                 a_min="$(printf '%s' "${SCENARIO_JSON}" | jq -r ".assertions[${i}].min_count // 1")"

--- a/tests/test-db-gate-score.sh
+++ b/tests/test-db-gate-score.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# test-db-gate-score.sh — regression guard for the db-gate-race integrity core.
+# Wires the scorer's frozen-rule unit tests and the corpus validator into the
+# standard suite (tests/run-tests.sh discovers tests/test-*.sh), so a future edit
+# to score.sh's comparators (e.g. flipping the inclusive FP ceiling) or a corpus
+# regression fails CI instead of passing silently. Bash 3.2 compatible; no set -e.
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT" || { echo "cannot cd to repo root"; exit 1; }
+
+fail=0
+
+echo "== db-gate-race: scorer frozen-rule + aggregation unit tests =="
+if bash scripts/db-gate-race/test-score.sh; then
+    echo "PASS: score.sh"
+else
+    echo "FAIL: score.sh"; fail=1
+fi
+
+echo "== db-gate-race: held-out corpus structure validator =="
+if bash scripts/db-gate-race/validate-corpus.sh; then
+    echo "PASS: corpus validator"
+else
+    echo "FAIL: corpus validator"; fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+    echo "test-db-gate-score: ALL PASS"
+else
+    echo "test-db-gate-score: FAILURES above"
+fi
+exit "$fail"

--- a/tests/test-run-behavioral-evals.sh
+++ b/tests/test-run-behavioral-evals.sh
@@ -103,6 +103,34 @@ assert_contains "output reports PASS for the matching assertion" "PASS" "${outpu
 assert_contains "output names the matched scenario id" "well-formed-scenario" "${output}"
 
 # ---------------------------------------------------------------------------
+# Directive injection: --directive-file content reaches the constructed prompt.
+# This is the mechanism that drives the db-gate-race B1/B2 treatment arms; a
+# silent break here would make all arms identical with no error. Assert the
+# directive body is injected (and wrapped in the activation_directive block).
+# ---------------------------------------------------------------------------
+echo "-- directive: --directive-file content is injected into the prompt --"
+
+DIRECTIVE_FILE_T="${TMPDIR:-/tmp}/acs-directive-$$.md"
+STDIN_CAPTURE="${TMPDIR:-/tmp}/acs-stdin-$$.txt"
+printf 'ZZ_UNIQUE_DIRECTIVE_MARKER_9137 walk the checklist\n' > "${DIRECTIVE_FILE_T}"
+
+MOCK_RESPONSE_FILE="${CANNED_RESPONSE_FILE}" \
+MOCK_STDIN_FILE="${STDIN_CAPTURE}" \
+BEHAVIORAL_EVALS=1 \
+CLAUDE_BIN="${PROJECT_ROOT}/tests/fixtures/behavioral-runner/mock-claude.sh" \
+ARTIFACTS_DIR="${TMPDIR:-/tmp}/acs-artifacts-$$" \
+SKILL_PATH="${PROJECT_ROOT}/skills/incident-analysis/SKILL.md" \
+bash "${RUNNER}" \
+  --scenario well-formed-scenario \
+  --directive-file "${DIRECTIVE_FILE_T}" \
+  --pack "${PROJECT_ROOT}/tests/fixtures/behavioral-runner/scenarios.json" >/dev/null 2>&1
+
+directive_captured="$(cat "${STDIN_CAPTURE}" 2>/dev/null)"
+assert_contains "directive body is injected into the constructed prompt" "ZZ_UNIQUE_DIRECTIVE_MARKER_9137" "${directive_captured}"
+assert_contains "directive is wrapped in an activation_directive block" "activation_directive" "${directive_captured}"
+rm -f "${DIRECTIVE_FILE_T}" "${STDIN_CAPTURE}"
+
+# ---------------------------------------------------------------------------
 # Verdict: stubbed claude returns a response that does NOT match the assertion
 # ---------------------------------------------------------------------------
 echo "-- verdict: stubbed claude fail case --"

--- a/tests/test-run-behavioral-evals.sh
+++ b/tests/test-run-behavioral-evals.sh
@@ -113,7 +113,13 @@ echo "-- directive: --directive-file content is injected into the prompt --"
 DIRECTIVE_FILE_T="${TMPDIR:-/tmp}/acs-directive-$$.md"
 STDIN_CAPTURE="${TMPDIR:-/tmp}/acs-stdin-$$.txt"
 printf 'ZZ_UNIQUE_DIRECTIVE_MARKER_9137 walk the checklist\n' > "${DIRECTIVE_FILE_T}"
+# Re-list accumulated temp paths so an abnormal exit before the inline cleanup
+# below does not leak these (matches the trap-accumulation pattern used at the
+# section boundaries at lines ~218/259).
+trap 'rm -f "${CANNED_RESPONSE_FILE}" "${DIRECTIVE_FILE_T}" "${STDIN_CAPTURE}"' EXIT
 
+# Exit code is intentionally NOT asserted here (hence >/dev/null); the observable
+# under test is the captured stdin (STDIN_CAPTURE), asserted below.
 MOCK_RESPONSE_FILE="${CANNED_RESPONSE_FILE}" \
 MOCK_STDIN_FILE="${STDIN_CAPTURE}" \
 BEHAVIORAL_EVALS=1 \

--- a/tests/test-run-behavioral-evals.sh
+++ b/tests/test-run-behavioral-evals.sh
@@ -313,4 +313,75 @@ MOCK_RESPONSE_FILE="${MODEL_RESPONSE_FILE}" \
 nobare_flag_line="$(grep -nxF -- '--bare' "${NOBARE_ARGS_FILE}" 2>/dev/null | head -n1 | cut -d: -f1)"
 assert_equals "no --bare flag forwarded when unset" "" "${nobare_flag_line}"
 
+# ---------------------------------------------------------------------------
+# Assertion kind: absent — mirror of 'text' that PASSES when a regex is NOT
+# found in RAW_OUTPUT and FAILS when it is. Built as a scenario-level,
+# end-to-end run through the real runner (not a bare grep test) so the
+# actual `case "${a_kind}" in absent)` branch is exercised. The pack is a
+# throwaway temp file (not a committed fixture) to keep this change scoped
+# to this test file only.
+# ---------------------------------------------------------------------------
+echo "-- assertion kind: absent --"
+
+ABSENT_PACK_FILE="${TMPDIR:-/tmp}/acs-absent-pack-$$.json"
+ABSENT_PASS_RESPONSE_FILE="${TMPDIR:-/tmp}/acs-absent-pass-resp-$$.txt"
+ABSENT_FAIL_RESPONSE_FILE="${TMPDIR:-/tmp}/acs-absent-fail-resp-$$.txt"
+ABSENT_ART_DIR="${TMPDIR:-/tmp}/acs-absent-art-$$"
+trap 'rm -f "${CANNED_RESPONSE_FILE}" "${SANDBOX_RESPONSE_FILE}" "${SANDBOX_ARGS_FILE}" "${MODEL_RESPONSE_FILE}" "${MODEL_ARGS_FILE}" "${NOMODEL_ARGS_FILE}" "${BARE_ARGS_FILE}" "${NOBARE_ARGS_FILE}" "${ABSENT_PACK_FILE}" "${ABSENT_PASS_RESPONSE_FILE}" "${ABSENT_FAIL_RESPONSE_FILE}"; rm -rf "${SANDBOX_ART_DIR}" "${MODEL_ART_DIR}" "${ABSENT_ART_DIR}"' EXIT
+
+cat > "${ABSENT_PACK_FILE}" <<'EOF'
+[
+  {
+    "id": "absent-assertion-scenario",
+    "prompt": "review this migration",
+    "expected_behavior": "Must not mention destructive DDL when the migration is safe.",
+    "assertions": [
+      {"kind": "absent", "text": "DROP TABLE|TRUNCATE", "description": "Does not mention destructive DDL"}
+    ]
+  }
+]
+EOF
+
+cat > "${ABSENT_PASS_RESPONSE_FILE}" <<'EOF'
+Reviewed migration: adds a nullable column, safe online.
+EOF
+
+cat > "${ABSENT_FAIL_RESPONSE_FILE}" <<'EOF'
+This migration will DROP TABLE orders — destructive.
+EOF
+
+echo "-- absent: PASSES when regex is missing from output --"
+
+output="$(MOCK_RESPONSE_FILE="${ABSENT_PASS_RESPONSE_FILE}" \
+BEHAVIORAL_EVALS=1 \
+CLAUDE_BIN="${PROJECT_ROOT}/tests/fixtures/behavioral-runner/mock-claude.sh" \
+ARTIFACTS_DIR="${ABSENT_ART_DIR}" \
+SKILL_PATH="${PROJECT_ROOT}/skills/incident-analysis/SKILL.md" \
+bash "${RUNNER}" \
+  --scenario absent-assertion-scenario \
+  --pack "${ABSENT_PACK_FILE}" 2>&1)"
+exit_code=$?
+
+assert_equals "absent assertion PASSES (exit 0) when regex missing from output" "0" "${exit_code}"
+assert_contains "output reports PASS for the absent assertion" "PASS" "${output}"
+assert_contains "output tags the assertion as kind absent" "absent" "${output}"
+
+echo "-- absent: FAILS when regex is present in output --"
+
+output="$(MOCK_RESPONSE_FILE="${ABSENT_FAIL_RESPONSE_FILE}" \
+BEHAVIORAL_EVALS=1 \
+CLAUDE_BIN="${PROJECT_ROOT}/tests/fixtures/behavioral-runner/mock-claude.sh" \
+ARTIFACTS_DIR="${ABSENT_ART_DIR}" \
+SKILL_PATH="${PROJECT_ROOT}/skills/incident-analysis/SKILL.md" \
+bash "${RUNNER}" \
+  --scenario absent-assertion-scenario \
+  --pack "${ABSENT_PACK_FILE}" 2>&1)"
+exit_code=$?
+
+assert_equals "absent assertion FAILS (exit 1) when regex present in output" "1" "${exit_code}"
+assert_contains "output reports FAIL for the absent assertion" "FAIL" "${output}"
+assert_contains "output names the failing assertion description" "Does not mention destructive DDL" "${output}"
+
+rm -rf "${ABSENT_ART_DIR}"
+
 print_summary


### PR DESCRIPTION
## What & why

Opportunistic eval prompted by PlanetScale's `database-skills`: **should our PDLC add a DB-review phase gate?** Instead of parking on "no felt pain," we ran a **pre-registered 3-arm A/B race** on a held-out DB-defect corpus to decide empirically.

## Verdict: **PARK** — a DB-review gate adds no measurable value

Bare REVIEW (arm A0) already detects **95% of 20 held-out DB defects** (all 5 taxa, incl. subtle variants) at **10% false-positive**. The frozen rule requires a gate to beat A0 by **≥20pp detection**, which needs det ≥ 1.15 — **impossible** (ceiling 1.0). Partial B1 (0.93) corroborates. Race stopped early once the verdict became mathematically determined. Full reasoning + caveats + revival trigger in `openspec/changes/db-gate-decision-race/DECISION.md`.

## What's in this PR (reusable eval-race harness)

- `absent` assertion kind added to the behavioral runner (purely additive; 39/39 runner tests green)
- Cross-model (Codex) **held-out corpus**, authored blind to the owned checklist (anti-overfit), with a structural validator
- 3-arm orchestrator (`run-race.sh`) — resumable, session-limit-aware, `DRY_RUN`/`IDS` filters
- Deterministic scorer with the **frozen decision rule** (+ unit tests, now wired into `run-tests.sh`)
- `review-base` emits a machine `DEFECTS:` verdict (structured-verdict scoring) — the fix for the free-text-regex FP-measurement bug the pilot caught
- Committed design/spec/DECISION under `openspec/changes/db-gate-decision-race/`

## Two bugs the pilot caught (why we piloted before 420 calls)
1. Inner `claude -p` couldn't auth under `--bare` (demands API key; we're on OAuth) → `--setting-sources ""`.
2. Free-text FP scoring was invalid (pinned at 1.0 by reviewers correctly *dismissing* concepts) → structured `DEFECTS:` verdict.

## Verification
- `bash tests/run-tests.sh` → **68/68 files passed, 0 failed**
- Whole-branch review (opus): no Critical/Important; governance clean (no `config/`/`hooks/` changes, inner sandbox preserved, no bypass patterns)

## Not shipped
No routing/config change — per spec, a "ship" verdict would open a *separate* change; this one records the measured decision (park) + the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)