### PR TITLE
chore: use GITHUB_TOKEN for version-bump's in-repo push

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -16,7 +16,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
-          token: ${{ secrets.MARKETPLACE_PAT }}
+          # Default GITHUB_TOKEN pushes the version bump to THIS repo (main has
+          # no branch protection; `permissions: contents: write` is declared
+          # above). The cross-repo marketplace push uses MARKETPLACE_PAT
+          # explicitly in its clone URL below, so a PAT issue can never block
+          # the in-repo version bump.
 
       - name: Determine bump type from commit message
         id: bump


### PR DESCRIPTION
## Why

After the repo transfer to `dkpapadopoulos`, the `Auto Version Bump` workflow started failing with:

```
remote: Permission to dkpapadopoulos/auto-claude-skills.git denied to damianpapadopoulos.
fatal: ... error: 403
```

Root cause: `actions/checkout` was configured with `token: ${{ secrets.MARKETPLACE_PAT }}`, so the **in-repo** version-bump `git push` authenticated with that cross-repo PAT. The PAT is owned by the former owner and lost write access to this repo on transfer, breaking every version bump.

## What changed

Remove the `token:` override from the checkout step. The in-repo push now uses the default `GITHUB_TOKEN` (job already declares `permissions: contents: write`; `main` has no branch protection). `MARKETPLACE_PAT` remains **only** on the cross-repo marketplace clone/push, so a PAT problem can never again block the in-repo version bump.

## Verification

- Root cause proven live: two failed runs 403'd on the PAT; after the token was regenerated under `dkpapadopoulos`, a re-run went fully green (bump 3.81.2 → 3.81.3, marketplace synced).
- `python3 yaml.safe_load`: valid YAML
- Code review: clean — confirmed GITHUB_TOKEN can push (permissions + no branch protection + `persist-credentials` default), marketplace step unaffected (fresh clone with PAT-in-URL, no credential collision), push target correct
- `bash tests/run-tests.sh`: 105/105 files pass (clean verification verdict at HEAD)

Note: `MARKETPLACE_PAT` still must be a `dkpapadopoulos`-owned token with write to both repos (already fixed) — this PR just removes the *main-repo* dependency on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)