### PR TITLE
fix: point the push-gate test harness at the real plugin root

### DIFF
--- a/tests/test-openspec-state.sh
+++ b/tests/test-openspec-state.sh
@@ -354,9 +354,16 @@ run_push_guard() {
         printf '%s' "${comp_state}" > "${HOME}/.claude/.skill-composition-state-${session_token}"
     fi
 
-    # Feed a git push command to the hook
+    # Feed a git push command to the hook.
+    #
+    # CLAUDE_PLUGIN_ROOT is set EXPLICITLY at the real tree. setup_test_env
+    # exports it at "${TEST_HOME}/.claude", a directory with no plugin in it —
+    # correct for tests that build fake plugin trees there, wrong here: the
+    # guard then loads NONE of its gate-enforcement libs, so these cases were
+    # exercising a fully degraded guard rather than the push gate. Surfaced by
+    # the #198 degradation advisory, which announced the dead root out loud.
     printf '{"tool_input":{"command":"git push"}}' | \
-        bash "${GUARD_HOOK}" 2>/dev/null
+        CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${GUARD_HOOK}" 2>/dev/null
 }
 
 test_push_gate_blocks_unverified() {
@@ -403,8 +410,8 @@ test_push_gate_allows_verified() {
 }
 test_push_gate_allows_verified
 
-test_push_gate_allows_no_composition() {
-    echo "-- test: push gate allows ad-hoc push (no composition) --"
+test_push_gate_denies_adhoc_push_without_evidence() {
+    echo "-- test: push gate denies ad-hoc push (no composition, no evidence) --"
     setup_test_env
     mkdir -p "${HOME}/.claude"
 
@@ -415,12 +422,21 @@ test_push_gate_allows_no_composition() {
     local output
     output="$(run_push_guard "test-push-adhoc-$$" "IMPLEMENT" "")"
 
-    assert_not_contains "push gate allows ad-hoc" "permissionDecision" "${output}"
-    assert_not_contains "push gate no deny for ad-hoc" "deny" "${output}"
+    # This case asserted the OPPOSITE until the harness root was fixed: it was
+    # named "allows ad-hoc push" and passed only because the guard ran with no
+    # libs loaded and no gate at all. The global fail-closed gate deliberately
+    # closed that hole — a push from a non-driven session used to be allowed
+    # unconditionally, and is not any more — so the old expectation had been
+    # obsolete since that gate landed, silently.
+    assert_contains "ad-hoc push with no evidence is denied" "deny" "${output:-<empty>}"
+    assert_contains "deny names the missing review milestone" \
+        "requesting-code-review" "${output:-<empty>}"
+    assert_contains "deny names the missing verify milestone" \
+        "verification-before-completion" "${output:-<empty>}"
 
     teardown_test_env
 }
-test_push_gate_allows_no_composition
+test_push_gate_denies_adhoc_push_without_evidence
 
 test_push_gate_allows_no_verification_in_chain() {
     echo "-- test: push gate allows when verification not in chain --"
@@ -437,7 +453,13 @@ test_push_gate_allows_no_verification_in_chain() {
     local output
     output="$(run_push_guard "test-push-nochain-$$" "PLAN" "${comp}")"
 
-    assert_not_contains "push gate allows no-verification chain" "permissionDecision" "${output}"
+    # Leaving verification out of the CHAIN does not exempt the push: the
+    # global fail-closed gate is chain-independent and still requires evidence
+    # for this branch. Previously asserted as an allow, which only held because
+    # the guard was running with no libs.
+    assert_contains "chain without verification is still denied" "deny" "${output:-<empty>}"
+    assert_contains "deny names verification-before-completion" \
+        "verification-before-completion" "${output:-<empty>}"
 
     teardown_test_env
 }
@@ -485,8 +507,14 @@ test_push_gate_allows_reviewed_without_verify_in_chain() {
     local output
     output="$(run_push_guard "test-push-reviewonly-$$" "REVIEW" "${comp}")"
 
-    assert_not_contains "push gate allows reviewed" "permissionDecision" "${output}"
-    assert_not_contains "push gate no deny when reviewed" "deny" "${output}"
+    # A completed REVIEW satisfies its own leg but not the VERIFY leg, so the
+    # deny must name ONLY the missing one. That asymmetry is the useful signal
+    # here and was unobservable while the guard ran with no libs.
+    assert_contains     "review-only chain is still denied" "deny" "${output:-<empty>}"
+    assert_contains     "deny names the missing verify milestone" \
+        "verification-before-completion" "${output:-<empty>}"
+    assert_not_contains "deny does NOT name the satisfied review milestone" \
+        "requires requesting-code-review" "${output:-}"
 
     teardown_test_env
 }

--- a/tests/test-openspec-state.sh
+++ b/tests/test-openspec-state.sh
@@ -326,17 +326,17 @@ test_non_ship_phase_skips_guard
 # ---------------------------------------------------------------------------
 
 # Helper: run the guard hook with a git push command and given state files
-# NOTE (#198): test-helpers.sh:31 exports CLAUDE_PLUGIN_ROOT="${TEST_HOME}/.claude",
-# a directory that contains no plugin — so the guard invoked here loads NONE of its
-# gate-enforcement libs and no gate actually runs. The "allows" cases below therefore
-# exercise a fully DEGRADED guard, not the allow path of a working one. That is a
-# pre-existing weakness of this harness, left as-is because pointing the root at the
-# real tree would change what every setup_test_env test exercises.
 #
-# What changed with #198 is only that the degradation is now ANNOUNCED, so the string
-# "PUSH GATE" legitimately appears on an allow. The property these cases mean to pin
-# is the DECISION, so they assert on the decision channel: an advisory never carries a
-# permissionDecision, and a block always does.
+# NOTE: test-helpers.sh:31 exports CLAUDE_PLUGIN_ROOT="${TEST_HOME}/.claude", a
+# directory containing no plugin. That is the RIGHT isolation for tests which build
+# fake plugin trees there, and the WRONG root for anything invoking a real hook: the
+# guard then loads none of its gate-enforcement libs and no gate runs at all. The
+# cases below inherited that root and, for months, asserted the behavior of a dead
+# guard. The global export is deliberately left alone — 517 call sites across 36
+# files depend on it — so each real-hook invocation sets the root explicitly instead.
+#
+# The dead root was invisible until the #198 degradation advisory started announcing
+# it out loud, which is the advisory doing its job on this repo's own suite.
 run_push_guard() {
     local session_token="$1"
     local phase="$2"
@@ -438,8 +438,8 @@ test_push_gate_denies_adhoc_push_without_evidence() {
 }
 test_push_gate_denies_adhoc_push_without_evidence
 
-test_push_gate_allows_no_verification_in_chain() {
-    echo "-- test: push gate allows when verification not in chain --"
+test_push_gate_denies_when_verification_not_in_chain() {
+    echo "-- test: push gate denies when verification not in chain --"
     setup_test_env
     mkdir -p "${HOME}/.claude"
 
@@ -463,7 +463,7 @@ test_push_gate_allows_no_verification_in_chain() {
 
     teardown_test_env
 }
-test_push_gate_allows_no_verification_in_chain
+test_push_gate_denies_when_verification_not_in_chain
 
 # Push gate must also enforce REVIEW completion, not just VERIFY. In the canonical
 # SDLC chain REVIEW precedes VERIFY, and memory_feedback_never_skip_review_ship_tdd
@@ -492,8 +492,8 @@ test_push_gate_blocks_unreviewed() {
 }
 test_push_gate_blocks_unreviewed
 
-test_push_gate_allows_reviewed_without_verify_in_chain() {
-    echo "-- test: push gate allows when review done and verification not in chain --"
+test_push_gate_denies_reviewed_without_verify_in_chain() {
+    echo "-- test: push gate denies when review done but verification not in chain --"
     setup_test_env
     mkdir -p "${HOME}/.claude"
 
@@ -514,11 +514,11 @@ test_push_gate_allows_reviewed_without_verify_in_chain() {
     assert_contains     "deny names the missing verify milestone" \
         "verification-before-completion" "${output:-<empty>}"
     assert_not_contains "deny does NOT name the satisfied review milestone" \
-        "requires requesting-code-review" "${output:-}"
+        "requesting-code-review" "${output:-}"
 
     teardown_test_env
 }
-test_push_gate_allows_reviewed_without_verify_in_chain
+test_push_gate_denies_reviewed_without_verify_in_chain
 
 # ---------------------------------------------------------------------------
 # 5. set_discovery_path creates/merges discovery_path


### PR DESCRIPTION
Follow-up to #201, which surfaced this.

## The problem

`tests/test-helpers.sh:31` exports `CLAUDE_PLUGIN_ROOT="${TEST_HOME}/.claude"` — a directory containing no plugin. That is the right isolation for tests which build fake plugin trees there. It is the wrong root for anything invoking a **real** hook: the guard then loads none of its gate-enforcement libs and no gate runs at all.

`run_push_guard` inherited that root, so four cases named `test_push_gate_allows_*` were never exercising the push gate. They passed because nothing was gated.

This was invisible until the #198 degradation advisory started announcing a dead root out loud instead of falling open silently — the advisory doing its job on this repo's own suite.

## The change

`run_push_guard` sets `CLAUDE_PLUGIN_ROOT` explicitly. The **global export is deliberately left alone**: 517 call sites across 36 files depend on it, and for tests that stand up fake plugin trees the temp root is correct.

With a real gate, three of those cases fail — because they encode **pre-fail-closed-gate semantics**:

- `git log -S'Global fail-closed gate'` puts that gate at **45095a2, 2026-07-11**.
- The three tests were added **a6ca68c (2026-04-16)** and **0047346 (2026-04-18)**.

They were correct when written and became wrong three months later, silently. The guard's own comment says so: *"a push with no active composition state used to be allowed unconditionally"*.

Rewritten to assert what the gate actually does:

| case | was | now |
|---|---|---|
| ad-hoc push, no composition | "allows" — the exact hole the fail-closed gate was written to close | denies, naming **both** missing milestones |
| chain without verification | "allows" | denies — the global gate is chain-independent |
| review done, verify not in chain | "allows" | denies naming **only** the missing VERIFY leg |

The third pins a real asymmetry: a completed REVIEW satisfies its own leg, so the deny must name only what is missing. That was unobservable while the guard ran with no libs.

## Verification

- Declared gate at `05aaf07`: **PASS, exit 0**, `failed:[]`, `could_not_verify:[]`, verdict bound to HEAD.
- `tests/test-openspec-state.sh`: **74 assertions**, up from 71.
- **Mutation-tested**: reverting the one-line root fix fails all seven new assertions, so none is vacuous.
- Independently reviewed. The reviewer ran the real guard in all three scenarios rather than trusting the tests, confirmed each deny message names what the test claims, verified the fail-closed-gate history above, and confirmed no coverage was lost — the new assertions are strictly stronger.

## On `gate_gaming_status: suspect`

The verdict for this branch is **suspect**, and it should be read before merging rather than waved through — rewriting failing assertions is, from a diff alone, indistinguishable from gaming tests to make them pass.

What the tripwire actually flagged is one line, and it is a deleted **comment**:

```
> -# is the DECISION, so they assert on the decision channel: an advisory never carries a
```

None of the three genuinely-inverted assertions was flagged. So in this one diff the check both over-detected (a comment containing the word "assert") and under-detected (three real assertion inversions) — consistent with the documented ~F1 0.44–0.70 line-grep behavior, and a reminder that `clean` is not proof either.

It is advisory here: routing-governance is `n/a` because this touches only `tests/`, and `verify-hardening` denies only on a failed verdict. The substantive check is the independent review above, not the tripwire.

## Out of scope

- **The global `CLAUDE_PLUGIN_ROOT` export.** Repointing it would change what every `setup_test_env` test exercises.
- **The other hook invocations that rely on the exported value.** The reviewer measured the closest sibling — `run_guard` (the `git commit` helper in this same file) — and it is *not* testing a dead guard for what it asserts: its three warnings are read from composition state with jq and need no lib. `test-routing.sh` / `test-registry.sh` / `test-attestation-measurement.sh` drive hooks whose registry cache the tests build themselves, so the temp root is the intended isolation there. Not exhaustively audited.
- **A real coverage gap this leaves**, worth its own issue: the ledger-aware OR-leg at `hooks/openspec-guard.sh:1113-1116` (`branch_ledger_has` satisfying REVIEW GUARD) can never fire under the dead root, so it has zero coverage in this file. Pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
