### PR TITLE
fix: memory-validate crashed BSD basename on anchors starting with '-'

### DIFF
--- a/scripts/memory-validate.sh
+++ b/scripts/memory-validate.sh
@@ -110,10 +110,15 @@ for f in "${MEM}"/*.md; do
     for a in ${anchors}; do
         # cross-memory-file reference (points at a sibling memory .md, not a repo
         # path) — out of scope for repo-staleness; the [[link]] check owns those.
-        [ -e "${MEM}/$(basename "${a}")" ] && continue
+        # `--` is load-bearing: anchors are untrusted memory text and the extraction
+        # regex admits a leading '-' (e.g. a cited suffix `-design.md`). BSD basename
+        # parses that as an option, errors, and the anchor is SILENTLY skipped — the
+        # scan under-reports instead of failing loudly. GNU basename tolerates it, so
+        # this only bites on macOS. Same reason on the /* branch below.
+        [ -e "${MEM}/$(basename -- "${a}")" ] && continue
         case "${a}" in
             /*)  # absolute path (or /tmp scratch): not repo-relative — resolve by basename only
-                printf '%s\n' "${HEADFILES}" | awk -F/ -v b="$(basename "${a}")" '$NF==b{hit=1} END{exit !hit}' && continue ;;
+                printf '%s\n' "${HEADFILES}" | awk -F/ -v b="$(basename -- "${a}")" '$NF==b{hit=1} END{exit !hit}' && continue ;;
             */*) # path anchor: exact OR suffix match at HEAD (memories cite partial paths)
                 printf '%s\n' "${HEADFILES}" | grep -qxF "${a}" && continue
                 printf '%s\n' "${HEADFILES}" | grep -qF "/${a}" && continue ;;

--- a/tests/test-memory-validate.sh
+++ b/tests/test-memory-validate.sh
@@ -285,4 +285,25 @@ else
     _record_fail "prefix-stripped hyphenated [[link]] resolves (no WARN)" "rc=${rc} out=${out}"
 fi
 
+# --- anchor beginning with '-' must not crash basename (BSD/macOS) ---
+# The anchor regex admits [A-Za-z0-9_./-], so a backticked token like `-design.md`
+# (real: several memories cite bare suffixes) reaches basename as its FIRST operand.
+# BSD basename then parses "-d" as an option and errors to stderr, and the anchor is
+# silently skipped — the scan under-reports rather than fails loudly.
+_reset_mem
+_mem dashanchor.md "---
+name: dashanchor
+description: d
+metadata:
+  type: project
+---
+cites a bare suffix anchor \`-design.md\` and a short flag \`-a\`"
+printf '%s\n' "- [Dash](dashanchor.md) — x" >> "${MEM}/MEMORY.md"
+out="$("${VALIDATE}" "${MEM}" "${REPO}" 2>&1)"; rc=$?
+if [ "${rc}" -eq 0 ] && ! printf '%s' "${out}" | grep -qF "illegal option"; then
+    _record_pass "an anchor starting with '-' does not crash basename"
+else
+    _record_fail "an anchor starting with '-' does not crash basename" "rc=${rc} out=${out}"
+fi
+
 print_summary


### PR DESCRIPTION
## Problem

`scripts/memory-validate.sh` crashes BSD `basename` on any anchor beginning with `-`:

```
basename: illegal option -- d
basename: illegal option -- p
```

The anchor extraction regex admits `[A-Za-z0-9_./-]`, so a memory citing a bare
suffix (`` `-design.md` ``) or a short flag (`` `-a` ``) reaches `basename` as its
**first operand**. BSD parses `-d` as an option and errors.

**The visible noise is not the real defect.** When `basename` fails, the anchor is
**silently skipped** — the stale-anchor scan under-reports rather than failing
loudly. GNU `basename` tolerates a leading dash, so this only bites on macOS,
which is where the tool actually runs.

## Fix

`basename -- "${a}"` at both anchor-derived call sites.

The `/*` branch is not currently reachable with a leading dash (that arm only
matches absolute paths), but it is hardened for symmetry so that reordering the
`case` arms later cannot silently reintroduce the bug. Call sites that take a
glob-expanded path (`"${f}"`) are untouched — they can never start with `-`.

## Behavioural delta (measured on the real 161-file corpus)

| | WARN | NOTE | basename errors | exit |
|---|---|---|---|---|
| before | 36 | 13 | **2** | 0 |
| after | **39** | 13 | **0** | 0 |

The fix **unmasks 3 previously-silent findings**, all in
`project_openspec_planning_decision.md`:

```
[WARN] repo-path anchor '-design.md' not found at HEAD
[WARN] repo-path anchor '-plan.md'   not found at HEAD
[WARN] repo-path anchor '-spec.md'   not found at HEAD
```

Those three are **heuristic false positives** — they are suffix *patterns*
(`docs/plans/*-design.md`), not file paths. Surfacing them is nonetheless the
correct behaviour: the previous code crashed and skipped them silently. Exit code
is unchanged (advisory, always 0).

**Follow-up (not in scope here):** teach the anchor extractor to skip bare-suffix
patterns, which would drop those 3 back out as noise rather than by accident.

## Testing

- **RED verified first** — the new test fails on the real production string
  (`illegal option`) before the fix.
- **Mutation-proven** — reverting the `--` produces exactly 1 failure; restoring
  it produces 0. The assertion is load-bearing, not decorative.
- `tests/test-memory-validate.sh` 16/16 green.
- `/bin/bash -n` clean (bash 3.2 compatible).
- Real-corpus verification: 2 errors → 0, with the delta table above.

- **Full suite green:** `tests/run-tests.sh` — 108 files run, 108 passed, 0 failed,
  0 `FAIL` lines across the whole log. (It took >10 min under concurrent session
  load, so it was run to completion in the background rather than inline.)

## Governance

Diff is 2 files. Touches no `hooks/`, `config/`, or `skills/` paths (so
routing-governance does not apply); adds no bypass patterns (`--no-verify`,
`--force`, `dangerouslyDisableSandbox`); removes no check; adds no outbound
action. The change is strictly reporting-hardening — it can only make the
validator report *more*, never less.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
