### PR TITLE
feat: skill-rules.json routing interop (org-hub PR-X)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **skill-rules.json routing interop (org-hub PR-X):** hub-published plugin skills are now routable. When a discovered plugin skill has no SKILL.md frontmatter `triggers`, the session-start registry builder falls back to the plugin's `skill-rules.json` — translating `promptTriggers.keywords` into lowercased, ERE-escaped, word-boundary-wrapped regexes and passing through only ERE-valid `intentPatterns` (PCRE-only constructs dropped via denylist + in-process `[[ =~ ]]` compile-check, dropped count logged to stderr). Frontmatter triggers still win; fail-open on every path; ~2 jq forks per file (measured ~20ms translation cost for a 30-skill hub). Spec: `openspec/changes/skill-rules-interop/`. Capability: `skill-routing`.
 - Local-adjustability hint: evidence-gated session-start banner line surfacing `~/.claude/skill-config.json` overrides when the previous session's zero-match rate shows routing friction (>=5 misses, >=8 prompts, >=30%; 7-day cooldown; suppressed for users with existing overrides; fail-open).
 
 ### Fixed

--- a/hooks/session-start-hook.sh
+++ b/hooks/session-start-hook.sh
@@ -253,6 +253,61 @@ _parse_frontmatter() {
 }
 
 # -----------------------------------------------------------------
