### PR TITLE
fix: exact-HEAD verdict outranks own-token ancestor in verdict_resolve_token (#123)

### DIFF
--- a/hooks/lib/verdict.sh
+++ b/hooks/lib/verdict.sh
@@ -50,43 +50,52 @@ verdict_covers_head() {
 # (issue #51). Concurrent sessions clobber the singleton (last-writer-wins) so the two
 # tokens diverge and a token-scoped read would never find the verdict — a live deadlock.
 #
-# To stay byte-identical when the session's own verdict is usable, this returns
-# <session_token> whenever ITS artifact covers HEAD. ONLY otherwise (the divergence
-# case) does it scan sibling ~/.claude/.skill-project-verified-* artifacts and return
-# the first one bound to the same HEAD, preferring a FAILURE at HEAD (deny-bias /
-# anti-gate-gaming) over a clean one. If nothing covers HEAD, returns <session_token>
-# unchanged (absent/stale semantics preserved). sha==HEAD remains the sole authority —
-# no forgery surface is added (token-scoping was session-isolation, never a security
-# property). Fail-open: echoes <session_token> on any error.
+# Precedence (issue #123 — an EXACT-HEAD verdict, ANY token, outranks an own ANCESTOR one):
+#   1. Own token's verdict at EXACT HEAD -> use it (strongest own evidence; byte-identical
+#      fast path, no sibling scan). Ancestor-only own coverage NO LONGER short-circuits here.
+#   2. Cross-token bridge: sibling artifacts bound to the EXACT HEAD; a FAILURE at HEAD
+#      outranks a clean one (deny-bias / anti-gate-gaming). This is now ALSO reached when the
+#      own verdict covers HEAD only via an ANCESTOR — pre-#123 that ancestor short-circuit
+#      shadowed a genuine sibling exact-HEAD verdict and false-blocked routing-governance.
+#   3. Own token's ANCESTOR coverage (fallback) -> use it; else <session_token> unchanged
+#      (absent/stale semantics preserved).
+# This widens WHEN the bridge is consulted, not WHAT it accepts: cross-token acceptance stays
+# EXACT-HEAD only (ancestor acceptance is scoped to the own token), so no forgery surface is
+# added (token-scoping was session-isolation, never a security property). The grep -F prefilter
+# on the HEAD sha still bounds the jq/git forks to the few files naming HEAD (usually 0-2).
+# Fail-open: echoes <session_token> on any error.
 verdict_resolve_token() {
     local session_token="${1:-}" proot="${2:-}" head f base tok best_clean=""
-    # 1. Session token's own verdict covers HEAD (equal OR ancestor) -> use it. This is
-    #    byte-identical to prior single-token behavior, including ancestor acceptance.
+    # 1. Own verdict at EXACT HEAD -> use it, no sibling scan (byte-identical fast path).
+    #    NOTE: verdict_sha_is_head, NOT verdict_covers_head — an own ANCESTOR verdict must
+    #    NOT short-circuit past a sibling verdict measured at the exact HEAD (issue #123).
+    if [ -n "$session_token" ] && verdict_sha_is_head "$session_token" "$proot"; then
+        printf '%s' "$session_token"; return 0
+    fi
+    head="$(git -C "${proot:-.}" rev-parse HEAD 2>/dev/null)" || head=""
+    if [ -n "$head" ]; then
+        # 2. Cross-token bridge: sibling artifacts bound to the EXACT HEAD. Failure@HEAD
+        #    outranks clean (deny-bias). Own token skipped — steps 1/3 own it. A grep -F
+        #    prefilter on the HEAD sha bounds the jq/git forks to the files naming HEAD.
+        while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            base="${f##*/}"                               # fork-free basename (bash 3.2; no BSD -- ambiguity)
+            tok="${base#.skill-project-verified-}"
+            [ -z "$tok" ] && continue
+            [ "$tok" = "$session_token" ] && continue
+            verdict_sha_is_head "$tok" "$proot" || continue   # jq-confirm exact HEAD (grep can match other fields)
+            if verdict_has_test_failure "$tok"; then printf '%s' "$tok"; return 0; fi
+            [ -z "$best_clean" ] && verdict_is_clean "$tok" && best_clean="$tok"
+        done <<EOF
+$(grep -lF "$head" "${HOME}/.claude/.skill-project-verified-"* 2>/dev/null)
+EOF
+        [ -n "$best_clean" ] && { printf '%s' "$best_clean"; return 0; }
+    fi
+    # 3. No exact-HEAD verdict anywhere -> fall back to the session's OWN coverage, which
+    #    ACCEPTS an ANCESTOR (scoped to the own token — forgery posture). Else unchanged.
     if [ -n "$session_token" ] && verdict_covers_head "$session_token" "$proot"; then
         printf '%s' "$session_token"; return 0
     fi
-    # 2. Cross-token bridge: consult sibling artifacts, but ONLY those bound to the EXACT
-    #    HEAD. A foreign session's verdict is authoritative for THIS push solely when
-    #    measured at this precise commit — the forgery-resistant binding (ancestor
-    #    acceptance stays scoped to the session's own token, step 1). A grep -F prefilter
-    #    on the HEAD sha bounds the jq/git forks to the few files naming HEAD (usually
-    #    0-2), so the scan cost does not grow with an un-GC'd artifact dir. A failure at
-    #    HEAD outranks a clean one (deny-bias / anti-gate-gaming).
-    head="$(git -C "${proot:-.}" rev-parse HEAD 2>/dev/null)" || head=""
-    [ -z "$head" ] && { printf '%s' "$session_token"; return 0; }
-    while IFS= read -r f; do
-        [ -n "$f" ] || continue
-        base="${f##*/}"                                   # fork-free basename (bash 3.2; no BSD -- ambiguity)
-        tok="${base#.skill-project-verified-}"
-        [ -z "$tok" ] && continue
-        [ "$tok" = "$session_token" ] && continue
-        verdict_sha_is_head "$tok" "$proot" || continue   # jq-confirm exact HEAD (grep can match other fields)
-        if verdict_has_test_failure "$tok"; then printf '%s' "$tok"; return 0; fi
-        [ -z "$best_clean" ] && verdict_is_clean "$tok" && best_clean="$tok"
-    done <<EOF
-$(grep -lF "$head" "${HOME}/.claude/.skill-project-verified-"* 2>/dev/null)
-EOF
-    [ -n "$best_clean" ] && { printf '%s' "$best_clean"; return 0; }
     printf '%s' "$session_token"
 }
 

--- a/tests/test-push-gate-verdict.sh
+++ b/tests/test-push-gate-verdict.sh
@@ -141,6 +141,17 @@ printf '%s' "$(jq -nc '{failed:[],could_not_verify:[],gate_gaming_status:"clean"
 out="$(run_in "${CV}")"
 assert_contains "foreign verdict not@HEAD => still deny (sha binding intact)" '"deny"' "${out:-<empty>}"
 
+# (12) PR #121 scenario (issue #123): OWN token clean at an ANCESTOR + FOREIGN token clean at
+# EXACT HEAD, routing changed after the ancestor. Pre-fix, the resolver short-circuited to the
+# own ANCESTOR verdict (routing delta since it) => false DENY, shadowing the genuine exact-HEAD
+# verdict on disk. Post-fix, the exact-HEAD foreign verdict OUTRANKS the own ancestor => NO deny.
+rm -f "${HOME}/.claude/.skill-project-verified-"*
+mkart "$(jq -nc --arg s "${CVBASE}" '{failed:[],could_not_verify:[],gate_gaming_status:"clean",sha:$s}')"   # OWN token @ ANCESTOR
+printf '%s' "$(jq -nc --arg s "${CVHEAD}" '{failed:[],could_not_verify:[],gate_gaming_status:"clean",sha:$s}')" \
+  > "${HOME}/.claude/.skill-project-verified-session-EXACTFOREIGN"                                          # FOREIGN @ EXACT HEAD
+out="$(run_in "${CV}")"
+assert_not_contains "own ancestor must not shadow foreign exact-HEAD@HEAD (PR #121, #123)" '"deny"' "${out:-}"
+
 export HOME="${_OLDHOME}"
 rm -rf "${TMP}"
 print_summary

--- a/tests/test-verdict-lib.sh
+++ b/tests/test-verdict-lib.sh
@@ -133,6 +133,31 @@ assert_equals "resolve: foreign ancestor-clean does NOT bridge (exact-HEAD only)
 mv "${HOME}/.claude/.skill-project-verified-session-anc" "${HOME}/.claude/.skill-project-verified-session-own"
 assert_equals "resolve: own ancestor-clean still covers (step 1)" "session-own" "$(verdict_resolve_token "session-own" "${REPO}")"
 
+# (f) issue #123: own ANCESTOR-clean must NOT shadow a sibling EXACT-HEAD clean.
+# The stronger evidence (exact HEAD) outranks the weaker (own ancestor) across tokens —
+# routing-governance needs a verdict AT HEAD, so an own-ancestor short-circuit that hides
+# a genuine sibling exact-HEAD verdict is a false-block.
+rm -f "${HOME}/.claude/.skill-project-verified-"*
+mkart_tok "session-own" "$(jq -nc --arg s "${C1}"    '{failed:[],could_not_verify:[],gate_gaming_status:"clean",sha:$s}')"
+mkart_tok "session-sib" "$(jq -nc --arg s "${RHEAD}" '{failed:[],could_not_verify:[],gate_gaming_status:"clean",sha:$s}')"
+assert_equals "resolve: sibling exact-HEAD outranks own ancestor-clean (#123)" "session-sib" "$(verdict_resolve_token "session-own" "${REPO}")"
+
+# (g) deny-bias preserved across the widened bridge: own ancestor-clean + sibling
+# exact-HEAD FAILED => the sibling failure wins (a failure at HEAD outranks a clean ancestor).
+rm -f "${HOME}/.claude/.skill-project-verified-"*
+mkart_tok "session-own" "$(jq -nc --arg s "${C1}"    '{failed:[],could_not_verify:[],gate_gaming_status:"clean",sha:$s}')"
+mkart_tok "session-sib" "$(jq -nc --arg s "${RHEAD}" '{failed:["tests"],could_not_verify:[],gate_gaming_status:"clean",sha:$s}')"
+RT3="$(verdict_resolve_token "session-own" "${REPO}")"
+assert_equals "resolve: own ancestor yields to sibling FAILED@HEAD (deny-bias, #123)" "session-sib" "${RT3}"
+assert_equals "resolve: the resolved token carries the failure" "0" "$(_bool verdict_has_test_failure "${RT3}")"
+
+# (h) #123 regression guard: own EXACT-HEAD clean is still preferred over a sibling
+# EXACT-HEAD clean (own fast path preserved — byte-identical to case (a)).
+rm -f "${HOME}/.claude/.skill-project-verified-"*
+mkart_tok "session-own" "$(jq -nc --arg s "${RHEAD}" '{failed:[],could_not_verify:[],gate_gaming_status:"clean",sha:$s}')"
+mkart_tok "session-sib" "$(jq -nc --arg s "${RHEAD}" '{failed:[],could_not_verify:[],gate_gaming_status:"clean",sha:$s}')"
+assert_equals "resolve: own exact-HEAD clean still wins over sibling exact-HEAD clean" "session-own" "$(verdict_resolve_token "session-own" "${REPO}")"
+
 export HOME="${_OLDHOME}"
 rm -rf "${TMP}"
 print_summary


### PR DESCRIPTION
Closes #123.

## Problem

`hooks/lib/verdict.sh::verdict_resolve_token` returned the session token verbatim whenever ITS own verdict "covered HEAD" — **including ancestor acceptance** (`verdict_covers_head`) — and only bridged to sibling `~/.claude/.skill-project-verified-*` artifacts otherwise. So an own-token verdict at an **ancestor** commit short-circuited resolution even when a sibling artifact held a clean verdict at **exact HEAD**. The weaker evidence shadowed the stronger, which is backwards for routing-governance (it needs a verdict AT HEAD, or a clean ancestor with no routing delta since).

Observed at the PR #121 ship: own clean@ancestor (`e2ab0ee`) + sibling clean@exact-HEAD (`422100a`) + a routing delta after the ancestor → routing-governance denied despite a genuine clean exact-HEAD verdict on disk.

## Fix

Surgical precedence change in `verdict_resolve_token`:
- **Step 1** now keys on `verdict_sha_is_head` (EXACT HEAD), not `verdict_covers_head` (ancestor). An own **ancestor** verdict no longer short-circuits past the sibling exact-HEAD scan.
- Ancestor acceptance moves to a **step-3 fallback**, consulted only when no exact-HEAD verdict exists under any token.

New precedence: exact-HEAD (any token) > own ancestor > session token unchanged.

## Invariants preserved

- **Own exact-HEAD fast path byte-identical** (PR #97 pin) — no sibling scan when the own verdict is at exact HEAD.
- **Deny-bias unchanged**: a failure at HEAD (any token) outranks a clean one.
- **Forgery posture unchanged**: cross-token acceptance stays exact-HEAD-only; ancestor acceptance stays scoped to the own token. This widens *when* the bridge is consulted, not *what* it accepts.
- `grep -F` HEAD-sha prefilter still bounds the sibling scan.
- Fail-open on every error path.

## Tests

- `tests/test-verdict-lib.sh` — cases (f)/(g): own ancestor-clean + sibling exact-HEAD {clean → sibling; FAILED → sibling, deny-bias}; case (h): own exact-HEAD clean still wins over sibling exact-HEAD clean (byte-identical regression guard).
- `tests/test-push-gate-verdict.sh` — case (12): e2e of the PR #121 scenario (own clean@ancestor + foreign clean@exact-HEAD + routing delta → NO deny). **Proven RED on the pre-fix resolver, GREEN with the fix.**

Bash 3.2 clean (`/bin/bash -n` + real-3.2 run). `verdict.sh` is in `_GATE_ENFORCE_LIBS` + the evaluator-surface advisory list, so the evaluator-surface advisory on this branch is working as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)