### PR TITLE
Fix: make push-gate IMPLEMENT-leg test self-contained (#141 follow-up)

### DIFF
--- a/tests/test-push-gate-implement-leg.sh
+++ b/tests/test-push-gate-implement-leg.sh
@@ -45,27 +45,50 @@ printf '%s' "${_TOK}" > "$HOME/.claude/.skill-session-token"
 printf '%s' '{"chain":["requesting-code-review","verification-before-completion","executing-plans"],"current_index":0,"completed":[]}' \
     > "${_COMP}"
 
-# Clean covering verdict at HEAD (same as test-push-gate-ledger.sh) — satisfies
-# routing-governance (this IS a routing repo) and, together with the ledger
-# records below, VERIFY, so only the IMPLEMENT leg's behavior is under test.
-_PVHEAD="$(git -C "${PROJECT_ROOT}" rev-parse HEAD 2>/dev/null)"
+# Self-contained fixture repo: a feature branch whose diff against its OWN
+# mainline (main) touches MATERIAL, non-routing source (src/app.py). The guard
+# runs with cwd = this repo (below), so its material-source gate is exercised
+# deterministically regardless of which branch the OUTER repo is on. The prior
+# version relied on the ambient repo's branch-diff-vs-mainline being non-empty,
+# so it silently failed when run from a clean `main` checkout (base==HEAD =>
+# empty diff => no material source => the advisory never fired). src/app.py is
+# NON-routing (not skills/|config/|hooks/), and the fixture repo has no
+# config/default-triggers.json, so routing-governance never fires and only the
+# IMPLEMENT leg is under test.
+_REPO="$(mktemp -d /tmp/pg-impl-repo-XXXXXX)"
+(
+  cd "${_REPO}" || exit 1
+  git init -q
+  git config user.email test@example.com
+  git config user.name  test
+  echo "# fixture" > README.md
+  git add README.md && git commit -qm "init"
+  git branch -M main
+  git checkout -qb feat/impl
+  mkdir -p src && echo "print('x')" > src/app.py
+  git add src/app.py && git commit -qm "feat: material source change"
+) || { echo "FATAL: fixture repo setup failed" >&2; export HOME="$_OLDHOME"; exit 1; }
+
+# Clean covering verdict at the FIXTURE repo's HEAD — satisfies verify-hardening
+# and, with the ledger records below, VERIFY; routing-governance does not fire
+# (no routing paths in the diff, no config/default-triggers.json in the repo),
+# so only the IMPLEMENT leg's behavior is under test.
+_PVHEAD="$(git -C "${_REPO}" rev-parse HEAD 2>/dev/null)"
 jq -nc --arg s "${_PVHEAD}" '{failed:[],could_not_verify:[],gate_gaming_status:"clean",sha:$s}' \
     > "$HOME/.claude/.skill-project-verified-${_TOK}"
 
 # shellcheck disable=SC1090
 . "${PROJECT_ROOT}/hooks/lib/branch-ledger.sh"
-branch_ledger_record "requesting-code-review"        "${PROJECT_ROOT}"
-branch_ledger_record "verification-before-completion" "${PROJECT_ROOT}"
+branch_ledger_record "requesting-code-review"        "${_REPO}"
+branch_ledger_record "verification-before-completion" "${_REPO}"
 
 _mkinput() {
     jq -n --arg tp "$_TPATH" \
         '{"transcript_path":$tp,"tool_input":{"command":"git push origin HEAD"}}'
 }
-run_guard() { _mkinput | CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${GUARD}" 2>/dev/null; }
-
-# Sanity: the real repo's current branch diff against mainline touches material
-# (non-docs) source (hooks/lib/verdict.sh, config/*.json, etc. per git log on
-# this branch) — no fixture commit needed to exercise the material-source gate.
+# Guard runs with cwd = the fixture repo so _proot (git rev-parse --show-toplevel)
+# resolves to it and the material-source diff is computed against feat/impl..main.
+run_guard() { ( cd "${_REPO}" && _mkinput | CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${GUARD}" 2>/dev/null ); }
 
 # (a) IMPLEMENT in chain, material source in diff, no impl evidence ->
 #     advisory present, and NOT a deny attributable to IMPLEMENT (no deny at
@@ -100,5 +123,6 @@ assert_not_contains "no impl-slot in chain => no IMPLEMENT advisory" "IMPLEMENT:
 assert_not_contains "no impl-slot in chain => no deny"                '"deny"'    "${out:-}"
 
 export HOME="$_OLDHOME"
+rm -rf "${_REPO}" 2>/dev/null
 print_summary
 exit $?

--- a/tests/test-push-gate-implement-leg.sh
+++ b/tests/test-push-gate-implement-leg.sh
@@ -25,7 +25,8 @@ assert_contains "leg is documented as warn-first (no deny yet)" "will become a d
 
 # --- Behavioral setup (mirrors test-push-gate-ledger.sh verbatim) ---
 _OLDHOME="$HOME"
-export HOME="$(mktemp -d /tmp/pg-impl-home-XXXXXX)"
+_THOME="$(mktemp -d /tmp/pg-impl-home-XXXXXX)"
+export HOME="$_THOME"
 mkdir -p "$HOME/.claude"
 
 _TPATH="$HOME/t.jsonl"
@@ -55,9 +56,16 @@ printf '%s' '{"chain":["requesting-code-review","verification-before-completion"
 # NON-routing (not skills/|config/|hooks/), and the fixture repo has no
 # config/default-triggers.json, so routing-governance never fires and only the
 # IMPLEMENT leg is under test.
-_REPO="$(mktemp -d /tmp/pg-impl-repo-XXXXXX)"
+#
+# pwd -P: git rev-parse --show-toplevel (how the guard resolves _proot) returns
+# the PHYSICAL path, so on macOS a /tmp symlink would make the record-time
+# branch-ledger key (raw mktemp path) differ from the guard's read-time key —
+# REVIEW/VERIFY would then be rescued only by the #131 bridge, not the direct
+# ledger this test intends. Pin the physical path so both keys agree.
+_REPO="$(cd "$(mktemp -d /tmp/pg-impl-repo-XXXXXX)" && pwd -P)"
 (
-  cd "${_REPO}" || exit 1
+  set -e                       # any failed setup step aborts the subshell (not just the last)
+  cd "${_REPO}"
   git init -q
   git config user.email test@example.com
   git config user.name  test
@@ -67,7 +75,7 @@ _REPO="$(mktemp -d /tmp/pg-impl-repo-XXXXXX)"
   git checkout -qb feat/impl
   mkdir -p src && echo "print('x')" > src/app.py
   git add src/app.py && git commit -qm "feat: material source change"
-) || { echo "FATAL: fixture repo setup failed" >&2; export HOME="$_OLDHOME"; exit 1; }
+) || { echo "FATAL: fixture repo setup failed" >&2; rm -rf "${_REPO}" "${_THOME}"; export HOME="$_OLDHOME"; exit 1; }
 
 # Clean covering verdict at the FIXTURE repo's HEAD — satisfies verify-hardening
 # and, with the ledger records below, VERIFY; routing-governance does not fire
@@ -87,7 +95,8 @@ _mkinput() {
         '{"transcript_path":$tp,"tool_input":{"command":"git push origin HEAD"}}'
 }
 # Guard runs with cwd = the fixture repo so _proot (git rev-parse --show-toplevel)
-# resolves to it and the material-source diff is computed against feat/impl..main.
+# resolves to it and the material-source diff is computed as
+# merge-base(HEAD,main)..HEAD (i.e. the src/app.py commit on feat/impl).
 run_guard() { ( cd "${_REPO}" && _mkinput | CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${GUARD}" 2>/dev/null ); }
 
 # (a) IMPLEMENT in chain, material source in diff, no impl evidence ->
@@ -123,6 +132,6 @@ assert_not_contains "no impl-slot in chain => no IMPLEMENT advisory" "IMPLEMENT:
 assert_not_contains "no impl-slot in chain => no deny"                '"deny"'    "${out:-}"
 
 export HOME="$_OLDHOME"
-rm -rf "${_REPO}" 2>/dev/null
+rm -rf "${_REPO}" "${_THOME}" 2>/dev/null
 print_summary
 exit $?


### PR DESCRIPTION
Follow-up to #141 (surfaced while shipping #145 / PR #146).

## Problem

`bash tests/run-tests.sh` fails on a clean `main` checkout: `test-push-gate-implement-leg.sh` reports 3 failures (`no impl evidence => IMPLEMENT advisory`, `advisory surfaces as additionalContext`, `IMPLEMENT warn writes a phase-gate telemetry line`).

Root cause: the test *deliberately* relied on "the real repo's current branch diff against mainline touches material source — no fixture commit needed" (its own comment). That assumption holds on a feature branch but is **false on `main`** (`merge-base(main,HEAD) == HEAD` → empty diff → no material source → the IMPLEMENT advisory never fires). The test passed in CI only because CI runs on PR branches with real diffs, masking the defect since #141. Verified: it fails identically on pre-merge `main` `45b79fd` — not caused by any recent change.

## Fix

Make the test self-contained instead of depending on ambient branch state:
- Build a temp fixture git repo with a `feat/impl` branch carrying a **material, non-routing** commit (`src/app.py`).
- Seed the branch-ledger (REVIEW/VERIFY) + a clean verdict **against that repo**.
- Run the guard with cwd = the fixture repo, so `_proot` (`git rev-parse --show-toplevel`) resolves there and the material-source diff is computed as `merge-base(HEAD,main)..HEAD`.

`src/app.py` is non-routing and the fixture has no `config/default-triggers.json`, so routing-governance never fires — only the IMPLEMENT leg is exercised. **No hook/behavior change — test-only.** Deterministic on any branch now (passes on a clean `main`).

## Review applied (subagent, "Ready")

- `pwd -P` on the fixture path so the guard's physical-path `_proot` matches the record-time branch-ledger key on macOS (`/tmp`→`/private/tmp`) — REVIEW/VERIFY are satisfied via the **direct ledger**, not the #131 bridge, matching the test's intent.
- `set -e` inside the fixture subshell (any setup step failure aborts, not just the last).
- Clean up the fixture repo **and** the mktemp HOME on both fatal and success paths.
- Corrected the diff-direction comment.

## Verification

- `test-push-gate-implement-leg.sh` → **12/12** on a clean `main` checkout (was 9/12).
- Full suite `bash tests/run-tests.sh` → **105/105** (was 104/105).
- Clean sha-bound verdict at HEAD: `failed:[]`, `gate_gaming_status:clean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