+# skill-rules.json -> ERE trigger translation (hub routing interop)
+# -----------------------------------------------------------------
+# Emits one line per skill:  <name>\t<triggers_json_array>\t<dropped_count>
+# keywords       -> lowercased, ERE-escaped, word-boundary-wrapped regexes
+# intentPatterns -> ERE-valid only: PCRE-only dropped via jq denylist, then
+#                   survivors compile-checked under bash [[ =~ ]].
+# Fail-open: a missing/malformed file yields no output for it.
+_translate_skill_rules() {
+    _srf="$1"
+    [ -f "${_srf}" ] || return 0
+    _sr_rows="$(jq -r '
+        def esc: gsub("(?<c>[.^$*+?()\\[\\]{}|\\\\])"; "\\" + .c);
+        def pcre: "[*+?]\\?|\\{[0-9,]*\\}\\?|\\\\[dDwWsSbB]|\\(\\?[:=!<]|\\\\[1-9]";
+        (.skills // {}) | to_entries[] |
+        .key as $n |
+        ((.value.promptTriggers.keywords // [])
+            | map(select(type=="string" and length>0))
+            | map(ascii_downcase | esc | "(^|[^a-z0-9])" + . + "($|[^a-z0-9])")) as $kw |
+        ((.value.promptTriggers.intentPatterns // [])
+            | map(select(type=="string" and length>0))) as $ipall |
+        ($ipall | map(select(test(pcre) | not))) as $ip |
+        [$n, ($kw|tojson), ($ip|tojson), ($ipall|length|tostring)] | join("\u001f")
+    ' "${_srf}" 2>/dev/null)" || return 0
+    [ -z "${_sr_rows}" ] && return 0
+
+    printf '%s\n' "${_sr_rows}" | while IFS=$'\x1f' read -r _n _kwj _ipj _iporig; do
+        [ -z "${_n}" ] && continue
+        _kept=0
+        _good_lines=""
+        _ip_list="$(printf '%s' "${_ipj}" | jq -r '.[]' 2>/dev/null)"
+        if [ -n "${_ip_list}" ]; then
+            while IFS= read -r _pat; do
+                [ -z "${_pat}" ] && continue
+                [[ "" =~ ${_pat} ]] 2>/dev/null
+                if [ "$?" -ne 2 ]; then
+                    _good_lines="${_good_lines}${_pat}
+"
+                    _kept=$((_kept + 1))
+                fi
+            done <<IPEOF
+${_ip_list}
+IPEOF
+        fi
+        _good_ip="$(printf '%s' "${_good_lines}" | jq -Rn '[inputs | select(length>0)]' 2>/dev/null)"
+        [ -z "${_good_ip}" ] && _good_ip="[]"
+        _trig="$(jq -cn --argjson kw "${_kwj:-[]}" --argjson ip "${_good_ip}" '$kw + $ip' 2>/dev/null)"
+        [ -z "${_trig}" ] && _trig="[]"
+        _drop=0
+        [[ "${_iporig}" =~ ^[0-9]+$ ]] && _drop=$(( _iporig - _kept ))
+        [ "${_drop}" -lt 0 ] && _drop=0
+        printf '%s\t%s\t%s\n' "${_n}" "${_trig}" "${_drop}"
+    done
+}
+
+# -----------------------------------------------------------------
 # Step 3: Discover all external plugin skills (unified scanner)
 # -----------------------------------------------------------------
 EXTERNAL_DISCOVERED=""
@@ -325,6 +380,7 @@ ALL_DISCOVERED="${EXTERNAL_DISCOVERED}${PLUGIN_DISCOVERED}${USER_DISCOVERED}"
 # -----------------------------------------------------------------
 _FM_FILES=""
 _FM_NAMES=""
+_SR_FILES=""
 
 # Scan all external plugins (same traversal as unified scanner in Step 3)
 for _mkt_dir in "${HOME}/.claude/plugins/cache"/*/; do
@@ -337,6 +393,10 @@ for _mkt_dir in "${HOME}/.claude/plugins/cache"/*/; do
         _latest_ver="$(ls -1 "${_plugin_dir}" 2>/dev/null | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)"
         if [ -n "${_latest_ver}" ]; then
             _resolved="${_plugin_dir}${_latest_ver}/"
+        fi
+        # Hub-style routing metadata sits beside skills/ (one file per plugin)
+        if [ -f "${_resolved}skill-rules.json" ]; then
+            _SR_FILES="${_SR_FILES} ${_resolved}skill-rules.json"
         fi
         if [ -d "${_resolved}skills" ]; then
             for _smd in "${_resolved}skills"/*/SKILL.md; do
@@ -376,6 +436,44 @@ if [ -n "${_FM_FILES}" ]; then
             [range(0; [$names | length, ($objs | length)] | min) as $i |
                 {($names[$i]): $objs[$i]}] | add // {}
         ')" || FRONTMATTER_MAP="{}"
+    fi
+fi
+
+# -----------------------------------------------------------------
+# Step 5c: Derive triggers from skill-rules.json for discovered skills
+# whose SKILL.md frontmatter supplied none (hub routing interop).
+# -----------------------------------------------------------------
+if [ -n "${_SR_FILES}" ]; then
+    _SR_OUT=""
+    for _srf in ${_SR_FILES}; do
+        _one="$(_translate_skill_rules "${_srf}")"
+        [ -z "${_one}" ] && continue
+        _SR_OUT="${_SR_OUT}${_one}
+"
+        _file_drop="$(printf '%s' "${_one}" | awk -F'\t' '{s+=$3} END{print s+0}')"
+        if [[ "${_file_drop}" =~ ^[0-9]+$ ]] && [ "${_file_drop}" -gt 0 ]; then
+            _sr_label="$(basename "$(dirname "${_srf}")")"
+            case "${_sr_label}" in
+                [0-9]*.[0-9]*) _sr_label="$(basename "$(dirname "$(dirname "${_srf}")")")" ;;
+            esac
+            printf '[skill-rules] %s: dropped %s PCRE-only/invalid intentPattern(s)\n' \
+                "${_sr_label}" "${_file_drop}" >&2
+        fi
+    done
+    if [ -n "${_SR_OUT}" ]; then
+        _SR_TRIGGERS_MAP="$(printf '%s' "${_SR_OUT}" | jq -Rn '
+            [inputs | select(length>0) | split("\t") | select(length>=2)
+             | {(.[0]): (.[1]|fromjson)}] | add // {}
+        ' 2>/dev/null)"
+        [ -z "${_SR_TRIGGERS_MAP}" ] && _SR_TRIGGERS_MAP="{}"
+        FRONTMATTER_MAP="$(printf '%s' "${FRONTMATTER_MAP}" | jq -c --argjson add "${_SR_TRIGGERS_MAP}" '
+            reduce ($add | to_entries[]) as $e (.;
+                if ((.[$e.key].triggers // []) | length) == 0 and (($e.value | length) > 0)
+                then .[$e.key] = ((.[$e.key] // {}) + {triggers: $e.value})
+                else . end
+            )
+        ' 2>/dev/null)" || FRONTMATTER_MAP="${FRONTMATTER_MAP}"
+        [ -z "${FRONTMATTER_MAP}" ] && FRONTMATTER_MAP="{}"
     fi
 fi
 

--- a/hooks/session-start-hook.sh
+++ b/hooks/session-start-hook.sh
@@ -255,15 +255,24 @@ _parse_frontmatter() {
 # -----------------------------------------------------------------
 # skill-rules.json -> ERE trigger translation (hub routing interop)
 # -----------------------------------------------------------------
-# Emits one line per skill:  <name>\t<triggers_json_array>\t<dropped_count>
-# keywords       -> lowercased, ERE-escaped, word-boundary-wrapped regexes
-# intentPatterns -> ERE-valid only: PCRE-only dropped via jq denylist, then
-#                   survivors compile-checked under bash [[ =~ ]].
-# Fail-open: a missing/malformed file yields no output for it.
+# For one skill-rules.json, prints a single line:  <dropped_count><US><json_map>
+# where json_map is {"<skill>": [<ERE trigger>, ...], ...}.
+#   keywords       -> lowercased, ERE-escaped, word-boundary-wrapped regexes
+#   intentPatterns -> ERE-valid only: PCRE-only dropped via jq denylist (below),
+#                     then survivors compile-checked in-process under [[ =~ ]].
+# The denylist covers the load-bearing PCRE constructs (lazy quantifiers,
+# \d \w \s \b shorthand, (?:/lookarounds, backrefs); exotic anchors like \A
+# pass through as literals and simply mis-match harmlessly). Fork budget is
+# 2 jq calls per FILE (extract + assemble) regardless of skill count -- the
+# compile-check runs in-process. Fail-open: a missing/malformed file yields
+# no output.
 _translate_skill_rules() {
     _srf="$1"
     [ -f "${_srf}" ] || return 0
-    _sr_rows="$(jq -r '
+    # Stage 1 (1 jq): emit records.
+    #   K<US>name<US>kw_json<US>orig_ip_count   (one per skill)
+    #   P<US>name<US>candidate_pattern          (one per denylist survivor)
+    _sr_recs="$(jq -r '
         def esc: gsub("(?<c>[.^$*+?()\\[\\]{}|\\\\])"; "\\" + .c);
         def pcre: "[*+?]\\?|\\{[0-9,]*\\}\\?|\\\\[dDwWsSbB]|\\(\\?[:=!<]|\\\\[1-9]";
         (.skills // {}) | to_entries[] |
@@ -274,37 +283,34 @@ _translate_skill_rules() {
         ((.value.promptTriggers.intentPatterns // [])
             | map(select(type=="string" and length>0))) as $ipall |
         ($ipall | map(select(test(pcre) | not))) as $ip |
-        [$n, ($kw|tojson), ($ip|tojson), ($ipall|length|tostring)] | join("\u001f")
+        ( "K\u001f" + $n + "\u001f" + ($kw|tojson) + "\u001f" + ($ipall|length|tostring) ),
+        ( $ip[] | "P\u001f" + $n + "\u001f" + . )
     ' "${_srf}" 2>/dev/null)" || return 0
-    [ -z "${_sr_rows}" ] && return 0
+    [ -z "${_sr_recs}" ] && return 0
 
-    printf '%s\n' "${_sr_rows}" | while IFS=$'\x1f' read -r _n _kwj _ipj _iporig; do
-        [ -z "${_n}" ] && continue
-        _kept=0
-        _good_lines=""
-        _ip_list="$(printf '%s' "${_ipj}" | jq -r '.[]' 2>/dev/null)"
-        if [ -n "${_ip_list}" ]; then
-            while IFS= read -r _pat; do
-                [ -z "${_pat}" ] && continue
-                [[ "" =~ ${_pat} ]] 2>/dev/null
-                if [ "$?" -ne 2 ]; then
-                    _good_lines="${_good_lines}${_pat}
-"
-                    _kept=$((_kept + 1))
-                fi
-            done <<IPEOF
-${_ip_list}
-IPEOF
-        fi
-        _good_ip="$(printf '%s' "${_good_lines}" | jq -Rn '[inputs | select(length>0)]' 2>/dev/null)"
-        [ -z "${_good_ip}" ] && _good_ip="[]"
-        _trig="$(jq -cn --argjson kw "${_kwj:-[]}" --argjson ip "${_good_ip}" '$kw + $ip' 2>/dev/null)"
-        [ -z "${_trig}" ] && _trig="[]"
-        _drop=0
-        [[ "${_iporig}" =~ ^[0-9]+$ ]] && _drop=$(( _iporig - _kept ))
-        [ "${_drop}" -lt 0 ] && _drop=0
-        printf '%s\t%s\t%s\n' "${_n}" "${_trig}" "${_drop}"
-    done
+    # Stage 2 (0 forks): compile-check candidate patterns in-process; a regex
+    # that fails to compile under bash ERE returns [[ ]] status 2 and is dropped.
+    _sr_kw=""    # lines: name<US>kw_json<US>orig
+    _sr_good=""  # lines: name<US>compilable_pattern
+    while IFS=$'\x1f' read -r _tag _a _b _c; do
+        case "${_tag}" in
+            K) _sr_kw="${_sr_kw}${_a}"$'\x1f'"${_b}"$'\x1f'"${_c}"$'\n' ;;
+            P) [[ "" =~ ${_b} ]] 2>/dev/null
+               [ "$?" -ne 2 ] && _sr_good="${_sr_good}${_a}"$'\x1f'"${_b}"$'\n' ;;
+        esac
+    done <<RECEOF
+${_sr_recs}
+RECEOF
+
+    # Stage 3 (1 jq): assemble name->triggers map + total dropped count.
+    jq -rn --arg kw "${_sr_kw}" --arg good "${_sr_good}" '
+        def rows($s): $s | split("\n") | map(select(length>0) | split("\u001f"));
+        (rows($kw) | map({name:.[0], kw:(.[1]|fromjson), orig:(.[2]|tonumber)})) as $ks |
+        (rows($good) | reduce .[] as $p ({}; .[$p[0]] += [$p[1]])) as $gm |
+        (reduce $ks[] as $k ({}; .[$k.name] = ($k.kw + ($gm[$k.name] // [])))) as $map |
+        (reduce $ks[] as $k (0; . + ($k.orig - (($gm[$k.name] // []) | length)))) as $drop |
+        ($drop|tostring) + "\u001f" + ($map|tojson)
+    ' 2>/dev/null || return 0
 }
 
 # -----------------------------------------------------------------
@@ -444,28 +450,25 @@ fi
 # whose SKILL.md frontmatter supplied none (hub routing interop).
 # -----------------------------------------------------------------
 if [ -n "${_SR_FILES}" ]; then
-    _SR_OUT=""
+    _SR_TRIGGERS_MAP="{}"
     for _srf in ${_SR_FILES}; do
-        _one="$(_translate_skill_rules "${_srf}")"
-        [ -z "${_one}" ] && continue
-        _SR_OUT="${_SR_OUT}${_one}
-"
-        _file_drop="$(printf '%s' "${_one}" | awk -F'\t' '{s+=$3} END{print s+0}')"
-        if [[ "${_file_drop}" =~ ^[0-9]+$ ]] && [ "${_file_drop}" -gt 0 ]; then
+        _res="$(_translate_skill_rules "${_srf}")"
+        [ -z "${_res}" ] && continue
+        _sr_drop="${_res%%$'\x1f'*}"
+        _sr_map="${_res#*$'\x1f'}"
+        [ -z "${_sr_map}" ] && continue
+        _SR_TRIGGERS_MAP="$(jq -cn --argjson a "${_SR_TRIGGERS_MAP}" --argjson b "${_sr_map}" '$a * $b' 2>/dev/null)"
+        [ -z "${_SR_TRIGGERS_MAP}" ] && _SR_TRIGGERS_MAP="{}"
+        if [[ "${_sr_drop}" =~ ^[0-9]+$ ]] && [ "${_sr_drop}" -gt 0 ]; then
             _sr_label="$(basename "$(dirname "${_srf}")")"
             case "${_sr_label}" in
                 [0-9]*.[0-9]*) _sr_label="$(basename "$(dirname "$(dirname "${_srf}")")")" ;;
             esac
             printf '[skill-rules] %s: dropped %s PCRE-only/invalid intentPattern(s)\n' \
-                "${_sr_label}" "${_file_drop}" >&2
+                "${_sr_label}" "${_sr_drop}" >&2
         fi
     done
-    if [ -n "${_SR_OUT}" ]; then
-        _SR_TRIGGERS_MAP="$(printf '%s' "${_SR_OUT}" | jq -Rn '
-            [inputs | select(length>0) | split("\t") | select(length>=2)
-             | {(.[0]): (.[1]|fromjson)}] | add // {}
-        ' 2>/dev/null)"
-        [ -z "${_SR_TRIGGERS_MAP}" ] && _SR_TRIGGERS_MAP="{}"
+    if [ "${_SR_TRIGGERS_MAP}" != "{}" ]; then
         FRONTMATTER_MAP="$(printf '%s' "${FRONTMATTER_MAP}" | jq -c --argjson add "${_SR_TRIGGERS_MAP}" '
             reduce ($add | to_entries[]) as $e (.;
                 if ((.[$e.key].triggers // []) | length) == 0 and (($e.value | length) > 0)

--- a/openspec/changes/skill-rules-interop/design.md
+++ b/openspec/changes/skill-rules-interop/design.md
@@ -92,6 +92,16 @@ keywords are the load-bearing routing source. That is expected and logged.
 4. Triggers-only; `type`/`priority`/`enforcement` mapping deferred.
 5. Drop count logged to stderr once per plugin when non-zero; stdout stays clean.
 
+## Follow-up (noted, out of scope for PR-X)
+
+Because nearly every real `intentPatterns` entry is PCRE (`.*?`, `(?!...)`) and
+gets dropped, keyword quality becomes the sole routing signal for hub skills.
+A follow-up could surface **which** skills lost the most patterns (a per-skill
+dropped-pattern breakdown, not just a per-plugin count) so hub authors can
+rewrite them as ERE or lean harder on keywords. PR-X logs only the aggregate
+per-plugin count to stderr; the richer author-facing breakdown is deferred
+(revival trigger: a hub author reports routing gaps traced to dropped patterns).
+
 ## Security posture
 
 Read-only of local, already-installed plugin files. skill-rules.json content

--- a/openspec/changes/skill-rules-interop/design.md
+++ b/openspec/changes/skill-rules-interop/design.md
@@ -1,0 +1,100 @@
+# Design: skill-rules.json Routing Interop (PR-X)
+
+## Architecture
+
+The translation is **deterministic** (string escaping + regex validation), so
+it belongs in the build-time hook — this does not violate the org-hub principle
+that the hook does "zero fuzzy work" (nothing inferential happens here).
+
+**Integration point:** Step 5b of `session-start-hook.sh` already traverses
+every cache plugin's `skills/*/SKILL.md` to build `FRONTMATTER_MAP`
+(name → {triggers, role, phase, ...}). We piggyback on that same traversal:
+for each plugin we also note its `skill-rules.json` (sibling to `skills/`, at
+the resolved plugin/version root). After `FRONTMATTER_MAP` is built, a single
+jq helper reads every collected `skill-rules.json` and, **only for skill names
+whose frontmatter entry has no `triggers`**, injects a translated `triggers`
+array back into `FRONTMATTER_MAP`.
+
+Because both downstream consumers already read `$fm.triggers` —
+Step 6 (defaults merge, line ~403) and Step 7 (custom-skill build, line ~455) —
+no downstream wiring changes. Hub skills are not in `default-triggers.json`, so
+they flow through Step 7 as customs and pick up the injected triggers there.
+
+```
+Step 5b traversal (cache plugins)
+   ├─ collect SKILL.md paths  → _parse_frontmatter → FRONTMATTER_MAP
+   └─ collect skill-rules.json paths (one per plugin, when present)
+                                    │
+                                    ▼
+   _derive_skillrules_triggers (jq): for each rules file, for each skill,
+     keywords → escaped, lowercased, boundary-wrapped ERE regexes
+     intentPatterns → drop PCRE-only (denylist), keep survivors
+                                    │
+                                    ▼
+   merge into FRONTMATTER_MAP.<name>.triggers  ONLY where currently absent
+   + secondary bash compile-check drops uncompilable survivors, logs drop count
+```
+
+## Keyword → regex translation
+
+Engine facts (verified in `skill-activation-hook.sh`): prompt `P` is lowercased
+(`:78`); triggers are ERE-matched `[[ "$P" =~ $trigger ]]` (`:196`); a
+boundary post-scan awards 30 pts on a word boundary vs 10 for a bare substring
+(`:213-214`). The repo's house word-boundary idiom is `(^|[^a-z0-9])`, **not**
+`\b` (`:1521` comment: "ERE avoids \b (BSD grep) and PCRE").
+
+Per keyword: `ascii_downcase` → escape ERE metacharacters `. ^ $ * + ? ( ) [ ] { } | \`
+→ wrap `(^|[^a-z0-9])<escaped>($|[^a-z0-9])`. Result: `"PR"` matches `open a pr`
+but not `compression`; `"values.yaml"` matches the literal, dot escaped.
+
+## intentPattern ERE validation
+
+Two-stage drop:
+
+1. **jq denylist** (primary, the proposal's stated mechanism) — drop any pattern
+   matching PCRE-only constructs: lazy quantifiers (`.*?`, `.+?`, `*?`, `+?`,
+   `??`, `{n,m}?`), backslash shorthand (`\d \w \s \D \W \S \b \B`),
+   special groups / lookarounds (`(?:`, `(?=`, `(?!`, `(?<=`, `(?<!`),
+   backreferences (`\1`–`\9`).
+2. **bash compile-check** (secondary net) — each survivor is tested with
+   `[[ x =~ $pat ]]` in a subshell; exit status 2 (regcomp failure) drops it.
+   Catches malformed-but-not-PCRE patterns (e.g. unbalanced parens) that would
+   otherwise make the activation hook emit a regex error on **every** prompt.
+
+Reality: nearly every real intentPattern uses `.*?` / `(?!` and is dropped —
+keywords are the load-bearing routing source. That is expected and logged.
+
+## Trade-offs (accepted)
+
+- **Most intentPatterns are dropped.** Accepted and by design — PCRE patterns
+  cannot run under bash ERE; silently keeping them would misbehave (the
+  `feedback_bash_ere_no_pcre_quantifiers` failure mode). Keywords carry routing.
+- **Boundary-wrapped triggers score in the substring tier (10), not 30.** The
+  engine's boundary post-scan sees word chars adjacent to the boundary-char the
+  regex already consumed. Consistent with existing `(^|[^a-z])`-prefixed triggers
+  in `default-triggers.json`; still routes correctly.
+- **cache-only discovery scope.** Marketplace-registered-but-uninstalled plugins
+  are not scanned — but installed plugins land in cache with their
+  `skill-rules.json`, which is the actual bug surface. Widening discovery is a
+  separate concern.
+- **Frontmatter precedence.** A skill carrying both frontmatter triggers and a
+  skill-rules entry keeps frontmatter (more specific/curated). skill-rules is a
+  fallback, not an override.
+
+## Decisions
+
+1. Fold into the existing Step 5b traversal + `FRONTMATTER_MAP`; no new plugin
+   walk, no downstream consumer changes.
+2. Lowercase keywords (engine lowercases the prompt; case-preserving would never
+   match without an engine change — out of scope).
+3. Denylist + secondary compile-check (protects the activation hook from
+   erroring every prompt on a malformed survivor).
+4. Triggers-only; `type`/`priority`/`enforcement` mapping deferred.
+5. Drop count logged to stderr once per plugin when non-zero; stdout stays clean.
+
+## Security posture
+
+Read-only of local, already-installed plugin files. skill-rules.json content
+becomes routing regexes only (never injected as instructions). No trifecta legs
+added by this change. Malformed input degrades to empty triggers (fail-open),
+never an abort — preserving the hook's fail-open contract.

--- a/openspec/changes/skill-rules-interop/design.md
+++ b/openspec/changes/skill-rules-interop/design.md
@@ -126,3 +126,19 @@ Read-only of local, already-installed plugin files. skill-rules.json content
 becomes routing regexes only (never injected as instructions). No trifecta legs
 added by this change. Malformed input degrades to empty triggers (fail-open),
 never an abort — preserving the hook's fail-open contract.
+
+## Implementation Notes (synced at ship time — PR-X, 2026-07-08)
+
+Shipped as designed. Two refinements captured during code review, both retested:
+
+- **Batched translation.** The first cut used a per-skill loop with 3 jq forks
+  per skill; a measured 30-skill hub added ~520ms over baseline. Reworked
+  `_translate_skill_rules` to 2 jq forks per FILE (extract K/P records → in-process
+  compile-check → assemble map), bringing the translation-only delta to ~20ms
+  for 30 skills. Behavior unchanged; all unit tests + full suite green.
+- **Test assertions extract raw triggers** (`jq -r '.triggers[]'`) rather than the
+  `jq -c` JSON form, so an escaped metacharacter like `values\.yaml` is matched as
+  the real regex string, not its JSON-doubled `values\\.yaml` serialization.
+
+Archive deferred to merge time (consistent with the parent org-hub-connector
+change, which stays active across its PRs).

--- a/openspec/changes/skill-rules-interop/design.md
+++ b/openspec/changes/skill-rules-interop/design.md
@@ -80,6 +80,24 @@ keywords are the load-bearing routing source. That is expected and logged.
 - **Frontmatter precedence.** A skill carrying both frontmatter triggers and a
   skill-rules entry keeps frontmatter (more specific/curated). skill-rules is a
   fallback, not an override.
+- **Default-triggers interaction.** skill-rules triggers sit at the frontmatter
+  tier (above `default-triggers.json`). If an external plugin shipped a skill
+  whose name collided with a curated default skill AND provided skill-rules
+  keywords, those keywords would override the curated triggers. Accepted:
+  correct-by-design (frontmatter tier wins), the own plugin is skipped in
+  discovery, and cross-plugin name collisions with curated skills are unlikely.
+
+## Performance (measured)
+
+Fork budget was the one substantive review concern. The translator is **2 jq
+forks per skill-rules.json file** (extract records → in-process bash
+compile-check → assemble map), independent of skill count, plus one map-merge
+per file and one final `FRONTMATTER_MAP` merge. Measured on macOS `/bin/bash`
+3.2 with a synthetic 30-skill single-file hub (2 keywords + 3 intentPatterns
+each): translation-only delta (30 skills **with** vs **without** `skill-rules.json`,
+same discovery cost both sides) is **~20 ms**. The larger cost of a big hub is
+discovering the skills themselves (frontmatter parsing), which is
+feature-independent. Well within the 200 ms session-start budget.
 
 ## Decisions
 

--- a/openspec/changes/skill-rules-interop/proposal.md
+++ b/openspec/changes/skill-rules-interop/proposal.md
@@ -1,0 +1,68 @@
+# Proposal: skill-rules.json Routing Interop (org-hub PR-X)
+
+## Why
+
+Hub-published (and any externally-installed) plugins are discovered by the
+session-start registry builder, but land with **empty triggers** whenever their
+routing metadata lives in a sibling `skill-rules.json` rather than in SKILL.md
+frontmatter. The builder ignores `skill-rules.json`, so those skills are
+**unroutable** — they never score against a prompt and never surface in
+activation context.
+
+`skill-rules.json` is the routing convention several hub plugins already ship
+(verified: 4 real files under `plugins/marketplaces/oviva-hub/plugins/*/` use
+`{skills.<name>.promptTriggers.{keywords,intentPatterns}}`). This is the
+committed, independent follow-up (PR-X) recorded in the org-hub-connector
+proposal — conflict-free with that change, landing after PR1 fixtures exist.
+
+## What Changes
+
+During registry build, when a discovered plugin skill has **no** SKILL.md
+frontmatter `triggers`, fall back to the plugin's `skill-rules.json`:
+
+1. **`promptTriggers.keywords` → word-boundary ERE regexes.** Each keyword is
+   lowercased (the engine lowercases the prompt before matching), ERE
+   metacharacters are escaped, and it is wrapped in the repo's house
+   word-boundary idiom `(^|[^a-z0-9])KW($|[^a-z0-9])` — never `\b` (the repo
+   deliberately avoids `\b` for BSD/PCRE portability).
+2. **`promptTriggers.intentPatterns` → ERE-validated pass-through.** PCRE-only
+   constructs (lazy quantifiers `*? +? ?? .*?`, shorthand `\d \w \s \b \B`,
+   non-capturing groups / lookarounds `(?: (?= (?! (?<`, backreferences `\1`)
+   are dropped via denylist; survivors are then compile-checked under bash
+   `[[ =~ ]]` and any that still fail to compile are also dropped. The dropped
+   count is logged to stderr, once per plugin, when non-zero.
+3. **Frontmatter still wins.** skill-rules triggers apply only where SKILL.md
+   frontmatter supplied none. No change to skills already carrying triggers.
+
+Fail-open on every path (missing/malformed `skill-rules.json`, missing jq, no
+matching skill entry): the skill simply keeps its empty triggers — never an
+abort. stdout stays clean JSON; the drop-count log goes to stderr only.
+
+## Capabilities
+
+- **Modified: `skill-routing`** — registry build gains a `skill-rules.json`
+  trigger-derivation fallback for frontmatter-triggerless discovered skills.
+
+## Impact
+
+- `hooks/session-start-hook.sh` — new deterministic translation folded into the
+  existing Step 5b frontmatter traversal + `FRONTMATTER_MAP` build (~30 lines +
+  one jq helper; +1 file read and +1 jq fork only for plugins that ship a
+  `skill-rules.json`). Well within the 200ms budget (hub plugins are single-digit).
+- `tests/test-registry.sh` — red-first fixtures: a cache plugin with
+  `skill-rules.json` + a frontmatter-triggerless SKILL.md.
+- No `config/default-triggers.json` / `config/fallback-registry.json` change
+  (no curated-skill or capability-key change → no lockstep obligation).
+- No new skill, no routing-fixture obligation (this is registry plumbing, not a
+  new owned skill).
+
+## Out of Scope
+
+- Adding a marketplaces-dir scan. Installed plugins already land in
+  `~/.claude/plugins/cache/`; the fix operates on the existing discovery scope.
+- Mapping `skill-rules.json` `type` / `priority` / `enforcement` →
+  role / priority (custom-skill defaults already cover role=domain; deferred).
+- `fileTriggers` / any non-`promptTriggers` sections of `skill-rules.json`.
+- `skills/project-verification/` and `hooks/lib/verdict.sh` (owned by a parallel
+  session; untouched).
+- org-hub PR2 tier wiring.

--- a/openspec/changes/skill-rules-interop/proposal.md
+++ b/openspec/changes/skill-rules-interop/proposal.md
@@ -10,7 +10,7 @@ frontmatter. The builder ignores `skill-rules.json`, so those skills are
 activation context.
 
 `skill-rules.json` is the routing convention several hub plugins already ship
-(verified: 4 real files under `plugins/marketplaces/oviva-hub/plugins/*/` use
+(verified against real installed hub plugins whose files use the shape
 `{skills.<name>.promptTriggers.{keywords,intentPatterns}}`). This is the
 committed, independent follow-up (PR-X) recorded in the org-hub-connector
 proposal — conflict-free with that change, landing after PR1 fixtures exist.

--- a/openspec/changes/skill-rules-interop/specs/skill-routing/spec.md
+++ b/openspec/changes/skill-rules-interop/specs/skill-routing/spec.md
@@ -1,0 +1,45 @@
+# skill-routing (delta)
+
+## ADDED Requirements
+
+### Requirement: skill-rules.json Trigger Derivation
+
+The session-start registry builder MUST derive routing triggers from a
+discovered plugin's `skill-rules.json` when the corresponding SKILL.md
+frontmatter supplies no `triggers`. `promptTriggers.keywords` MUST be translated
+to word-boundary ERE regexes and `promptTriggers.intentPatterns` MUST be passed
+through only when ERE-valid. All failure paths MUST fail open (the skill keeps
+empty triggers; the hook never aborts).
+
+#### Scenario: Keyword translated to word-boundary regex
+- **WHEN** a discovered plugin skill has no frontmatter `triggers` and its
+  `skill-rules.json` lists the keyword `branch`
+- **THEN** the built registry entry for that skill MUST contain a trigger
+  `(^|[^a-z0-9])branch($|[^a-z0-9])`
+
+#### Scenario: Keyword lowercased and metacharacters escaped
+- **WHEN** the keyword is `values.yaml` or an acronym such as `PR`
+- **THEN** the generated trigger MUST be lowercased and MUST escape ERE
+  metacharacters (e.g. `values\.yaml`), so it matches the lowercased prompt at a
+  word boundary and not as a mid-word substring
+
+#### Scenario: PCRE-only intentPattern dropped with logged count
+- **WHEN** an `intentPatterns` entry uses a PCRE-only construct such as `.*?` or
+  `(?!...)`
+- **THEN** that pattern MUST NOT appear in the skill's triggers **AND** the
+  builder MUST log the dropped count to stderr (never to stdout)
+
+#### Scenario: ERE-valid intentPattern preserved
+- **WHEN** an `intentPatterns` entry is a valid ERE (e.g. `(create|start).*(branch|feature)`)
+- **THEN** that pattern MUST appear verbatim in the skill's triggers
+
+#### Scenario: Frontmatter triggers take precedence
+- **WHEN** a discovered skill has both SKILL.md frontmatter `triggers` and a
+  `skill-rules.json` entry
+- **THEN** the frontmatter triggers MUST be used and the `skill-rules.json`
+  entry MUST be ignored for that skill
+
+#### Scenario: Malformed skill-rules.json fails open
+- **WHEN** a plugin's `skill-rules.json` is missing, empty, or not valid JSON
+- **THEN** the affected skill MUST keep empty triggers and the registry build
+  MUST complete normally (fail-open, no abort)

--- a/tests/test-registry.sh
+++ b/tests/test-registry.sh
@@ -2250,4 +2250,50 @@ fi
 teardown_test_env
 
 
+# ---------------------------------------------------------------------------
+# skill-rules.json routing interop (org-hub PR-X)
+# ---------------------------------------------------------------------------
+echo "-- test: skill-rules.json keywords become word-boundary triggers --"
+setup_test_env
+_hub="${HOME}/.claude/plugins/cache/oviva-hub/hub-plugin/1.0.0"
+mkdir -p "${_hub}/skills/hub-skill"
+printf '%s\n' '---' 'name: hub-skill' 'description: A hub skill' '---' '# Hub Skill' \
+    > "${_hub}/skills/hub-skill/SKILL.md"
+cat > "${_hub}/skill-rules.json" <<'JSON'
+{ "skills": { "hub-skill": { "promptTriggers": {
+  "keywords": ["branch", "values.yaml", "PR"] } } } }
+JSON
+run_hook >/dev/null
+_cf="${HOME}/.claude/.skill-registry-cache.json"
+# Extract raw trigger strings (jq -r) so regex backslashes are not JSON-doubled
+_trigs="$(jq -r '.skills[] | select(.name=="hub-skill") | .triggers[]' "${_cf}" 2>/dev/null)"
+if printf '%s\n' "${_trigs}" | grep -qxF '(^|[^a-z0-9])branch($|[^a-z0-9])' \
+   && printf '%s\n' "${_trigs}" | grep -qxF '(^|[^a-z0-9])values\.yaml($|[^a-z0-9])' \
+   && printf '%s\n' "${_trigs}" | grep -qxF '(^|[^a-z0-9])pr($|[^a-z0-9])'; then
+    echo "  PASS: keywords translated to lowercased, escaped, boundary-wrapped triggers"; TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    echo "  FAIL: got triggers=${_trigs}"; TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+teardown_test_env
+
+echo "-- test: frontmatter triggers win over skill-rules --"
+setup_test_env
+_hub2="${HOME}/.claude/plugins/cache/oviva-hub/fm-plugin/1.0.0"
+mkdir -p "${_hub2}/skills/fm-skill"
+printf '%s\n' '---' 'name: fm-skill' 'description: fm' 'triggers:' '  - "customtrig"' '---' '# FM' \
+    > "${_hub2}/skills/fm-skill/SKILL.md"
+cat > "${_hub2}/skill-rules.json" <<'JSON'
+{ "skills": { "fm-skill": { "promptTriggers": { "keywords": ["ignored"] } } } }
+JSON
+run_hook >/dev/null
+_cf2="${HOME}/.claude/.skill-registry-cache.json"
+_ft="$(jq -c '.skills[] | select(.name=="fm-skill") | .triggers' "${_cf2}" 2>/dev/null)"
+if printf '%s' "${_ft}" | grep -qF 'customtrig' && ! printf '%s' "${_ft}" | grep -qF 'ignored'; then
+    echo "  PASS: frontmatter triggers preserved, skill-rules ignored"; TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    echo "  FAIL: got triggers=${_ft}"; TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+teardown_test_env
+
+
 print_summary

--- a/tests/test-registry.sh
+++ b/tests/test-registry.sh
@@ -2255,7 +2255,7 @@ teardown_test_env
 # ---------------------------------------------------------------------------
 echo "-- test: skill-rules.json keywords become word-boundary triggers --"
 setup_test_env
-_hub="${HOME}/.claude/plugins/cache/oviva-hub/hub-plugin/1.0.0"
+_hub="${HOME}/.claude/plugins/cache/example-hub/hub-plugin/1.0.0"
 mkdir -p "${_hub}/skills/hub-skill"
 printf '%s\n' '---' 'name: hub-skill' 'description: A hub skill' '---' '# Hub Skill' \
     > "${_hub}/skills/hub-skill/SKILL.md"
@@ -2278,7 +2278,7 @@ teardown_test_env
 
 echo "-- test: frontmatter triggers win over skill-rules --"
 setup_test_env
-_hub2="${HOME}/.claude/plugins/cache/oviva-hub/fm-plugin/1.0.0"
+_hub2="${HOME}/.claude/plugins/cache/example-hub/fm-plugin/1.0.0"
 mkdir -p "${_hub2}/skills/fm-skill"
 printf '%s\n' '---' 'name: fm-skill' 'description: fm' 'triggers:' '  - "customtrig"' '---' '# FM' \
     > "${_hub2}/skills/fm-skill/SKILL.md"
@@ -2297,7 +2297,7 @@ teardown_test_env
 
 echo "-- test: intentPatterns ERE-validated (PCRE dropped, valid kept, malformed dropped) --"
 setup_test_env
-_hub3="${HOME}/.claude/plugins/cache/oviva-hub/ip-plugin/1.0.0"
+_hub3="${HOME}/.claude/plugins/cache/example-hub/ip-plugin/1.0.0"
 mkdir -p "${_hub3}/skills/ip-skill"
 printf '%s\n' '---' 'name: ip-skill' 'description: ip' '---' '# IP' \
     > "${_hub3}/skills/ip-skill/SKILL.md"
@@ -2320,6 +2320,46 @@ if printf '%s\n' "${_it}" | grep -qxF '(create|start).*(branch|feature)' \
 else
     echo "  FAIL: got triggers=${_it}"; TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
+teardown_test_env
+
+echo "-- test: malformed skill-rules.json fails open --"
+setup_test_env
+_hub4="${HOME}/.claude/plugins/cache/example-hub/bad-plugin/1.0.0"
+mkdir -p "${_hub4}/skills/bad-skill"
+printf '%s\n' '---' 'name: bad-skill' 'description: bad' '---' '# Bad' \
+    > "${_hub4}/skills/bad-skill/SKILL.md"
+printf '%s' 'not json{' > "${_hub4}/skill-rules.json"
+run_hook >/dev/null; _rc=$?
+_cf4="${HOME}/.claude/.skill-registry-cache.json"
+_bt="$(jq -c '.skills[] | select(.name=="bad-skill") | .triggers' "${_cf4}" 2>/dev/null)"
+if [ "${_rc}" -eq 0 ] && [ -f "${_cf4}" ] && [ "${_bt}" = "[]" ]; then
+    echo "  PASS: malformed skill-rules.json -> empty triggers, build completed (exit 0)"; TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    echo "  FAIL: rc=${_rc} triggers=${_bt}"; TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+teardown_test_env
+
+echo "-- test: dropped-count logs to stderr, never stdout --"
+setup_test_env
+_hub5="${HOME}/.claude/plugins/cache/example-hub/log-plugin/1.0.0"
+mkdir -p "${_hub5}/skills/log-skill"
+printf '%s\n' '---' 'name: log-skill' 'description: log' '---' '# Log' \
+    > "${_hub5}/skills/log-skill/SKILL.md"
+cat > "${_hub5}/skill-rules.json" <<'JSON'
+{ "skills": { "log-skill": { "promptTriggers": {
+  "keywords": ["deploy"],
+  "intentPatterns": ["(a).*?(b)", "(c).+?(d)"] } } } }
+JSON
+CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" _SKILL_TEST_MODE=1 bash "${HOOK}" 2>"/tmp/sr_stderr.$$" >"/tmp/sr_stdout.$$"
+if grep -qF '[skill-rules]' "/tmp/sr_stderr.$$" \
+   && grep -qE 'dropped 2 ' "/tmp/sr_stderr.$$" \
+   && ! grep -qF '[skill-rules]' "/tmp/sr_stdout.$$" \
+   && jq -e . "/tmp/sr_stdout.$$" >/dev/null 2>&1; then
+    echo "  PASS: drop count on stderr, stdout is clean valid JSON"; TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    echo "  FAIL: stderr=$(cat "/tmp/sr_stderr.$$")"; TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+rm -f "/tmp/sr_stderr.$$" "/tmp/sr_stdout.$$"
 teardown_test_env
 
 

--- a/tests/test-registry.sh
+++ b/tests/test-registry.sh
@@ -2295,5 +2295,32 @@ else
 fi
 teardown_test_env
 
+echo "-- test: intentPatterns ERE-validated (PCRE dropped, valid kept, malformed dropped) --"
+setup_test_env
+_hub3="${HOME}/.claude/plugins/cache/oviva-hub/ip-plugin/1.0.0"
+mkdir -p "${_hub3}/skills/ip-skill"
+printf '%s\n' '---' 'name: ip-skill' 'description: ip' '---' '# IP' \
+    > "${_hub3}/skills/ip-skill/SKILL.md"
+cat > "${_hub3}/skill-rules.json" <<'JSON'
+{ "skills": { "ip-skill": { "promptTriggers": {
+  "keywords": ["deploy"],
+  "intentPatterns": [
+    "(create|start).*(branch|feature)",
+    "(deploy|release).*?(prod)",
+    "(unbalanced"
+  ] } } } }
+JSON
+run_hook >/dev/null
+_cf3="${HOME}/.claude/.skill-registry-cache.json"
+_it="$(jq -r '.skills[] | select(.name=="ip-skill") | .triggers[]' "${_cf3}" 2>/dev/null)"
+if printf '%s\n' "${_it}" | grep -qxF '(create|start).*(branch|feature)' \
+   && ! printf '%s\n' "${_it}" | grep -qF '.*?(prod)' \
+   && ! printf '%s\n' "${_it}" | grep -qF '(unbalanced'; then
+    echo "  PASS: valid ERE kept, PCRE and malformed intentPatterns dropped"; TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    echo "  FAIL: got triggers=${_it}"; TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+teardown_test_env
+
 
 print_summary


### PR DESCRIPTION
## Why

Hub-published (and any externally-installed) plugin skills are discovered by the session-start registry builder but land with **empty triggers** when their routing metadata lives in a sibling `skill-rules.json` rather than SKILL.md frontmatter — so they are **unroutable**. This is the committed, independent follow-up (PR-X) from the org-hub-connector proposal.

## What changed

During registry build, when a discovered plugin skill has no SKILL.md frontmatter `triggers`, the builder falls back to the plugin's `skill-rules.json`:

- **`promptTriggers.keywords` → word-boundary ERE regexes**: lowercased (engine lowercases the prompt), ERE-metacharacters escaped, wrapped in the repo's `(^|[^a-z0-9])KW($|[^a-z0-9])` idiom (never `\b`). e.g. `PR` → `(^|[^a-z0-9])pr($|[^a-z0-9])`; `values.yaml` → `values\.yaml`.
- **`promptTriggers.intentPatterns` → ERE-valid pass-through**: PCRE-only constructs (lazy quantifiers, `\d \w \s \b`, `(?:`/lookarounds, backrefs) dropped via jq denylist, then survivors compile-checked in-process under `[[ =~ ]]`. Dropped count logged to stderr (never stdout). In practice most real intentPatterns are PCRE and get dropped — keywords are the load-bearing routing signal (documented follow-up to surface per-skill drop breakdown).
- **Frontmatter triggers always win**; skill-rules is a fallback, not an override.
- **Fail-open everywhere** (missing/malformed file, missing jq → skill keeps empty triggers, hook never aborts). stdout stays clean JSON.

## Scope

`hooks/session-start-hook.sh` (Step 5b traversal + new Step 5c) + `tests/test-registry.sh`. No `config/` change (no curated-skill or capability-key change → no lockstep). No new skill.

## Performance

`_translate_skill_rules` is **2 jq forks per file** (extract records → in-process compile-check → assemble), independent of skill count. Measured on macOS bash 3.2: translation-only delta for a 30-skill hub is **~20 ms** (30 skills with vs without `skill-rules.json`). Well within the 200 ms budget.

## Testing

Red-first TDD. 5 new `test-registry.sh` cases (keyword translation, frontmatter precedence, intentPattern ERE-validation, malformed fail-open, stderr-only drop logging). Full suite: **78/78 files pass** under `/bin/bash` 3.2. Code-reviewed (batching refactor + measurement was the one substantive follow-up, now resolved).

Spec: `openspec/changes/skill-rules-interop/` (capability `skill-routing`, `openspec validate --strict` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)