### PR TITLE
Record that main is unprotected, and why enabling it is not a toggle

### DIFF
--- a/docs/CI.md
+++ b/docs/CI.md
@@ -77,7 +77,11 @@ So the steps below are correct GitHub mechanics but are **not currently in effec
 Before following them, do one of:
 
 - convert `version-bump.yml` to open a PR instead of pushing to `main`, or
-- grant that workflow an explicit bypass on the protection rule, or
+- grant that workflow an explicit bypass — **use a repository ruleset, not classic
+  branch protection**. A ruleset's bypass list can name the single GitHub App
+  (`github-actions[bot]`); classic protection's only lever is "include
+  administrators", which exempts *every* admin from *every* rule. Very different
+  blast radius for the same stated goal.
 - accept that version bumps stop and handle them by hand.
 
 Treat enabling protection as its own change with the bot fix included — not a

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -55,11 +55,41 @@ To make it hard-blocking, follow the steps below and type **`Done Gates`** in th
 status-check search box (step 6). It is independent of `OpenSpec Validate` — you
 can require either, both, or neither.
 
+## Current state: `main` is NOT protected (deliberately)
+
+As of 2026-07-29, `main` has **no branch protection rule** — verified via
+`gh api repos/<owner>/<repo>/branches/main/protection` → `404 Branch not protected`.
+Neither `OpenSpec Validate` nor `Done Gates` is a required check. Both run on every
+PR and go red on a violation, but **nothing blocks a merge**.
+
+**This is a deliberate trade-off, not an oversight, and enabling protection is not a
+one-click step.** `.github/workflows/version-bump.yml` pushes **directly to `main`**
+after every merge (`git push`, with `permissions: contents: write`), and its own
+comment states the assumption plainly: *"no branch protection; `permissions:
+contents: write` is declared."* Its commits carry `[skip ci]`, so required status
+checks would never report on them, and required checks block direct pushes to a
+protected branch. `GITHUB_TOKEN` runs as `github-actions[bot]` with no admin bypass.
+
+**Turning on required checks would therefore break every version bump — silently.**
+Nothing fails loudly; the plugin version simply stops moving until someone notices.
+
+So the steps below are correct GitHub mechanics but are **not currently in effect**.
+Before following them, do one of:
+
+- convert `version-bump.yml` to open a PR instead of pushing to `main`, or
+- grant that workflow an explicit bypass on the protection rule, or
+- accept that version bumps stop and handle them by hand.
+
+Treat enabling protection as its own change with the bot fix included — not a
+settings toggle.
+
 ## Making the gate a required check (hard block)
 
 Applies to **both** workflows — `OpenSpec Validate` and `Done Gates`. Each produces
 a check that **must be manually required** in branch protection rules for it to
 actually block merges. Without this step, PRs can merge even when the check is red.
+
+Read the section above first — on this repo today, doing this breaks the release bot.
 
 In step 6 below, add the check you want: `OpenSpec Validate`, `Done Gates`, or both.
 

--- a/docs/enforcement-map.md
+++ b/docs/enforcement-map.md
@@ -46,12 +46,20 @@ with `ACSM_SKIP_PUSH_GATE=1` in its environment. The agent cannot set either.
 
 ## CI (merge-time, outside the hooks)
 
+- **NOTHING IN CI HARD-BLOCKS A MERGE TODAY.** `main` has no branch protection
+  rule at all (verified 2026-07-29:
+  `gh api repos/<owner>/<repo>/branches/main/protection` → `404 Branch not
+  protected`). Both workflows below run and go red on a violation, but a red
+  check does not stop a merge. Treat them as visible signals, not gates.
+  Enabling protection is NOT a settings toggle here: `version-bump.yml` pushes
+  directly to `main` with `[skip ci]`, so required checks would block it and
+  version bumps would stop silently. See docs/CI.md before changing this.
 - Done Gates workflow (`.github/workflows/done-gates.yml`) — runs the two owned
   done-gates, routing-fixture coverage and skill-content coverage, on every PR.
-  Hard-blocks only if marked Required in branch protection (docs/CI.md).
+  Would hard-block only if marked Required (see the caveat above).
   Regression: `tests/test-done-gate-ci.sh` pins the workflow to this claim.
-- OpenSpec Validate workflow (spec-driven mode) — hard-blocks only if marked
-  Required in branch protection (docs/CI.md).
+- OpenSpec Validate workflow (spec-driven mode) — same: runs on every PR, not
+  currently Required, so it does not block.
 - **The FULL `tests/run-tests.sh` suite does NOT run in CI.** `.verify.yml` is
   `substrate: local`: it is read by `hooks/lib/verdict.sh`, the
   `project-verification` skill and tests — by no workflow. Until this file was


### PR DESCRIPTION
Follow-up to #180. While acting on #180's own advice — "mark `Done Gates` Required in branch protection" — I discovered that advice was itself misleading, in the same way this repo has now been wrong twice before.

## What's actually true

`main` has **no branch protection rule at all**:

```
gh api repos/<owner>/<repo>/branches/main/protection
→ 404 {"message":"Branch not protected"}
```

Review independently confirmed there is no ruleset either (`gh api .../rulesets` → `[]`). So neither `OpenSpec Validate` nor `Done Gates` is required, and **nothing in CI hard-blocks a merge today.** Both workflows run and go red on a violation, but a red check does not stop anything.

## Why this isn't just a missing checkbox

`.github/workflows/version-bump.yml` pushes **directly to `main`** after every merge, and says so itself:

> `main` has no branch protection; `permissions: contents: write` is declared above

Its commits carry `[skip ci]` (that's also its own loop-guard), so required status checks would never report on them — and required checks reject a direct push whose required contexts have no passing run. `GITHUB_TOKEN` authenticates as `github-actions[bot]`, which holds no admin role and gets no bypass unless one is configured. Nothing here configures one.

**Turning on required checks would break every version bump, silently.** Nothing errors loudly; the plugin version just stops moving until someone notices. Visible in history: `29aa516`, `9de4be6`, `dabd198` are all direct-to-main bot pushes.

## The change

Docs only. Both files now state the actual state rather than implying enforcement:

- **`docs/CI.md`** — a new section recording that `main` is unprotected *by design*, why enabling protection is not a toggle here, and the three safe routes (convert the bot to a PR flow, grant it a bypass, or accept manual bumps). The existing "Making the gate a required check" steps are kept — they're correct GitHub mechanics — but now open by pointing at the caveat.
- **`docs/enforcement-map.md`** — the anti-folklore doc now leads its CI section with "**NOTHING IN CI HARD-BLOCKS A MERGE TODAY**", so a reader can't infer enforcement from the presence of a workflow.

On the bypass option specifically: it must be a **repository ruleset**, whose bypass list can name the single GitHub App, *not* classic protection's "include administrators", which exempts every admin from every rule. Same stated goal, very different blast radius.

## Why this keeps happening

Third instance in two days of the same shape — a document asserting enforcement that doesn't exist:

1. `smoke-hook-renders-precondition` — cited in two docs as the render proof; existed nowhere (fixed in #178).
2. `.verify.yml` "CI-blocking" — claimed in CLAUDE.md *and* the anti-folklore doc; no workflow read it (fixed in #180).
3. This one — #180 told readers to mark a check Required without checking whether protection existed or what depended on its absence.

Each was found by running the check rather than reading the prose. None was found by reasoning about the code.

## Verification

- Every factual claim independently re-verified in review against live repo state and GitHub's documented mechanics — including deliberate scrutiny of the load-bearing inference (that required checks block bot pushes), since asserting *that* without evidence would have reproduced the exact defect this PR fixes.
- `test-fixture-coverage` 63/63, `test-skill-content-coverage` 21/21, `test-done-gate-ci` 10/10.
- No remaining statement in either file implies a check currently blocks merges.

No code changes; no behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
