### PR TITLE
chore: repoint repo owner references to dkpapadopoulos

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,5 +5,5 @@
   "author": {
     "name": "auto-claude-skills contributors"
   },
-  "homepage": "https://github.com/damianpapadopoulos/auto-claude-skills"
+  "homepage": "https://github.com/dkpapadopoulos/auto-claude-skills"
 }

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Update marketplace repo
         run: |
-          git clone https://x-access-token:${{ secrets.MARKETPLACE_PAT }}@github.com/damianpapadopoulos/auto-claude-skills-marketplace.git /tmp/marketplace
+          git clone https://x-access-token:${{ secrets.MARKETPLACE_PAT }}@github.com/dkpapadopoulos/auto-claude-skills-marketplace.git /tmp/marketplace
           cd /tmp/marketplace
 
           jq --arg v "${{ steps.version.outputs.new }}" \

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Artifacts from earlier phases stay readable throughout — the plan referenced i
 **Minimal install:**
 
 ```
-/plugin marketplace add damianpapadopoulos/auto-claude-skills-marketplace
+/plugin marketplace add dkpapadopoulos/auto-claude-skills-marketplace
 /plugin install auto-claude-skills@acsm
 ```
 

--- a/hooks/session-start-hook.sh
+++ b/hooks/session-start-hook.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # --- Session Start Hook: Skill Registry Builder -------------------
-# https://github.com/damianpapadopoulos/auto-claude-skills
+# https://github.com/dkpapadopoulos/auto-claude-skills
 #
 # Runs at SessionStart. Scans plugin cache and user skills, merges
 # with default triggers, applies user config overrides, and caches

--- a/hooks/skill-activation-hook.sh
+++ b/hooks/skill-activation-hook.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # --- Claude Code Skill Activation Hook v2 (config-driven) --------
-# https://github.com/damianpapadopoulos/auto-claude-skills
+# https://github.com/dkpapadopoulos/auto-claude-skills
 #
 # Config-driven routing engine that reads the cached skill registry
 # instead of using hardcoded regex patterns.


### PR DESCRIPTION
## Why

The `auto-claude-skills` repo (and its marketplace repo) were transferred from `damianpapadopoulos` to `dkpapadopoulos`. This updates the **functional** references to the new owner so nothing depends on GitHub's redirect long-term.

## What changed (5 one-line edits)

| File | Reference |
|---|---|
| `.claude-plugin/plugin.json` | `homepage` URL |
| `README.md` | `/plugin marketplace add …` install command |
| `.github/workflows/version-bump.yml` | marketplace-repo clone URL (CI push target) |
| `hooks/session-start-hook.sh` | header comment URL |
| `hooks/skill-activation-hook.sh` | header comment URL |

Also updated out-of-band (in the marketplace repo): `marketplace.json` `source.url` → `dkpapadopoulos/auto-claude-skills.git`.

## Deliberately left unchanged

Historical/archived references under `docs/plans/archive/`, `openspec/changes/archive/`, `.claude/knowledge/` PR links, and all `damianpapadopoulos/Dion` references (a **different** repo). GitHub's redirect covers these.

## Verification

- `bash tests/run-tests.sh`: **105/105 files passed**
- Hooks pass `bash -n`; `plugin.json` valid JSON; `version-bump.yml` valid YAML (static-URL swap only, no injection surface)
- Code review: clean, ready to merge
- No remaining functional refs to the old owner outside archives/knowledge/Dion

🤖 Generated with [Claude Code](https://claude.com/claude-code)