### PR TITLE
fix: reject an ambiguous PR reference instead of guessing wrong

### DIFF
--- a/hooks/lib/pr-diff.sh
+++ b/hooks/lib/pr-diff.sh
@@ -24,7 +24,7 @@ PR_DIFF_GH_TIMEOUT="${PR_DIFF_GH_TIMEOUT:-10}"
 
 # pr_ref_from_command <command> -> bare PR number, or nothing
 pr_ref_from_command() {
-    local _cmd="${1:-}" _cand="" _tok _seen_merge="" _restore_glob=1
+    local _cmd="${1:-}" _cand="" _tok _seen_merge="" _restore_glob=1 _ndigit=0
     case "${_cmd}" in
         *pulls/*/merge*)
             # gh api repos/o/r/pulls/7/merge
@@ -59,10 +59,22 @@ pr_ref_from_command() {
                     esac
                     continue
                 fi
+                # AMBIGUITY: do NOT break on the first digit-leading token —
+                # count them all. This scanner splits raw command TEXT and
+                # cannot tell a flag's value from a positional, so
+                #   gh pr merge --title "PR 42 notes" 99
+                # yields both `42` and `99`. Breaking early returned 42: a real
+                # but UNRELATED PR, recorded as diff_base:"pr:42" while PR 99
+                # was merged. For a corpus whose purpose is stating what each
+                # event was measured against, a plausible wrong label is worse
+                # than none — "unresolved" is a known-unknown an adjudicator can
+                # exclude; "pr:42" is a lie they cannot detect. Two or more
+                # candidates ⇒ ambiguous ⇒ return nothing.
                 case "${_tok}" in
-                    [0-9]*) _cand="${_tok}"; break ;;
+                    [0-9]*) _ndigit=$((_ndigit + 1)); _cand="${_tok}" ;;
                 esac
             done
+            if [ "${_ndigit}" -gt 1 ]; then _cand=""; fi
             [ "${_restore_glob}" = 1 ] && set +f
             ;;
         *) return 0 ;;

--- a/openspec/changes/merge-pr-diff-subject/design.md
+++ b/openspec/changes/merge-pr-diff-subject/design.md
@@ -21,6 +21,19 @@ merges (`hooks/lib/git-command.sh` `command_invokes_gh_merge`):
 | `gh api repos/o/r/pulls/7/merge` | `7` |
 | `gh pr merge` (bare) | none — v1 records this `unresolved`; see Out-of-Scope |
 | `gh api graphql … mergePullRequest` | none — node id, not a number |
+| `gh pr merge --title "PR 42 notes" 99` | none — **ambiguous**, see below |
+
+**Ambiguity yields nothing, deliberately.** The scanner splits raw command
+text and cannot distinguish a flag's value from a positional argument, so a
+number inside `--title`/`--body` is indistinguishable from the PR ref. Breaking
+on the first digit-leading token returned `42` there — a real but *unrelated*
+PR, stamped `diff_base:"pr:42"` while PR 99 was actually merged. When two or
+more digit-leading tokens follow `merge`, the reference is treated as
+unresolvable. For a corpus whose entire purpose is stating what each event was
+measured against, a plausible wrong label is strictly worse than none:
+`unresolved` is a known-unknown an adjudicator can exclude, `pr:42` is a lie
+they cannot detect. This is the same "silence beats a wrong subject" principle
+that governs the advisory flush.
 
 **Validation is a security boundary, not a nicety.** The command is
 model-authored text. The extracted ref MUST match `^[0-9]+$`; anything else
@@ -35,7 +48,16 @@ empty for a bare `gh pr merge` and the record is `unresolved`. See
 Out-of-Scope.
 
 **`pr_changed_files`** runs `gh pr view <ref> --json files --jq '.files[].path'`
-with a hard timeout. Any failure — `gh` absent, unauthenticated, offline,
+bounded by **`PR_DIFF_GH_TIMEOUT` (default 10s, overridable)**. That cap is a
+worst case, not a routine cost: the measured happy path is ~620ms, and the
+full 10s is only reached when `gh` genuinely hangs — a network stall or an
+interactive auth prompt. It is deliberately not lowered to 5s: a shorter cap
+converts *merely slow* networks into `unresolved` records, corrupting the
+corpus in exactly the direction this change exists to protect. Users on a
+persistently slow link should lower it themselves and accept that trade
+knowingly. The bound applies only to the merge path; `git push` never calls out.
+
+Any failure — `gh` absent, unauthenticated, offline,
 unknown PR, timeout — returns nothing.
 
 ### Predicate split

--- a/tests/test-pr-diff.sh
+++ b/tests/test-pr-diff.sh
@@ -37,6 +37,27 @@ assert_equals "path-shaped ref rejected"        "" "$(pr_ref_from_command 'gh pr
 assert_equals "semicolon injection rejected"    "" "$(pr_ref_from_command 'gh pr merge 7;rm -rf /')"
 assert_equals "graphql node id not a number"    "" "$(pr_ref_from_command 'gh api graphql -f query=mergePullRequest')"
 assert_equals "bare merge has no explicit ref"  "" "$(pr_ref_from_command 'gh pr merge')"
+
+# --- AMBIGUITY: prefer no answer over a confidently wrong one -------------
+# This scanner splits raw command TEXT; it cannot tell a flag's value from a
+# positional. `gh pr merge --title "PR 42 notes" 99` used to return 42 — a real
+# but UNRELATED PR — so the record would read diff_base:"pr:42" while PR 99 was
+# merged. In a corpus whose whole purpose is stating what each event was
+# measured against, a plausible wrong label is strictly worse than "unresolved":
+# unresolved is a known-unknown an adjudicator can exclude, pr:42 is a lie they
+# cannot detect. So when MORE THAN ONE digit-leading token follows `merge`, the
+# reference is ambiguous and we return nothing.
+assert_equals "ambiguous ref (number in --title) rejected"  "" \
+    "$(pr_ref_from_command 'gh pr merge --title "PR 42 notes" 99')"
+assert_equals "ambiguous ref (number in --body) rejected"   "" \
+    "$(pr_ref_from_command 'gh pr merge --body "fixes 7" 99')"
+assert_equals "ambiguous ref (two positionals) rejected"    "" \
+    "$(pr_ref_from_command 'gh pr merge 42 99')"
+# ...and the unambiguous cases must be untouched by that rule.
+assert_equals "single ref with trailing flags still works" "12" \
+    "$(pr_ref_from_command 'gh pr merge 12 --squash --delete-branch')"
+assert_equals "numeric flag BEFORE merge still ignored"     "7" \
+    "$(pr_ref_from_command 'gh --org 42 pr merge --squash 7')"
 assert_equals "a push is not a merge"           "" "$(pr_ref_from_command 'git push origin HEAD')"
 
 # --- fetch: hermetic, gh is stubbed; NO test may hit the network ---------


### PR DESCRIPTION
Follow-up to #168, from that PR's review recommendations. Two of three acted on; the third assessed and deliberately declined.

## ⚠️ Reviewer: evaluator-surface adjacency

This touches `hooks/lib/pr-diff.sh`, which feeds the push gate's IMPLEMENT leg. The leg is advisory-only and no `permissionDecision` is involved, but the verdict covering this branch was produced by a gate this library informs — read the change rather than relying on the green verdict.

## R3 — fixed: a wrong PR number was worse than none

`pr_ref_from_command` broke on the **first** digit-leading token after `merge`:

```
gh pr merge --title "PR 42 notes" 99   ->  42
```

That is a real but *unrelated* PR. The shadow record then read `diff_base:"pr:42"` while PR 99 was actually merged, and the file list fetched described the wrong PR entirely.

The scanner splits raw command text and cannot distinguish a flag's value from a positional. No flag-allowlist fixes that in general — `--title`, `--body`, `--subject`, and any future option can carry a number. So the rule is now: **two or more digit-leading tokens after `merge` ⇒ ambiguous ⇒ return nothing**, and the record reads `unresolved`.

That is the right trade for this corpus. `unresolved` is a known-unknown an adjudicator can exclude; `pr:42` is a lie they cannot detect. It is the same *silence beats a wrong subject* principle that already governs the advisory flush in #168.

**Unambiguous cases are untouched**, verified:

| command | ref |
|---|---|
| `gh pr merge 12 --squash --delete-branch` | `12` |
| `gh --org 42 pr merge --squash 7` | `7` (the `_seen_merge` latch means only post-`merge` tokens count) |
| `gh api repos/o/r/pulls/7/merge` | `7` |
| `gh pr merge --title "PR 42 notes" 99` | **none** (was `42`) |

**Mutation-proved:** removing the ambiguity rule fails all three new assertions; restoring passes 24/24. The assertions are load-bearing, not decorative.

## R1 — documented, and deliberately not lowered

`PR_DIFF_GH_TIMEOUT` appeared nowhere in the design doc. It now does, with the reasoning:

The 10s cap is a **hang worst-case, not a routine cost** — the measured happy path is ~620ms, and the full 10s is only reached when `gh` genuinely stalls (network failure, interactive auth prompt). I considered the suggested drop to 5s and rejected it: a shorter cap converts *merely slow* networks into `unresolved` records, corrupting the corpus in precisely the direction this work exists to protect. Users on a persistently slow link should lower it themselves and take that trade knowingly. The bound applies only to the merge path; `git push` never calls out.

## R2 — assessed, declined

`_flush_push_advisories` reading `_impl_db` from outer scope is an accurate observation, and the "low risk, advisory-only" judgement is right. But `_pe_action`, `_proot`, `_SESSION_TOKEN` and every other guard variable work the same way — this file is built that way. Parameterising just this one adds coupling and inconsistency for no behavioural gain, and a future subshell-wrapping refactor would need to audit all of them regardless. Left as is, on purpose.

## Verification

- `tests/test-pr-diff.sh` **24/24**; `tests/test-push-gate-implement-leg.sh` 0 failures
- **Full suite 108/108**
- `openspec validate`: all active changes pass
- `bash -n` clean under real `/bin/bash` 3.2
- Verdict at HEAD: `failed:[]`, `could_not_verify:[]`, `gate_gaming_status:"clean"`, `test_delta:"covered"`

Two self-inflicted defects were caught before commit while writing this: `_ndigit` was initially undeclared (would have leaked as a global and tripped `set -u`), and the guard was first written as a trailing `[ … ] && _cand=""`, which is the exit-code trap `CLAUDE.md` explicitly documents. Both fixed before the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
