### PR TITLE
fix: dispatch reviewers without asking, and stop naming an agent that does not exist

### DIFF
--- a/.claude/hookify.require-review-before-push.local.md
+++ b/.claude/hookify.require-review-before-push.local.md
@@ -12,7 +12,7 @@ You are about to push without completing the REVIEW and SHIP phases.
 
 **Before pushing, confirm ALL of the following:**
 
-1. **Code review dispatched?** Did you dispatch a `superpowers:code-reviewer` subagent with BASE_SHA and HEAD_SHA in this session?
+1. **Code review dispatched?** Did you dispatch a code-reviewer subagent (general-purpose + the superpowers code-reviewer.md template; prefer pr-review-toolkit:code-reviewer or feature-dev:code-reviewer when installed) with BASE_SHA and HEAD_SHA in this session?
 2. **Review findings addressed?** Were critical/important issues fixed?
 3. **Verification run?** Did you run `bash tests/run-tests.sh` with fresh output AFTER the last code change?
 4. **User approved the push?** Did the user explicitly say "push it", "go ahead and push", or similar?

--- a/config/default-triggers.json
+++ b/config/default-triggers.json
@@ -138,7 +138,7 @@
       "requires": [
         "executing-plans"
       ],
-      "description": "Dispatch superpowers:code-reviewer subagent with git diff range and plan reference. Fix critical/important issues before proceeding.",
+      "description": "Dispatch a code-reviewer subagent (general-purpose + superpowers' code-reviewer.md template; prefer pr-review-toolkit:code-reviewer when installed) with git diff range and plan reference. Fix critical/important issues before proceeding.",
       "invoke": "Skill(superpowers:requesting-code-review)"
     },
     {
@@ -1477,7 +1477,7 @@
       "sequence": [
         {
           "step": "requesting-code-review",
-          "purpose": "Get BASE_SHA and HEAD_SHA. Dispatch superpowers:code-reviewer subagent with diff and plan reference. Fix critical/important issues."
+          "purpose": "Get BASE_SHA and HEAD_SHA. Dispatch a code-reviewer subagent (general-purpose + superpowers' code-reviewer.md template) with diff and plan reference. Fix critical/important issues."
         },
         {
           "step": "agent-team-review",

--- a/config/fallback-registry.json
+++ b/config/fallback-registry.json
@@ -151,7 +151,7 @@
       "requires": [
         "executing-plans"
       ],
-      "description": "Dispatch superpowers:code-reviewer subagent with git diff range and plan reference. Fix critical/important issues before proceeding.",
+      "description": "Dispatch a code-reviewer subagent (general-purpose + superpowers' code-reviewer.md template; prefer pr-review-toolkit:code-reviewer when installed) with git diff range and plan reference. Fix critical/important issues before proceeding.",
       "invoke": "Skill(superpowers:requesting-code-review)",
       "available": false,
       "enabled": true
@@ -1347,7 +1347,7 @@
       "sequence": [
         {
           "step": "requesting-code-review",
-          "purpose": "Get BASE_SHA and HEAD_SHA. Dispatch superpowers:code-reviewer subagent with diff and plan reference. Fix critical/important issues."
+          "purpose": "Get BASE_SHA and HEAD_SHA. Dispatch a code-reviewer subagent (general-purpose + superpowers' code-reviewer.md template) with diff and plan reference. Fix critical/important issues."
         },
         {
           "step": "agent-team-review",

--- a/hooks/skill-activation-hook.sh
+++ b/hooks/skill-activation-hook.sh
@@ -1487,7 +1487,7 @@ HALT if any Red Flag is true:
     if command -v jq >/dev/null 2>&1 && [[ -f "${HOME}/.claude/skill-config.json" ]]; then
       _RD_RAW="$(jq -r '.phase_enforcement.review_dispatch // "auto"' \
                  "${HOME}/.claude/skill-config.json" 2>/dev/null)" || _RD_RAW="auto"
-      [[ "${_RD_RAW}" == "ask" ]] && _RD_MODE="ask"
+      if [[ "${_RD_RAW}" == "ask" ]]; then _RD_MODE="ask"; fi
     fi
     if [[ "${_RD_MODE}" != "ask" ]]; then
       RED_FLAGS="${RED_FLAGS}

--- a/hooks/skill-activation-hook.sh
+++ b/hooks/skill-activation-hook.sh
@@ -1479,6 +1479,20 @@ HALT if any Red Flag is true:
 - Not providing BASE_SHA and HEAD_SHA git diff range to the reviewer
 - Claiming review is complete without acting on critical/important findings
 - Skipping security-scanner during review (Invoke Skill(auto-claude-skills:security-scanner) for deterministic scanning)"
+    # Standing reviewer-dispatch authorization. Default is "auto"; ANY read
+    # failure (no file, no key, no jq, unparseable) also yields "auto",
+    # because falling back to silence would restore the very stall this
+    # renders to remove. Opt out with review_dispatch: "ask".
+    _RD_MODE="auto"
+    if command -v jq >/dev/null 2>&1 && [[ -f "${HOME}/.claude/skill-config.json" ]]; then
+      _RD_RAW="$(jq -r '.phase_enforcement.review_dispatch // "auto"' \
+                 "${HOME}/.claude/skill-config.json" 2>/dev/null)" || _RD_RAW="auto"
+      [[ "${_RD_RAW}" == "ask" ]] && _RD_MODE="ask"
+    fi
+    if [[ "${_RD_MODE}" != "ask" ]]; then
+      RED_FLAGS="${RED_FLAGS}
+REVIEWER DISPATCH: dispatching a read-only reviewer subagent is pre-authorized for this phase. Dispatch it directly; do NOT pause to ask the user to approve the dispatch. This authorization covers agents that only read and report. It does NOT cover agents that edit files, push, or take outbound actions — those still require approval."
+    fi
     ;;
   LEARN)
     RED_FLAGS="

--- a/hooks/skill-activation-hook.sh
+++ b/hooks/skill-activation-hook.sh
@@ -1475,7 +1475,7 @@ HALT if any Red Flag is true:
   REVIEW)
     RED_FLAGS="
 HALT if any Red Flag is true:
-- Summarizing changes instead of dispatching superpowers:code-reviewer subagent
+- Summarizing changes instead of dispatching a code-reviewer subagent (general-purpose + the superpowers code-reviewer.md template; prefer pr-review-toolkit:code-reviewer or feature-dev:code-reviewer when installed)
 - Not providing BASE_SHA and HEAD_SHA git diff range to the reviewer
 - Claiming review is complete without acting on critical/important findings
 - Skipping security-scanner during review (Invoke Skill(auto-claude-skills:security-scanner) for deterministic scanning)"

--- a/tests/test-review-dispatch-authorization.sh
+++ b/tests/test-review-dispatch-authorization.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+. "${SCRIPT_DIR}/test-helpers.sh"
+echo "=== test-review-dispatch-authorization.sh ==="
+
+HOOK="${PROJECT_ROOT}/hooks/skill-activation-hook.sh"
+_OLDHOME="$HOME"
+
+# Drive the hook with a REVIEW-phase prompt and a controlled HOME.
+#
+# TWO measured facts are load-bearing here; changing either silently guts this test.
+#
+# 1. THE PROMPT. The RED_FLAGS `case` keys off the DETECTED PHASE, so the
+#    sentinel renders only when the phase is REVIEW. Measured against the real
+#    hook: "review the code", "code review please", "requesting code review",
+#    and "review my pull request" ALL route to LEARN, not REVIEW. Only a
+#    diff-quality phrasing reaches REVIEW. Do not "simplify" this prompt to
+#    something that reads more like a review request — it will route to LEARN
+#    and every assertion below will fail for the wrong reason.
+#
+# 2. NO `< /dev/null` HERE. The payload is PIPED in. Adding the redirect
+#    overrides the pipe, the hook reads an EMPTY payload, exits 0 with no
+#    output, and all four assertions fail confusingly. The standing
+#    `< /dev/null` rule applies to hooks invoked WITHOUT a piped payload
+#    (e.g. session-start-hook), not to this one.
+_REVIEW_PROMPT='check the code quality of this diff'
+
+_run_review() {   # $1 = skill-config.json content, or empty for "no file"
+    export HOME="$(mktemp -d /tmp/rda-home-XXXXXX)"
+    mkdir -p "$HOME/.claude"
+    # The activation hook needs a registry cache; session-start builds it.
+    # This one takes NO piped payload, so it DOES need < /dev/null.
+    ( cd "${PROJECT_ROOT}" && CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" _SKILL_TEST_MODE=1 \
+        bash "${PROJECT_ROOT}/hooks/session-start-hook.sh" >/dev/null 2>&1 < /dev/null )
+    [ -n "$1" ] && printf '%s' "$1" > "$HOME/.claude/skill-config.json"
+    printf '{"prompt":"%s"}' "${_REVIEW_PROMPT}" \
+      | ( cd "${PROJECT_ROOT}" && CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${HOOK}" 2>/dev/null )
+}
+
+# (0) VACUITY GUARD — run FIRST. Every assertion below infers "the
+# authorization did not render" from the sentinel's absence. That inference is
+# only valid if the REVIEW phase was reached at all. Without this guard, a
+# routing change turns the whole test green-by-absence in the (b) case and
+# red-for-the-wrong-reason everywhere else, and the failure message would send
+# the next engineer hunting in the wrong file.
+_probe="$(_run_review "")"
+if printf '%s' "${_probe}" | grep -qF 'Summarizing changes instead of dispatching'; then
+    _record_pass "REVIEW phase is actually reached (test is not vacuous)"
+else
+    _record_fail "REVIEW phase is actually reached (test is not vacuous)" \
+        "the REVIEW red-flag block did not render — the prompt no longer routes to REVIEW, so every assertion below is meaningless"
+fi
+
+# (a) No config at all => authorization renders (the default is auto).
+if _run_review "" | grep -qF 'REVIEWER DISPATCH:'; then
+    _record_pass "default install renders the dispatch authorization"
+else
+    _record_fail "default install renders the dispatch authorization" "sentinel absent"
+fi
+
+# (b) Explicit opt-out => suppressed.
+if _run_review '{"phase_enforcement":{"review_dispatch":"ask"}}' | grep -qF 'REVIEWER DISPATCH:'; then
+    _record_fail "opt-out suppresses the authorization" "sentinel present despite ask"
+else
+    _record_pass "opt-out suppresses the authorization"
+fi
+
+# (c) Unparseable config => falls back to the DEFAULT (auto), not to silence.
+# A config read failure must not restore the stall this feature removes.
+if _run_review '{not valid json' | grep -qF 'REVIEWER DISPATCH:'; then
+    _record_pass "unparseable config falls back to the authorization"
+else
+    _record_fail "unparseable config falls back to the authorization" "sentinel absent"
+fi
+
+# (d) Explicit auto => renders.
+if _run_review '{"phase_enforcement":{"review_dispatch":"auto"}}' | grep -qF 'REVIEWER DISPATCH:'; then
+    _record_pass "explicit auto renders the authorization"
+else
+    _record_fail "explicit auto renders the authorization" "sentinel absent"
+fi
+
+export HOME="$_OLDHOME"
+print_summary
+exit $?

--- a/tests/test-review-dispatch-authorization.sh
+++ b/tests/test-review-dispatch-authorization.sh
@@ -8,6 +8,29 @@ echo "=== test-review-dispatch-authorization.sh ==="
 HOOK="${PROJECT_ROOT}/hooks/skill-activation-hook.sh"
 _OLDHOME="$HOME"
 
+# Each _run_review call gets its own throwaway HOME via mktemp; track every one
+# created so the EXIT trap can remove exactly those paths (never a glob — an
+# unmatched glob is FATAL in zsh and would abort the trap silently) and runs
+# on both pass and fail.
+#
+# This MUST be a file, not a shell variable: every call site below invokes
+# _run_review either inside a pipe (`_run_review ... | grep`) or a command
+# substitution (`$(_run_review ...)`), and both run the left/inner side in a
+# subshell — a variable appended-to there is lost the instant the subshell
+# exits, so the created HOME would never make it back into a parent-shell
+# list. A manifest file is plain disk I/O and survives the subshell boundary.
+_RDA_MANIFEST="$(mktemp "${TMPDIR:-/tmp}/rda-manifest.XXXXXX")"
+_cleanup_rda_tmp_dirs() {
+    local _d
+    if [ -f "${_RDA_MANIFEST}" ]; then
+        while IFS= read -r _d; do
+            [ -n "${_d}" ] && [ -d "${_d}" ] && rm -rf "${_d}"
+        done < "${_RDA_MANIFEST}"
+        rm -f "${_RDA_MANIFEST}"
+    fi
+}
+trap _cleanup_rda_tmp_dirs EXIT
+
 # Drive the hook with a REVIEW-phase prompt and a controlled HOME.
 #
 # TWO measured facts are load-bearing here; changing either silently guts this test.
@@ -28,7 +51,8 @@ _OLDHOME="$HOME"
 _REVIEW_PROMPT='check the code quality of this diff'
 
 _run_review() {   # $1 = skill-config.json content, or empty for "no file"
-    export HOME="$(mktemp -d /tmp/rda-home-XXXXXX)"
+    export HOME="$(mktemp -d "${TMPDIR:-/tmp}/rda-home-XXXXXX")"
+    printf '%s\n' "${HOME}" >> "${_RDA_MANIFEST}"
     mkdir -p "$HOME/.claude"
     # The activation hook needs a registry cache; session-start builds it.
     # This one takes NO piped payload, so it DOES need < /dev/null.
@@ -45,6 +69,14 @@ _run_review() {   # $1 = skill-config.json content, or empty for "no file"
 # routing change turns the whole test green-by-absence in the (b) case and
 # red-for-the-wrong-reason everywhere else, and the failure message would send
 # the next engineer hunting in the wrong file.
+#
+# This guard only probes the "" (no-config) run, not the (b)/(c)/(d) configs.
+# That is safe only under an unstated assumption: PRIMARY_PHASE is derived
+# solely from trigger-scored skills built by session-start-hook.sh, which
+# _run_review always runs BEFORE the config file (if any) is written — so
+# config content cannot influence routing/phase detection, and probing one
+# run's phase covers all of them. If _run_review is ever reordered to write
+# the config before session-start runs, re-verify this assumption.
 _probe="$(_run_review "")"
 if printf '%s' "${_probe}" | grep -qF 'Summarizing changes instead of dispatching'; then
     _record_pass "REVIEW phase is actually reached (test is not vacuous)"

--- a/tests/test-reviewer-agent-name.sh
+++ b/tests/test-reviewer-agent-name.sh
@@ -8,14 +8,35 @@ echo "=== test-reviewer-agent-name.sh ==="
 # The superpowers plugin ships no agents/ directory, so this agent type is
 # unregistered and a literal dispatch of it fails. grep -F: the string has no
 # regex metacharacters, but -F is the standing rule for literal matching.
-_hits="$(grep -rF 'superpowers:code-reviewer' \
-    "${PROJECT_ROOT}/hooks" "${PROJECT_ROOT}/config" "${PROJECT_ROOT}/skills" \
-    2>/dev/null | wc -l | tr -d ' ')"
-if [ "${_hits}" = "0" ]; then
-    _record_pass "no unregistered superpowers:code-reviewer reference remains"
+#
+# Scanned via `git grep` over TRACKED files, not a filesystem grep over a
+# fixed directory list: the requirement is about what SHIPS. `git grep`
+# automatically skips `.claude/worktrees/` checkouts and gitignored scratch
+# (verified: `.superpowers/`, which holds the SDD ledger and quotes this
+# string, is gitignored and does not self-match).
+#   - `openspec/` is excluded: the spec documents quote the dead string
+#     deliberately, as evidence of the defect being fixed.
+#   - `tests/` is excluded: it holds this test file plus 4 frozen eval
+#     snapshots under `tests/fixtures/*/evals/behavioral.json` that
+#     legitimately embed the old string. Confirmed inert — both consuming
+#     suites pass: test-composition-uptake-pack.sh (16/16) and
+#     test-attestation-measurement.sh (37/37).
+# A `git grep` exit code >1 is a real error (bad pathspec, not a repo, etc.)
+# and must fail loudly rather than read as "zero hits, clean" — silently
+# collapsing "could not check" into "no reference" would defeat the gate.
+_gg_output="$(cd "${PROJECT_ROOT}" && git grep -lF 'superpowers:code-reviewer' -- \
+    ':(exclude)openspec/' ':(exclude)tests/' 2>&1)"
+_gg_exit=$?
+if [ "${_gg_exit}" -gt 1 ]; then
+    _record_fail "git grep scan for superpowers:code-reviewer completed without error" \
+        "git grep exited ${_gg_exit}: ${_gg_output}"
+elif [ -z "${_gg_output}" ]; then
+    _record_pass "no unregistered superpowers:code-reviewer reference remains in tracked files"
 else
-    _record_fail "no unregistered superpowers:code-reviewer reference remains" \
-        "found ${_hits} reference(s)"
+    _hits="$(printf '%s\n' "${_gg_output}" | wc -l | tr -d ' ')"
+    _record_fail "no unregistered superpowers:code-reviewer reference remains in tracked files" \
+        "found ${_hits} tracked file(s):
+${_gg_output}"
 fi
 
 # The replacement must name a target that exists on every install.

--- a/tests/test-reviewer-agent-name.sh
+++ b/tests/test-reviewer-agent-name.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+. "${SCRIPT_DIR}/test-helpers.sh"
+echo "=== test-reviewer-agent-name.sh ==="
+
+# The superpowers plugin ships no agents/ directory, so this agent type is
+# unregistered and a literal dispatch of it fails. grep -F: the string has no
+# regex metacharacters, but -F is the standing rule for literal matching.
+_hits="$(grep -rF 'superpowers:code-reviewer' \
+    "${PROJECT_ROOT}/hooks" "${PROJECT_ROOT}/config" "${PROJECT_ROOT}/skills" \
+    2>/dev/null | wc -l | tr -d ' ')"
+if [ "${_hits}" = "0" ]; then
+    _record_pass "no unregistered superpowers:code-reviewer reference remains"
+else
+    _record_fail "no unregistered superpowers:code-reviewer reference remains" \
+        "found ${_hits} reference(s)"
+fi
+
+# The replacement must name a target that exists on every install.
+if grep -rqF 'general-purpose' "${PROJECT_ROOT}/config/default-triggers.json"; then
+    _record_pass "routing config names an always-available reviewer target"
+else
+    _record_fail "routing config names an always-available reviewer target" \
+        "general-purpose not found in default-triggers.json"
+fi
+
+print_summary
+exit $?

--- a/tests/test-reviewer-agent-name.sh
+++ b/tests/test-reviewer-agent-name.sh
@@ -21,10 +21,26 @@ echo "=== test-reviewer-agent-name.sh ==="
 #     legitimately embed the old string. Confirmed inert — both consuming
 #     suites pass: test-composition-uptake-pack.sh (16/16) and
 #     test-attestation-measurement.sh (37/37).
+#
+# The `tests/` exclusion is also self-defense, independent of those frozen
+# snapshots: this file's own source carries the search string 4 times (the
+# grep pattern itself plus these comments). Drop the exclusion and the scan
+# matches itself, failing permanently no matter what the rest of the repo
+# looks like.
+#
 # A `git grep` exit code >1 is a real error (bad pathspec, not a repo, etc.)
 # and must fail loudly rather than read as "zero hits, clean" — silently
 # collapsing "could not check" into "no reference" would defeat the gate.
-_gg_output="$(cd "${PROJECT_ROOT}" && git grep -lF 'superpowers:code-reviewer' -- \
+#
+# Use `git -C`, NOT `cd ... && git grep`: `2>&1` on the compound only binds
+# to git grep, so a failing `cd` leaks its error to the outer stderr instead
+# of being captured, leaving `_gg_output` empty with exit 1 — indistinguishable
+# from git grep's own "no matches" exit 1, which silently takes the PASS
+# branch below. `git -C` folds the directory-change failure into git's own
+# exit status (128, "fatal: cannot change to ..."), which the `-gt 1` guard
+# already handles. Do not "simplify" this back to `cd &&` — that reintroduces
+# the silent-pass hole this comment exists to prevent.
+_gg_output="$(git -C "${PROJECT_ROOT}" grep -lF 'superpowers:code-reviewer' -- \
     ':(exclude)openspec/' ':(exclude)tests/' 2>&1)"
 _gg_exit=$?
 if [ "${_gg_exit}" -gt 1 ]; then


### PR DESCRIPTION
## Why

A session stalled at REVIEW: the model would not dispatch a code reviewer and asked the user to approve the dispatch instead. Two independent defects were behind it, each sufficient on its own to stop a review happening.

**1. The plugin instructed dispatching an agent that does not exist.** Five call sites named `superpowers:code-reviewer`. The `superpowers` plugin ships no `agents/` directory — that type is not registered anywhere. Its own `requesting-code-review/SKILL.md:34` says to dispatch a `general-purpose` subagent filled from its `code-reviewer.md` template. A model obeying the instruction literally gets an invalid `subagent_type`; one that improvises is guessing.

**2. No standing authorization existed.** The harness carries `Do not call the AgentTool unless the user requested it`. Precedence is user > skill > default, so that line outranks `agent-team-review`'s unconditional "Spawn Reviewers" step. A skill cannot outrank a user-level instruction — the plugin can only **satisfy** it, by making the authorization explicit and present at the moment REVIEW routes.

## What changed

- **Correct reviewer target** at all five sites: `general-purpose` + superpowers' own template as the always-available fallback; `pr-review-toolkit:code-reviewer` / `feature-dev:code-reviewer` named as preferred, never required (agent availability is per-install).
- **`phase_enforcement.review_dispatch`** in `~/.claude/skill-config.json` — `auto` by default, `ask` opts out. Renders a standing REVIEW-phase authorization to dispatch a **read-only** reviewer without per-dispatch approval. Agents that edit, push, or take outbound actions are explicitly excluded and still require approval.
- **A regression guard** (`tests/test-reviewer-agent-name.sh`) scanning tracked files via `git grep`, so the dead name cannot return.

## Two deliberate decisions worth reviewing

**Fail-open direction is inverted, on purpose.** Any config read failure — file absent, key absent, `jq` missing, unparseable JSON — resolves to `auto`, i.e. the authorization **renders**. Falling back to silence would restore the exact stall this removes. The `ask` opt-out is honoured only when it can actually be read; that is a deliberate trade, not an oversight.

**The read-only bound is instructional, not capability-enforced.** The rendered text scopes the authorization to agents that only read and report. The harness does not enforce that — `general-purpose` and `pr-review-toolkit:code-reviewer` both have full tool access. Residual risk is contained (subagents inherit the parent permission mode, so edits still prompt in default mode), but under `acceptEdits`/`bypassPermissions` the pre-authorization removes the last human look. Flagging it explicitly rather than letting the wording imply a guarantee it does not provide.

## Scan hardening

The guard test started as a filesystem grep over three directories. Two fixes during review:

- **Widened to `git grep` over tracked files.** The directory list missed a live instruction in `.claude/hookify.require-review-before-push.local.md` — the requirement is about what *ships*, not about a fixed path list. `openspec/` and `tests/` are excluded deliberately: the first quotes the string as evidence of the defect, the second contains the scanning test itself (4 self-references) plus frozen eval snapshots.
- **`git -C` instead of `cd … && git grep`.** `2>&1` binds only to `git grep`, so a failing `cd` left empty output with exit 1 — indistinguishable from "no matches", and the test **silently passed**. `git -C` surfaces a real error (128) that the existing guard catches. Measured: nonexistent dir and non-repo both hit the loud branch; healthy path unchanged.

## Verification

- Full suite on top of current `main`: **121/121 files, 0 failures** (`Files run: 121`, `Files failed: 0`).
- Both new suites green; `/bin/bash -n` clean; both JSON configs parse.
- The guard test is **mutation-tested**, not merely green: reintroducing the defect in `hooks/`, `config/`, and `skills/` individually is caught in all three cases, and the `general-purpose` assertion would have failed pre-fix (0 occurrences at base, 2 after).

## Relationship to #197

`main` has since shipped the REVIEW status/verdict split, whose advisory reads *"a Skill return is not evidence a review ran"*. This PR is the complementary half: #197 asks whether a review **passed**; this makes the reviewer actually **get dispatched** in the first place. They are coherent together, but a reader hitting both messages sees the plugin simultaneously pre-authorizing reviewer dispatch and warning that a credited review is not evidence — worth reconciling the wording deliberately rather than leaving two independently-written texts to be squared by whoever reads them.

A follow-up (PR #212) carries a passive `reviewer-ran` observer that records whether a reviewer subagent actually returned. It was split out of this PR precisely because it overlaps #197 and needs designing alongside it rather than accreting beside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
