### PR TITLE
fix: give the reviewer dispatch brief a delivery contract and the lead an idle-recovery protocol (#204)

### DIFF
--- a/.github/workflows/done-gates.yml
+++ b/.github/workflows/done-gates.yml
@@ -70,6 +70,14 @@ jobs:
       - name: Skill-content coverage gate
         run: bash tests/test-skill-content-coverage.sh < /dev/null
 
+      # Reviewer dispatch-brief content gate (issue #204). Pure content-grep over
+      # skills/agent-team-review/SKILL.md plus its pinned fixture — fast and
+      # flake-free, the profile this workflow reserves for itself. It is here
+      # because the fixture and the openspec proposal both CLAIM the leg runs in
+      # CI; reachable only via tests/run-tests.sh, that claim was false.
+      - name: Reviewer dispatch-brief gate
+        run: bash tests/test-reviewer-dispatch-brief.sh < /dev/null
+
       # The regression that pins this workflow to the documentation claim.
       - name: Done-gate CI claim is accurate
         run: bash tests/test-done-gate-ci.sh < /dev/null

--- a/docs/enforcement-map.md
+++ b/docs/enforcement-map.md
@@ -54,10 +54,16 @@ with `ACSM_SKIP_PUSH_GATE=1` in its environment. The agent cannot set either.
   Enabling protection is NOT a settings toggle here: `version-bump.yml` pushes
   directly to `main` with `[skip ci]`, so required checks would block it and
   version bumps would stop silently. See docs/CI.md before changing this.
-- Done Gates workflow (`.github/workflows/done-gates.yml`) — runs the two owned
-  done-gates, routing-fixture coverage and skill-content coverage, on every PR.
-  Would hard-block only if marked Required (see the caveat above).
-  Regression: `tests/test-done-gate-ci.sh` pins the workflow to this claim.
+- Done Gates workflow (`.github/workflows/done-gates.yml`) — runs three content
+  checks on every PR: the two owned done-gates (routing-fixture coverage,
+  skill-content coverage) plus the reviewer dispatch-brief gate
+  (`tests/test-reviewer-dispatch-brief.sh`, issue #204). The third is a
+  single-skill content gate, not a third owned done-gate — it is here because
+  its own fixture and openspec proposal CLAIMED it ran in CI while it was
+  reachable only through `tests/run-tests.sh`, i.e. the folklore corrected in
+  the bullet below. All three would hard-block only if marked Required (see the
+  caveat above). Regression: `tests/test-done-gate-ci.sh` pins the workflow to
+  this claim — extend it when adding a step, or the claim rots.
 - OpenSpec Validate workflow (spec-driven mode) — same: runs on every PR, not
   currently Required, so it does not block.
 - **The FULL `tests/run-tests.sh` suite does NOT run in CI.** `.verify.yml` is

--- a/openspec/changes/reviewer-dispatch-brief/design.md
+++ b/openspec/changes/reviewer-dispatch-brief/design.md
@@ -1,0 +1,85 @@
+# Design: reviewer dispatch brief — delivery contract and idle recovery
+
+## Architecture
+
+Two surfaces, split by who reads them.
+
+### Reviewer-side: the clause must be in the prompt
+
+A reviewer subagent sees exactly one thing: its own `prompt`. Protocol prose in
+`SKILL.md` is read by the **lead**, never by the reviewer. So every clause that governs
+reviewer behaviour is duplicated into all four lens prompts, and the test asserts it
+**per block**. A whole-file needle would pass with the clause in one prompt and absent
+from the other three — which is the exact failure shape observed (a correction reached
+one reviewer after it had already mutated the shared tree).
+
+Placement is deliberate: the `## Delivery Contract` block sits **before** `## Your Lens`.
+The memory this issue derives from says to state it "up front"; a reviewer that runs out
+of budget mid-review has already read a contract that tells it to send what it has.
+
+| Clause | Failure it addresses |
+|--------|----------------------|
+| Time-box 15 min, `REPORT EVEN IF INCOMPLETE` | one reviewer timed out and delivered nothing |
+| `Deliver unprompted` + send to `main` | three reviewers went idle holding complete reports |
+| `Silence is not a pass` | idle read as "done, nothing found" |
+| `do not manufacture findings` | keeps the delivery metric ungameable (issue #204 safety clause) |
+| `git worktree add --detach` | one reviewer ran 8 mutations in the shared tree during a 12-min suite run |
+| VERIFIED-vs-INFERRED labelling | pairs with the existing `Evidence: observable failure path` contract |
+
+### Lead-side: a mechanism, not an assertion
+
+`Verification` already claimed the outcome. Issue #204's finding is that nothing produced
+it. Protocol §3 now carries a reviewer-state table, so each state has a defined action
+instead of leaving "idle" to be read as success.
+
+The ordering inside that table is the non-obvious part. **The first move on a quiet agent
+is `git status`/`git log`, not re-dispatch.** Confirmed across a 6-task branch: of five
+stalled subagents, three had the completed work sitting uncommitted in the tree. A
+re-dispatch-first protocol duplicates real work — this was observed four separate times.
+
+**Chase twice.** Two reviewers had to be nudged twice before delivering, and both were
+holding substantive findings; one caught a dead-agent reference the lead's own scan
+missed. A single-nudge write-off loses real findings, so the floor is two.
+
+**Undelivered ≠ clean.** The verdict writer already has `could-not-review`. Wiring the
+uncovered-lens case to it keeps "we could not review" distinguishable from "we reviewed
+and found nothing" — the same distinction the anti-fabrication clause protects on the
+reviewer side.
+
+## Why the deterministic gate is content-only
+
+The gate asserts that the clauses are present, not that reviewers obey them. That is the
+same deliberate presence-not-quality bar the repo's other skill-content gates take
+(`tests/test-skill-content-coverage.sh`). Behavioural conformance is the A/B contract's
+other leg, pinned in `tests/fixtures/agent-team-review/dispatch-brief/pinned-range.txt`.
+
+## Non-vacuity
+
+Three ways this test could pass while proving nothing, each pinned:
+
+1. **Empty/unreadable fixture** ⇒ the per-lens loop iterates zero needles. A floor of 7
+   needles is asserted before the loop (mutation-verified: emptying the fixture drops the
+   run count 55 → 19 and fails that one control).
+2. **Moved anchors** ⇒ an unmatched `name: "<lens>"` yields an empty block and every
+   clause assertion for that lens vanishes. Empty extraction is an explicit failure.
+3. **Last block running to EOF** ⇒ `adversarial-reviewer` is the final prompt, so a range
+   terminating only on the next `name: "` would absorb Red Flags and Verification, and a
+   clause misplaced there would false-pass. The range also stops at the next top-level
+   `## ` heading (mutation-verified: moving a clause from the adversarial prompt into
+   `## Red Flags` fails).
+
+All four mutations plus the M1 single-lens strip were run and each failed exactly the
+assertion it should, with a green control before and after.
+
+## Alternatives rejected
+
+- **State the contract once in Protocol §2 and reference it from the prompts.** The
+  reviewer never reads Protocol §2. This is precisely the bug.
+- **A shared `references/dispatch-brief.md` interpolated at dispatch time.** The prompts
+  are literal templates a model copies; there is no interpolation step to hook. It would
+  add an indirection the model must resolve at exactly the moment it is under budget
+  pressure.
+- **Make undelivered reviewers a hard block on SHIP.** Out of proportion and untested;
+  the repo's documented discipline is warn-first-and-measure (deny variants shipped
+  without a backtest ran 56–94% false-block). The verdict downgrade to `could-not-review`
+  already records the state without blocking.

--- a/openspec/changes/reviewer-dispatch-brief/design.md
+++ b/openspec/changes/reviewer-dispatch-brief/design.md
@@ -46,6 +46,14 @@ uncovered-lens case to it keeps "we could not review" distinguishable from "we r
 and found nothing" — the same distinction the anti-fabrication clause protects on the
 reviewer side.
 
+## "Runs in CI" is not "blocks merge"
+
+The gate is a `done-gates.yml` step, so it runs on every PR. It **hard-blocks** only once
+"Done Gates" is marked Required in GitHub branch protection — a manual repo setting outside
+this tree, exactly as `docs/CI.md` and that workflow's own header already state for the two
+pre-existing gates. Do not upgrade the wording to "blocks merge" without checking that
+setting.
+
 ## Why the deterministic gate is content-only
 
 The gate asserts that the clauses are present, not that reviewers obey them. That is the
@@ -85,10 +93,22 @@ cut got wrong, and it is the reason there are two authorities rather than one:
    and anchored on new text. The same class hit `git status` (generic) and the
    `## Verification` mechanism lines (unasserted entirely — the diff's headline claim).
 
-Measured with a green control before and after each: single-lens clause strip ⇒ 1 fail
-scoped to that lens; emptied fixture ⇒ the non-vacuity control fires and the run count
-drops **57 → 21**; renamed lens anchor ⇒ block-extraction fail; clause relocated into
-`## Red Flags` ⇒ that lens fails; lead-side row deleted ⇒ fail.
+**The anchor set must track the FIXTURE, not the issue.** The first cut of control 1
+anchored issue #204's own clauses only, while the fixture grew past them during review, and
+the floor was set to the *anchor* count rather than the *fixture* count. All three reviewers
+independently found the resulting gap: deleting the three unanchored needles (`mktemp -d`,
+the subject-confirmation rule, the VERIFIED/INFERRED rule) landed exactly on the floor and
+ran **82/82 green** — a green run that reinstated the fixed-path worktree collision in all
+four prompts, i.e. deleted a fix this very change had just made. Every needle is anchored
+now and the floor equals the fixture size, so the two controls are independent rather than
+one duplicating the other (the mutation now fails 4 assertions: 3 anchors + the floor).
+
+Measured at the current tip, with a green control before and after each: **14 needles, 14
+anchors, 102 assertions**; single-lens clause strip ⇒ 1 fail scoped to that lens; emptied
+fixture ⇒ 46 run / 15 fail; renamed lens anchor ⇒ block-extraction fail; clause relocated
+into `## Red Flags` ⇒ that lens fails; lead-side row deleted ⇒ fail. Counts are
+data-dependent (needles × lenses), so treat them as measurements to re-run, never as
+constants to pin.
 
 **Duplication has one cost — drift — and it is now pinned.** Nothing previously asserted
 that the four Delivery Contract blocks were identical, so a reworded copy still carrying

--- a/openspec/changes/reviewer-dispatch-brief/design.md
+++ b/openspec/changes/reviewer-dispatch-brief/design.md
@@ -55,21 +55,44 @@ other leg, pinned in `tests/fixtures/agent-team-review/dispatch-brief/pinned-ran
 
 ## Non-vacuity
 
-Three ways this test could pass while proving nothing, each pinned:
+Six ways this test could pass while proving nothing. The first is the one the initial
+cut got wrong, and it is the reason there are two authorities rather than one:
 
-1. **Empty/unreadable fixture** ⇒ the per-lens loop iterates zero needles. A floor of 7
-   needles is asserted before the loop (mutation-verified: emptying the fixture drops the
-   run count 55 → 19 and fails that one control).
-2. **Moved anchors** ⇒ an unmatched `name: "<lens>"` yields an empty block and every
-   clause assertion for that lens vanishes. Empty extraction is an explicit failure.
-3. **Last block running to EOF** ⇒ `adversarial-reviewer` is the final prompt, so a range
+1. **A shrinking fixture silently deletes its own assertions.** With the fixture as sole
+   authority and only a count floor, review demonstrated a **fully green 49/49 run that
+   inverted issue #204's clauses 1 and 2**: delete two needles from `required-clauses.txt`
+   (9 → 7, exactly the old floor) and reword the matching clauses in all four prompts to
+   say the opposite. A count floor cannot notice this, because the deleted needle takes
+   its assertion with it. Fixed by hardcoding the #204 clause anchors in the *test* and
+   asserting the fixture still contains each of them (`grep -Fx`, whole-line). The fixture
+   may be extended; it may not shrink.
+2. **Empty/unreadable/wholly-commented fixture** ⇒ the per-lens loop iterates zero needles.
+   The anchor control above trips first; the count floor remains as a second net.
+3. **Moved anchors** ⇒ an unmatched `name: "<lens>"` yields an empty block and every clause
+   assertion for that lens vanishes. Empty extraction is an explicit failure.
+4. **Last block running to EOF** ⇒ `adversarial-reviewer` is the final prompt, so a range
    terminating only on the next `name: "` would absorb Red Flags and Verification, and a
    clause misplaced there would false-pass. The range also stops at the next top-level
    `## ` heading (mutation-verified: moving a clause from the adversarial prompt into
    `## Red Flags` fails).
+5. **A hardcoded lens list exempts a fifth lens.** Review demonstrated appending a
+   `perf-reviewer` template carrying none of the clauses: green. The population is now
+   derived from `SKILL.md` inside `## Reviewer Spawn Templates`, with a floor of 4.
+6. **A needle satisfied by a pre-existing fallback pins nothing.** `could-not-review`
+   already occurred once at the base commit in `## Record the Review Verdict`, so the
+   assertion labelled "undelivered reviewer downgrades the verdict" passed with the entire
+   new Protocol §3 paragraph deleted. Lead-side assertions are now scoped to the §3 block
+   and anchored on new text. The same class hit `git status` (generic) and the
+   `## Verification` mechanism lines (unasserted entirely — the diff's headline claim).
 
-All four mutations plus the M1 single-lens strip were run and each failed exactly the
-assertion it should, with a green control before and after.
+Measured with a green control before and after each: single-lens clause strip ⇒ 1 fail
+scoped to that lens; emptied fixture ⇒ the non-vacuity control fires and the run count
+drops **57 → 21**; renamed lens anchor ⇒ block-extraction fail; clause relocated into
+`## Red Flags` ⇒ that lens fails; lead-side row deleted ⇒ fail.
+
+**Duplication has one cost — drift — and it is now pinned.** Nothing previously asserted
+that the four Delivery Contract blocks were identical, so a reworded copy still carrying
+every needle passed. The blocks are extracted and compared byte-for-byte against the first.
 
 ## Alternatives rejected
 

--- a/openspec/changes/reviewer-dispatch-brief/proposal.md
+++ b/openspec/changes/reviewer-dispatch-brief/proposal.md
@@ -45,8 +45,14 @@ Two facts make the reviewer-side clauses load-bearing rather than decorative:
    findings", which keeps the delivery metric from being gamed by fabrication.
 
 2. **An own-worktree rule in every lens's `## Rules`** — any reviewer that RUNS or MUTATES
-   anything (tests, builds, mutation testing) must `git worktree add --detach` first and
-   never write to the shared tree. Paired with a verified-vs-inferred labelling rule.
+   anything (tests, builds, mutation testing) must `git worktree add --detach` into a
+   `mktemp -d` path first and never write to the shared tree. The path must be unique per
+   invocation: lens names are constants, so a fixed `/tmp/review-<lens>` fails with
+   `fatal: already exists` the moment the lead re-dispatches a timed-out reviewer, which
+   the lead-side protocol mandates. The reviewer must also confirm its worktree matches the
+   subject — a detached worktree does not carry the shared tree's uncommitted changes, so
+   running against it and reporting VERIFIED would name a different tree. Paired with a
+   verified-vs-inferred labelling rule.
 
    The clauses live **in each prompt, not in the protocol prose**, because a reviewer
    subagent only ever sees its own prompt.
@@ -68,7 +74,17 @@ Two facts make the reviewer-side clauses load-bearing rather than decorative:
 
 6. **Deterministic gate** `tests/test-reviewer-dispatch-brief.sh` — asserts every clause in
    **every** lens block, scoped per block so a clause stated once cannot satisfy four
-   reviewers, plus the lead-side protocol and the no-regression clauses.
+   reviewers, plus the lead-side protocol (scoped to Protocol §3) and the no-regression
+   clauses. The gate is a **second authority**, not a fixture reader: it hardcodes the #204
+   clause anchors and asserts the fixture still carries them, because with the fixture as
+   sole authority a deleted needle silently deletes its own assertion. It derives the lens
+   population from the skill rather than hardcoding four, and compares the four Delivery
+   Contract blocks byte-for-byte, since drift is duplication's one cost.
+
+7. **Registered in CI** — added to `.github/workflows/done-gates.yml` and pinned by
+   `tests/test-done-gate-ci.sh`. This was a claim before it was true: `.verify.yml` is
+   `substrate: local` and is read by no workflow, so a test reachable only through
+   `tests/run-tests.sh` is not a CI check.
 
 ## Capabilities
 
@@ -87,7 +103,8 @@ Two facts make the reviewer-side clauses load-bearing rather than decorative:
 ## Sequencing: why the behavioral leg is not a merge precondition
 
 The A/B contract in #204 has two legs. The deterministic leg (every lens prompt carries
-every clause) is cheap, runs in CI, and lands with the prompt edit. The behavioral leg
+every clause) is cheap and lands with the prompt edit — and is registered as a
+`done-gates.yml` step so that "runs in CI" is a fact rather than a claim. The behavioral leg
 (dispatch the 4-lens team over the pinned range and measure unprompted delivery ≥ 3/4 with
 zero main-tree mutations) requires live multi-agent dispatch: slow, nondeterministic, and
 explicitly optional evidence per the issue. Its subject is pinned in `pinned-range.txt` so a

--- a/openspec/changes/reviewer-dispatch-brief/proposal.md
+++ b/openspec/changes/reviewer-dispatch-brief/proposal.md
@@ -1,0 +1,103 @@
+# Proposal: give the reviewer dispatch brief a delivery contract, and the lead an idle-recovery protocol
+
+## Why
+
+Issue #204. From a single push-gate review round, recorded in
+`memory/background-reviewers-need-explicit-report-request.md`:
+
+- four reviewers dispatched; **three went idle with no findings attached** and produced
+  full reports only when explicitly asked;
+- **one errored with a request timeout** and produced nothing at all;
+- one reviewer performing mutation testing **edited the shared working tree** while a
+  12-minute suite run was in progress against it, invalidating the run.
+
+The unprompted delivery rate for that round was **0/4**.
+
+At the issue's verified sha, each of the four lens prompts in
+`skills/agent-team-review/SKILL.md` said only:
+
+```
+- Read-only: do NOT modify any files
+- Send all findings to the lead via SendMessage
+```
+
+That brief is silent on every condition the observed failures turned on. And the skill's
+`Verification` section already asserts the *outcome* — "Every spawned reviewer returned a
+finding set this session -- no reviewer silently dropped" — while supplying **no mechanism
+by which that outcome is reached**. It is an unenforced assertion, which is why the round
+above could produce 0/4 delivery and still pass the skill as written.
+
+Two facts make the reviewer-side clauses load-bearing rather than decorative:
+
+1. A background `Agent` in this harness signals idle with a `summary` at best. **An agent's
+   final text is its return value, not a message to the lead** — nothing routes it to the
+   main conversation unless the agent calls `SendMessage` to `main`, which it often does
+   not do unprompted.
+2. The read-only rule covers editing *for review purposes*. It does not cover a reviewer
+   told to mutation-test, which is exactly the case that corrupted the shared tree.
+
+## What Changes
+
+1. **A `## Delivery Contract (read this first)` block in every one of the four lens
+   prompts**, placed ahead of the lens itself so it is read before the review starts:
+   time-box + report-even-if-incomplete; deliver unprompted (idle loses the review);
+   "Silence is not a pass"; and "say plainly if you find nothing — do not manufacture
+   findings", which keeps the delivery metric from being gamed by fabrication.
+
+2. **An own-worktree rule in every lens's `## Rules`** — any reviewer that RUNS or MUTATES
+   anything (tests, builds, mutation testing) must `git worktree add --detach` first and
+   never write to the shared tree. Paired with a verified-vs-inferred labelling rule.
+
+   The clauses live **in each prompt, not in the protocol prose**, because a reviewer
+   subagent only ever sees its own prompt.
+
+3. **A lead-side collection protocol** in Protocol §3, as a state table: idle is not a
+   report; chase at least twice; a timeout is not a pass and is never counted toward
+   coverage; **check `git status`/`git log` before re-dispatching**, because subagents here
+   routinely finish the work and stall before reporting, leaving it uncommitted in the tree
+   — re-dispatching without looking duplicates work already done. A lens that never
+   delivers makes the verdict `could-not-review`, not `clean`. A **silent drop** red flag
+   names the failure of reporting a round complete without one of its lenses.
+
+4. **The `Verification` outcome is tied to that mechanism** rather than left as a bare
+   assertion.
+
+5. **Pinned eval set** `tests/fixtures/agent-team-review/dispatch-brief/` (never delete):
+   `required-clauses.txt` (the literal needles) and `pinned-range.txt` (the sha-bound
+   subject and pre-registered metric for the behavioral leg).
+
+6. **Deterministic gate** `tests/test-reviewer-dispatch-brief.sh` — asserts every clause in
+   **every** lens block, scoped per block so a clause stated once cannot satisfy four
+   reviewers, plus the lead-side protocol and the no-regression clauses.
+
+## Capabilities
+
+### Modified Capabilities
+- `pdlc-safety`: the multi-lens review dispatch brief gains a delivery contract and a
+  worktree-isolation rule per lens, and the lead gains a defined recovery protocol for
+  idle and errored reviewers.
+
+## Impact
+
+- `skills/agent-team-review/SKILL.md` — delivery contract + worktree rule in all four lens
+  prompts; lead-side collection protocol; Verification tied to mechanism.
+- `tests/fixtures/agent-team-review/dispatch-brief/` — **new**, pinned eval set.
+- `tests/test-reviewer-dispatch-brief.sh` — **new**, deterministic content gate.
+
+## Sequencing: why the behavioral leg is not a merge precondition
+
+The A/B contract in #204 has two legs. The deterministic leg (every lens prompt carries
+every clause) is cheap, runs in CI, and lands with the prompt edit. The behavioral leg
+(dispatch the 4-lens team over the pinned range and measure unprompted delivery ≥ 3/4 with
+zero main-tree mutations) requires live multi-agent dispatch: slow, nondeterministic, and
+explicitly optional evidence per the issue. Its subject is pinned in `pinned-range.txt` so a
+later run stays comparable to the baseline.
+
+## Out-of-Scope
+
+- The reviewer-ran push-gate evidence leg (`openspec/changes/reviewer-dispatch-and-evidence`,
+  PR #212, parked pending reconciliation with #197). This change makes reviewers deliver;
+  it does not change what the push gate credits.
+- The `Task tool (general-purpose)` label in the prompt headers. This harness names the
+  subagent tool `Agent`; correcting that is tracked with the `^Task$` → `^(Task|Agent)$`
+  matcher work, not here.

--- a/openspec/changes/reviewer-dispatch-brief/specs/pdlc-safety/spec.md
+++ b/openspec/changes/reviewer-dispatch-brief/specs/pdlc-safety/spec.md
@@ -1,0 +1,94 @@
+# Spec delta: pdlc-safety — reviewer dispatch brief
+
+## ADDED Requirements
+
+### Requirement: Every reviewer lens prompt MUST carry the delivery contract
+
+Each reviewer lens prompt in `skills/agent-team-review/SKILL.md` MUST state, within that
+prompt's own text, that the reviewer:
+
+- time-boxes itself and reports even if incomplete, naming what it did not cover;
+- delivers its report unprompted via `SendMessage` to `main` before going idle or ending
+  its turn;
+- sends a report saying so when it could not review, because silence is not a pass;
+- says plainly when it finds nothing and does not manufacture findings.
+
+The clauses MUST be present in **every** lens prompt. Stating them once in the skill's
+protocol prose MUST NOT be treated as satisfying this requirement, because a reviewer
+subagent reads only its own prompt.
+
+#### Scenario: all four lens prompts carry every clause
+
+- **GIVEN** `skills/agent-team-review/SKILL.md`
+- **WHEN** each of the `security-reviewer`, `quality-reviewer`, `spec-reviewer`, and
+  `adversarial-reviewer` prompt blocks is extracted
+- **THEN** every needle in
+  `tests/fixtures/agent-team-review/dispatch-brief/required-clauses.txt` appears inside
+  each extracted block
+
+#### Scenario: a clause outside the prompt blocks does not satisfy the requirement
+
+- **GIVEN** a clause removed from a lens prompt and added to the skill's `## Red Flags`
+  section
+- **WHEN** the deterministic gate runs
+- **THEN** it fails for that lens
+
+### Requirement: A reviewer that executes or mutates MUST use its own worktree
+
+Each reviewer lens prompt MUST require that any reviewer needing to run tests, builds, or
+mutation testing first creates a detached worktree (`git worktree add --detach`), works
+only there, and never writes to the shared working tree.
+
+The existing read-only rule MUST be retained. No reviewer MUST be granted write access to
+the shared tree.
+
+#### Scenario: worktree rule present alongside the retained read-only rule
+
+- **GIVEN** any reviewer lens prompt
+- **WHEN** its `## Rules` section is read
+- **THEN** it contains both `Read-only: do NOT modify any files` and a
+  `git worktree add --detach` instruction
+
+### Requirement: The lead MUST have a defined recovery protocol for idle and errored reviewers
+
+`skills/agent-team-review/SKILL.md` MUST define, as lead-side protocol, that:
+
+- an idle notification is not a report, and the lead requests the report explicitly;
+- a quiet reviewer is chased at least twice before being written off;
+- an errored or timed-out reviewer is re-dispatched and never counted toward coverage;
+- `git status` and `git log` are checked before any re-dispatch, because stalled subagents
+  frequently leave completed work uncommitted in the tree;
+- a lens that never delivers yields verdict `could-not-review`, not `clean`;
+- reporting a round as complete without a lens is a named red flag ("silent drop"), so
+  coverage counts reports delivered rather than agents spawned.
+
+The `Verification` section's existing outcome assertion MUST reference this mechanism
+rather than standing alone.
+
+#### Scenario: errored reviewer is not counted as covered
+
+- **GIVEN** a dispatched reviewer that errors or times out
+- **WHEN** the lead computes review coverage
+- **THEN** that reviewer is re-dispatched and excluded from coverage, and if it still does
+  not deliver the recorded verdict is `could-not-review`
+
+### Requirement: The dispatch-brief eval set MUST be pinned and non-vacuous
+
+`tests/fixtures/agent-team-review/dispatch-brief/` MUST exist and MUST NOT be deleted. It
+MUST contain the literal required clauses and a sha-bound range plus the pre-registered
+unprompted-delivery metric for the behavioral leg.
+
+The deterministic gate MUST fail rather than silently pass when the clause fixture is
+empty or unreadable, and MUST fail when a lens prompt block cannot be extracted.
+
+#### Scenario: emptied fixture fails the gate
+
+- **GIVEN** an empty `required-clauses.txt`
+- **WHEN** the deterministic gate runs
+- **THEN** it fails on the non-vacuity control rather than reporting all tests passed
+
+#### Scenario: moved prompt anchor fails the gate
+
+- **GIVEN** a lens prompt whose `name:` anchor has been renamed
+- **WHEN** the deterministic gate runs
+- **THEN** it fails on that lens's block extraction

--- a/openspec/changes/reviewer-dispatch-brief/specs/pdlc-safety/spec.md
+++ b/openspec/changes/reviewer-dispatch-brief/specs/pdlc-safety/spec.md
@@ -39,15 +39,25 @@ Each reviewer lens prompt MUST require that any reviewer needing to run tests, b
 mutation testing first creates a detached worktree (`git worktree add --detach`), works
 only there, and never writes to the shared working tree.
 
-The existing read-only rule MUST be retained. No reviewer MUST be granted write access to
-the shared tree.
+The existing read-only rule MUST be retained, scoped to the shared tree. No reviewer MUST
+EVER be granted write access to the shared working tree.
+
+The worktree path MUST be unique per invocation (`mktemp -d`), never a fixed
+lens-derived path: lens names are constants, so a re-dispatched reviewer — which the
+lead-side protocol mandates — reuses the name and fails with `fatal: already exists` on
+its first command, as do two overlapping review rounds.
+
+Each prompt MUST require the reviewer to confirm its worktree matches the subject before
+labelling anything VERIFIED, because a detached worktree does not carry the shared tree's
+uncommitted changes and would otherwise be a different tree from the one under review.
 
 #### Scenario: worktree rule present alongside the retained read-only rule
 
 - **GIVEN** any reviewer lens prompt
-- **WHEN** its `## Rules` section is read
-- **THEN** it contains both `Read-only: do NOT modify any files` and a
-  `git worktree add --detach` instruction
+- **WHEN** the prompt is read
+- **THEN** it contains `Read-only in the shared tree`, `do NOT modify any files`,
+  `git worktree add --detach`, `mktemp -d`, `Never write to the shared working tree`, and
+  `Confirm your worktree matches the subject`
 
 ### Requirement: The lead MUST have a defined recovery protocol for idle and errored reviewers
 
@@ -65,12 +75,29 @@ the shared tree.
 The `Verification` section's existing outcome assertion MUST reference this mechanism
 rather than standing alone.
 
-#### Scenario: errored reviewer is not counted as covered
+The lead MUST also reap reviewer worktrees at the end of a round. `git worktree add`
+registers under the shared repo's `.git/worktrees/`, which `git status --porcelain` cannot
+observe, so a reviewer killed before its own cleanup leaks invisibly to any main-tree
+cleanliness check.
 
-- **GIVEN** a dispatched reviewer that errors or times out
-- **WHEN** the lead computes review coverage
-- **THEN** that reviewer is re-dispatched and excluded from coverage, and if it still does
-  not deliver the recorded verdict is `could-not-review`
+#### Scenario: the errored-reviewer rule is stated in Protocol §3
+
+- **GIVEN** `skills/agent-team-review/SKILL.md`
+- **WHEN** the block between `### 3. Parallel Review` and the next `### ` heading is
+  extracted
+- **THEN** it states that a timeout is not a pass and that such a reviewer is never counted
+  toward coverage, that an undelivered lens is recorded as `--verdict could-not-review`,
+  and that reviewer worktrees are pruned
+- **AND** the assertion is scoped to that block, not to the whole file: `could-not-review`
+  already occurs elsewhere in the skill, so a whole-file needle is satisfied by that
+  pre-existing text and pins nothing
+
+#### Scenario: the Verification outcome cites its mechanism
+
+- **GIVEN** the `## Verification` section
+- **WHEN** it is read
+- **THEN** it names Protocol §3 as the mechanism producing the outcome it asserts, and
+  states that a lens that never delivered means `could-not-review`, not APPROVE
 
 ### Requirement: The dispatch-brief eval set MUST be pinned and non-vacuous
 
@@ -78,8 +105,22 @@ rather than standing alone.
 MUST contain the literal required clauses and a sha-bound range plus the pre-registered
 unprompted-delivery metric for the behavioral leg.
 
-The deterministic gate MUST fail rather than silently pass when the clause fixture is
-empty or unreadable, and MUST fail when a lens prompt block cannot be extracted.
+The fixture MUST NOT be the sole authority for what is asserted. The gate MUST
+independently carry the issue-#204 clause anchors and MUST fail when the fixture no longer
+contains one of them — otherwise deleting a needle silently deletes its own assertion, and
+a fixture trimmed to the floor plus inverted prompts runs green.
+
+The gate MUST derive the lens population from `skills/agent-team-review/SKILL.md` rather
+than hardcoding it, so a lens added later cannot be silently exempt, and MUST assert that
+the per-lens Delivery Contract blocks are identical, since duplication is the chosen design
+and drift is its only cost.
+
+The gate MUST fail rather than silently pass when the clause fixture is empty, unreadable,
+or absent, and MUST fail when a lens prompt block cannot be extracted.
+
+The gate MUST run in CI, not only in the local `.verify.yml` suite. `.verify.yml` is
+`substrate: local` and is read by no workflow, so a test reachable only through
+`tests/run-tests.sh` is not a CI check.
 
 #### Scenario: emptied fixture fails the gate
 
@@ -92,3 +133,23 @@ empty or unreadable, and MUST fail when a lens prompt block cannot be extracted.
 - **GIVEN** a lens prompt whose `name:` anchor has been renamed
 - **WHEN** the deterministic gate runs
 - **THEN** it fails on that lens's block extraction
+
+#### Scenario: a needle deleted from the fixture fails the gate
+
+- **GIVEN** `required-clauses.txt` with an issue-#204 clause anchor removed
+- **WHEN** the deterministic gate runs
+- **THEN** it fails on the anchor control, rather than passing with one fewer assertion
+
+#### Scenario: an unlisted fifth lens is not exempt
+
+- **GIVEN** a fifth reviewer template added under `## Reviewer Spawn Templates` carrying
+  none of the clauses
+- **WHEN** the deterministic gate runs
+- **THEN** it fails, because the lens population is derived from the skill rather than
+  hardcoded
+
+#### Scenario: the gate is invoked by the CI workflow
+
+- **GIVEN** `.github/workflows/done-gates.yml`
+- **WHEN** its `run:` lines are read
+- **THEN** they invoke `tests/test-reviewer-dispatch-brief.sh` with stdin closed

--- a/openspec/changes/reviewer-dispatch-brief/specs/pdlc-safety/spec.md
+++ b/openspec/changes/reviewer-dispatch-brief/specs/pdlc-safety/spec.md
@@ -42,6 +42,10 @@ only there, and never writes to the shared working tree.
 The existing read-only rule MUST be retained, scoped to the shared tree. No reviewer MUST
 EVER be granted write access to the shared working tree.
 
+Each prompt's Context block MUST supply the sha the worktree command consumes. An
+instruction referencing a field the prompt does not carry is unfollowable, and a reviewer
+improvising `HEAD` reintroduces the wrong-tree defect while believing it complied.
+
 The worktree path MUST be unique per invocation (`mktemp -d`), never a fixed
 lens-derived path: lens names are constants, so a re-dispatched reviewer — which the
 lead-side protocol mandates — reuses the name and fails with `fatal: already exists` on
@@ -56,8 +60,9 @@ uncommitted changes and would otherwise be a different tree from the one under r
 - **GIVEN** any reviewer lens prompt
 - **WHEN** the prompt is read
 - **THEN** it contains `Read-only in the shared tree`, `do NOT modify any files`,
-  `git worktree add --detach`, `mktemp -d`, `Never write to the shared working tree`, and
-  `Confirm your worktree matches the subject`
+  `git worktree add --detach`, `mktemp -d`, `Never write to the shared working tree`,
+  `Confirm your worktree matches the subject`, and a `Review range:` Context field naming
+  the shas
 
 ### Requirement: The lead MUST have a defined recovery protocol for idle and errored reviewers
 
@@ -106,9 +111,14 @@ MUST contain the literal required clauses and a sha-bound range plus the pre-reg
 unprompted-delivery metric for the behavioral leg.
 
 The fixture MUST NOT be the sole authority for what is asserted. The gate MUST
-independently carry the issue-#204 clause anchors and MUST fail when the fixture no longer
-contains one of them — otherwise deleting a needle silently deletes its own assertion, and
-a fixture trimmed to the floor plus inverted prompts runs green.
+independently carry an anchor for EVERY needle the fixture holds, and MUST fail when the
+fixture no longer contains one of them — otherwise deleting a needle silently deletes its
+own assertion, and a fixture trimmed to the floor plus inverted prompts runs green.
+
+The anchor set MUST track the fixture, not issue #204. Anchoring only #204's own clauses
+leaves every later-added needle unanchored, which is a live instance of the same defect.
+The non-vacuity floor MUST equal the fixture's needle count, never the anchor count: any
+headroom between the two is a set of needles deletable without tripping either control.
 
 The gate MUST derive the lens population from `skills/agent-team-review/SKILL.md` rather
 than hardcoding it, so a lens added later cannot be silently exempt, and MUST assert that
@@ -136,9 +146,10 @@ The gate MUST run in CI, not only in the local `.verify.yml` suite. `.verify.yml
 
 #### Scenario: a needle deleted from the fixture fails the gate
 
-- **GIVEN** `required-clauses.txt` with an issue-#204 clause anchor removed
+- **GIVEN** `required-clauses.txt` with any needle removed
 - **WHEN** the deterministic gate runs
-- **THEN** it fails on the anchor control, rather than passing with one fewer assertion
+- **THEN** it fails on that needle's anchor control AND on the non-vacuity floor, rather
+  than passing with one fewer assertion
 
 #### Scenario: an unlisted fifth lens is not exempt
 

--- a/skills/agent-team-review/SKILL.md
+++ b/skills/agent-team-review/SKILL.md
@@ -56,11 +56,35 @@ Each reviewer gets:
 
 ### 3. Parallel Review
 
-Reviewers work independently using Read, Grep, and analysis tools. They do NOT modify any files.
+Reviewers work independently using Read, Grep, and analysis tools. They do NOT modify the
+shared working tree; a reviewer that must RUN something works in its own detached worktree.
+
+**Collect the reports — they do not arrive on their own.** A background reviewer in this
+harness signals idle with no findings attached, because its final text is a return value,
+not a message to the lead. Observed on one push-gate change: of four reviewers, three went
+idle empty and produced full reports only when asked, and one errored out and produced
+nothing.
+
+| Reviewer state | What the lead does |
+|----------------|--------------------|
+| Report received via SendMessage | Count it. This is the only state that counts as delivered. |
+| Idle, no findings attached | **Idle is not a report.** SendMessage the reviewer asking for the report, listing the exact questions you want answered. |
+| Idle again after one nudge | Chase a quiet reviewer **at least twice** before writing it off — reviewers chased twice have delivered substantive findings that a single nudge would have lost. |
+| Errored, timed out, or killed | **A timeout is not a pass.** Re-dispatch it and never count it toward coverage. |
+| Still nothing after re-dispatch | Record the lens as uncovered and carry it into the verdict (below). Do not silently reduce the team. |
+
+**Before re-dispatching anything, run `git status` and `git log`.** The first move on a quiet
+agent is not re-dispatch — subagents here frequently finish the work and stall before
+reporting, leaving completed changes sitting uncommitted in the tree. Re-dispatching without
+looking duplicates work that is already done.
+
+**Coverage is what was delivered, not what was spawned.** If any lens never delivered, the
+review is not `clean` — record `--verdict could-not-review` (see "Record the Review Verdict")
+and say which lens is missing. Silence and "we could not review" are different states.
 
 ### 4. Lead Synthesis
 
-After all reviewers report findings:
+After collecting the reports per §3 — including any lens recorded as uncovered:
 
 1. Group findings by severity (blocking → warning → suggestion)
 2. Deduplicate overlapping findings
@@ -139,6 +163,17 @@ Task tool (general-purpose):
   prompt: |
     You are a security reviewer examining code changes.
 
+    ## Delivery Contract (read this first)
+    - Time-box yourself to 15 minutes of review, then REPORT EVEN IF INCOMPLETE: send
+      what you have via SendMessage to `main` and name what you did NOT cover. Partial
+      honest coverage beats a timeout that delivers nothing.
+    - Deliver unprompted. Send the report BEFORE you go idle or end your turn. Your
+      final text is a return value, not a message to the lead, and an idle notification
+      carries no findings — if you stop without a SendMessage, your whole review is lost.
+    - If you could not review, send a report saying so and why. Silence is not a pass.
+    - Say plainly if you find nothing — do not manufacture findings. A "no findings"
+      report delivered on time is a successful review.
+
     ## Your Lens: Security
 
     Focus on:
@@ -159,6 +194,13 @@ Task tool (general-purpose):
 
     ## Rules
     - Read-only: do NOT modify any files
+    - Own worktree for anything that executes or mutates: if your lens needs to run
+      tests, builds, or mutation testing, first `git worktree add --detach
+      /tmp/review-<your-name> HEAD`, work only there, and remove it when done.
+      Never write to the shared working tree — another agent's test suite may be
+      running against it.
+    - Distinguish what you VERIFIED by running from what you INFERRED by reading, and
+      label each finding accordingly.
     - Report each finding using the plain-text FINDING format, including the Confidence and Evidence fields
     - Send all findings to the lead via SendMessage
     - Be specific: include file path, line number, and remediation
@@ -171,6 +213,17 @@ Task tool (general-purpose):
   team_name: "code-review"
   prompt: |
     You are a code quality reviewer examining code changes.
+
+    ## Delivery Contract (read this first)
+    - Time-box yourself to 15 minutes of review, then REPORT EVEN IF INCOMPLETE: send
+      what you have via SendMessage to `main` and name what you did NOT cover. Partial
+      honest coverage beats a timeout that delivers nothing.
+    - Deliver unprompted. Send the report BEFORE you go idle or end your turn. Your
+      final text is a return value, not a message to the lead, and an idle notification
+      carries no findings — if you stop without a SendMessage, your whole review is lost.
+    - If you could not review, send a report saying so and why. Silence is not a pass.
+    - Say plainly if you find nothing — do not manufacture findings. A "no findings"
+      report delivered on time is a successful review.
 
     ## Your Lens: Code Quality
 
@@ -195,6 +248,13 @@ Task tool (general-purpose):
 
     ## Rules
     - Read-only: do NOT modify any files
+    - Own worktree for anything that executes or mutates: if your lens needs to run
+      tests, builds, or mutation testing, first `git worktree add --detach
+      /tmp/review-<your-name> HEAD`, work only there, and remove it when done.
+      Never write to the shared working tree — another agent's test suite may be
+      running against it.
+    - Distinguish what you VERIFIED by running from what you INFERRED by reading, and
+      label each finding accordingly.
     - Report each finding using the plain-text FINDING format, including the Confidence and Evidence fields
     - Send all findings to the lead via SendMessage
     - Distinguish between blocking issues and suggestions
@@ -207,6 +267,17 @@ Task tool (general-purpose):
   team_name: "code-review"
   prompt: |
     You are a spec compliance reviewer examining code changes.
+
+    ## Delivery Contract (read this first)
+    - Time-box yourself to 15 minutes of review, then REPORT EVEN IF INCOMPLETE: send
+      what you have via SendMessage to `main` and name what you did NOT cover. Partial
+      honest coverage beats a timeout that delivers nothing.
+    - Deliver unprompted. Send the report BEFORE you go idle or end your turn. Your
+      final text is a return value, not a message to the lead, and an idle notification
+      carries no findings — if you stop without a SendMessage, your whole review is lost.
+    - If you could not review, send a report saying so and why. Silence is not a pass.
+    - Say plainly if you find nothing — do not manufacture findings. A "no findings"
+      report delivered on time is a successful review.
 
     ## Your Lens: Spec Compliance
 
@@ -226,6 +297,13 @@ Task tool (general-purpose):
 
     ## Rules
     - Read-only: do NOT modify any files
+    - Own worktree for anything that executes or mutates: if your lens needs to run
+      tests, builds, or mutation testing, first `git worktree add --detach
+      /tmp/review-<your-name> HEAD`, work only there, and remove it when done.
+      Never write to the shared working tree — another agent's test suite may be
+      running against it.
+    - Distinguish what you VERIFIED by running from what you INFERRED by reading, and
+      label each finding accordingly.
     - Report each finding using the plain-text FINDING format, including the Confidence and Evidence fields
     - Send all findings to the lead via SendMessage
     - Flag both missing features AND unplanned additions
@@ -238,6 +316,17 @@ Task tool (general-purpose):
   team_name: "code-review"
   prompt: |
     You are a governance reviewer examining code changes for safety regressions.
+
+    ## Delivery Contract (read this first)
+    - Time-box yourself to 15 minutes of review, then REPORT EVEN IF INCOMPLETE: send
+      what you have via SendMessage to `main` and name what you did NOT cover. Partial
+      honest coverage beats a timeout that delivers nothing.
+    - Deliver unprompted. Send the report BEFORE you go idle or end your turn. Your
+      final text is a return value, not a message to the lead, and an idle notification
+      carries no findings — if you stop without a SendMessage, your whole review is lost.
+    - If you could not review, send a report saying so and why. Silence is not a pass.
+    - Say plainly if you find nothing — do not manufacture findings. A "no findings"
+      report delivered on time is a successful review.
 
     ## Your Lens: Governance & Safety
 
@@ -257,6 +346,13 @@ Task tool (general-purpose):
 
     ## Rules
     - Read-only: do NOT modify any files
+    - Own worktree for anything that executes or mutates: if your lens needs to run
+      tests, builds, or mutation testing, first `git worktree add --detach
+      /tmp/review-<your-name> HEAD`, work only there, and remove it when done.
+      Never write to the shared working tree — another agent's test suite may be
+      running against it.
+    - Distinguish what you VERIFIED by running from what you INFERRED by reading, and
+      label each finding accordingly.
     - Report each finding using the plain-text FINDING format, including the Confidence and Evidence fields
     - Send all findings to the lead via SendMessage
     - A finding is blocking if it removes or weakens an existing safety constraint
@@ -266,6 +362,7 @@ Task tool (general-purpose):
 
 ## Red Flags
 
+- **Silent drop:** a reviewer went idle or errored and the round was reported as complete without its lens. Coverage counts reports delivered, not agents spawned — an undelivered lens is an uncovered lens. Chase it per Protocol §3; if it still does not deliver, name the gap and record `could-not-review` rather than approving around it.
 - **Doubt theater:** across 2 or more review rounds, reviewers surfaced substantive findings and zero were classified actionable. That is doubt theater — you are validating, not reviewing. Stop and surface the dismissal pattern to the user instead of proceeding to SHIP.
 
 ## Verification
@@ -273,6 +370,9 @@ Task tool (general-purpose):
 Before emitting an APPROVE verdict, confirm:
 
 - Every spawned reviewer returned a finding set this session -- no reviewer silently dropped.
+  This is an outcome, and Protocol §3 is the mechanism that reaches it: an idle or errored
+  reviewer was chased and re-dispatched, not counted. A lens that never delivered means
+  `could-not-review`, not APPROVE.
 - Each actionable finding was resolved or explicitly accepted with rationale -- not waved through.
 - The verdict cites evidence / confidence / severity per the finding contract, not a bare "looks good".
 - The doubt-theater pattern is not present (see Red Flags above) — if it is, surface it instead of approving.

--- a/skills/agent-team-review/SKILL.md
+++ b/skills/agent-team-review/SKILL.md
@@ -82,6 +82,12 @@ looking duplicates work that is already done.
 review is not `clean` — record `--verdict could-not-review` (see "Record the Review Verdict")
 and say which lens is missing. Silence and "we could not review" are different states.
 
+**Reap the reviewers' worktrees before TeamDelete.** A reviewer that timed out or was killed
+never ran its own `git worktree remove`, and `git worktree add` registers under the shared
+repo's `.git/worktrees/` — which `git status --porcelain` cannot see, so a leak is invisible
+to the main-tree cleanliness check. Run `git worktree list`, remove any left by this round,
+then `git worktree prune`.
+
 ### 4. Lead Synthesis
 
 After collecting the reports per §3 — including any lens recorded as uncovered:
@@ -165,7 +171,8 @@ Task tool (general-purpose):
 
     ## Delivery Contract (read this first)
     - Time-box yourself to 15 minutes of review, then REPORT EVEN IF INCOMPLETE: send
-      what you have via SendMessage to `main` and name what you did NOT cover. Partial
+      what you have via SendMessage to `main` (or the lead address your brief names)
+      and name what you did NOT cover. Partial
       honest coverage beats a timeout that delivers nothing.
     - Deliver unprompted. Send the report BEFORE you go idle or end your turn. Your
       final text is a return value, not a message to the lead, and an idle notification
@@ -193,12 +200,21 @@ Task tool (general-purpose):
     Files changed: {files}
 
     ## Rules
-    - Read-only: do NOT modify any files
-    - Own worktree for anything that executes or mutates: if your lens needs to run
-      tests, builds, or mutation testing, first `git worktree add --detach
-      /tmp/review-<your-name> HEAD`, work only there, and remove it when done.
+    - Read-only in the shared tree: do NOT modify any files there.
+    - Own worktree for anything that executes or mutates. If your lens needs to run
+      tests, builds, or mutation testing, make a PRIVATE one first:
+      `W="$(mktemp -d)/wt" && git worktree add --detach "$W" <the HEAD sha in your
+      Context>`. Never a fixed path like `/tmp/review-<lens>`: a re-dispatched
+      reviewer carries the same name, so a fixed path fails with `fatal: already
+      exists` on its first command, and two overlapping rounds collide the same way.
+      Work only inside `$W`, then `git worktree remove "$W"`.
       Never write to the shared working tree — another agent's test suite may be
       running against it.
+    - Confirm your worktree matches the subject before trusting anything you RUN in
+      it. A detached worktree does NOT carry the shared tree's uncommitted changes,
+      so if the diff under review is uncommitted your worktree is a DIFFERENT tree.
+      Say so and review by reading rather than labelling a run against the wrong tree
+      as VERIFIED.
     - Distinguish what you VERIFIED by running from what you INFERRED by reading, and
       label each finding accordingly.
     - Report each finding using the plain-text FINDING format, including the Confidence and Evidence fields
@@ -216,7 +232,8 @@ Task tool (general-purpose):
 
     ## Delivery Contract (read this first)
     - Time-box yourself to 15 minutes of review, then REPORT EVEN IF INCOMPLETE: send
-      what you have via SendMessage to `main` and name what you did NOT cover. Partial
+      what you have via SendMessage to `main` (or the lead address your brief names)
+      and name what you did NOT cover. Partial
       honest coverage beats a timeout that delivers nothing.
     - Deliver unprompted. Send the report BEFORE you go idle or end your turn. Your
       final text is a return value, not a message to the lead, and an idle notification
@@ -247,12 +264,21 @@ Task tool (general-purpose):
     Files changed: {files}
 
     ## Rules
-    - Read-only: do NOT modify any files
-    - Own worktree for anything that executes or mutates: if your lens needs to run
-      tests, builds, or mutation testing, first `git worktree add --detach
-      /tmp/review-<your-name> HEAD`, work only there, and remove it when done.
+    - Read-only in the shared tree: do NOT modify any files there.
+    - Own worktree for anything that executes or mutates. If your lens needs to run
+      tests, builds, or mutation testing, make a PRIVATE one first:
+      `W="$(mktemp -d)/wt" && git worktree add --detach "$W" <the HEAD sha in your
+      Context>`. Never a fixed path like `/tmp/review-<lens>`: a re-dispatched
+      reviewer carries the same name, so a fixed path fails with `fatal: already
+      exists` on its first command, and two overlapping rounds collide the same way.
+      Work only inside `$W`, then `git worktree remove "$W"`.
       Never write to the shared working tree — another agent's test suite may be
       running against it.
+    - Confirm your worktree matches the subject before trusting anything you RUN in
+      it. A detached worktree does NOT carry the shared tree's uncommitted changes,
+      so if the diff under review is uncommitted your worktree is a DIFFERENT tree.
+      Say so and review by reading rather than labelling a run against the wrong tree
+      as VERIFIED.
     - Distinguish what you VERIFIED by running from what you INFERRED by reading, and
       label each finding accordingly.
     - Report each finding using the plain-text FINDING format, including the Confidence and Evidence fields
@@ -270,7 +296,8 @@ Task tool (general-purpose):
 
     ## Delivery Contract (read this first)
     - Time-box yourself to 15 minutes of review, then REPORT EVEN IF INCOMPLETE: send
-      what you have via SendMessage to `main` and name what you did NOT cover. Partial
+      what you have via SendMessage to `main` (or the lead address your brief names)
+      and name what you did NOT cover. Partial
       honest coverage beats a timeout that delivers nothing.
     - Deliver unprompted. Send the report BEFORE you go idle or end your turn. Your
       final text is a return value, not a message to the lead, and an idle notification
@@ -296,12 +323,21 @@ Task tool (general-purpose):
     Files changed: {files}
 
     ## Rules
-    - Read-only: do NOT modify any files
-    - Own worktree for anything that executes or mutates: if your lens needs to run
-      tests, builds, or mutation testing, first `git worktree add --detach
-      /tmp/review-<your-name> HEAD`, work only there, and remove it when done.
+    - Read-only in the shared tree: do NOT modify any files there.
+    - Own worktree for anything that executes or mutates. If your lens needs to run
+      tests, builds, or mutation testing, make a PRIVATE one first:
+      `W="$(mktemp -d)/wt" && git worktree add --detach "$W" <the HEAD sha in your
+      Context>`. Never a fixed path like `/tmp/review-<lens>`: a re-dispatched
+      reviewer carries the same name, so a fixed path fails with `fatal: already
+      exists` on its first command, and two overlapping rounds collide the same way.
+      Work only inside `$W`, then `git worktree remove "$W"`.
       Never write to the shared working tree — another agent's test suite may be
       running against it.
+    - Confirm your worktree matches the subject before trusting anything you RUN in
+      it. A detached worktree does NOT carry the shared tree's uncommitted changes,
+      so if the diff under review is uncommitted your worktree is a DIFFERENT tree.
+      Say so and review by reading rather than labelling a run against the wrong tree
+      as VERIFIED.
     - Distinguish what you VERIFIED by running from what you INFERRED by reading, and
       label each finding accordingly.
     - Report each finding using the plain-text FINDING format, including the Confidence and Evidence fields
@@ -319,7 +355,8 @@ Task tool (general-purpose):
 
     ## Delivery Contract (read this first)
     - Time-box yourself to 15 minutes of review, then REPORT EVEN IF INCOMPLETE: send
-      what you have via SendMessage to `main` and name what you did NOT cover. Partial
+      what you have via SendMessage to `main` (or the lead address your brief names)
+      and name what you did NOT cover. Partial
       honest coverage beats a timeout that delivers nothing.
     - Deliver unprompted. Send the report BEFORE you go idle or end your turn. Your
       final text is a return value, not a message to the lead, and an idle notification
@@ -345,12 +382,21 @@ Task tool (general-purpose):
     Files changed: {files}
 
     ## Rules
-    - Read-only: do NOT modify any files
-    - Own worktree for anything that executes or mutates: if your lens needs to run
-      tests, builds, or mutation testing, first `git worktree add --detach
-      /tmp/review-<your-name> HEAD`, work only there, and remove it when done.
+    - Read-only in the shared tree: do NOT modify any files there.
+    - Own worktree for anything that executes or mutates. If your lens needs to run
+      tests, builds, or mutation testing, make a PRIVATE one first:
+      `W="$(mktemp -d)/wt" && git worktree add --detach "$W" <the HEAD sha in your
+      Context>`. Never a fixed path like `/tmp/review-<lens>`: a re-dispatched
+      reviewer carries the same name, so a fixed path fails with `fatal: already
+      exists` on its first command, and two overlapping rounds collide the same way.
+      Work only inside `$W`, then `git worktree remove "$W"`.
       Never write to the shared working tree — another agent's test suite may be
       running against it.
+    - Confirm your worktree matches the subject before trusting anything you RUN in
+      it. A detached worktree does NOT carry the shared tree's uncommitted changes,
+      so if the diff under review is uncommitted your worktree is a DIFFERENT tree.
+      Say so and review by reading rather than labelling a run against the wrong tree
+      as VERIFIED.
     - Distinguish what you VERIFIED by running from what you INFERRED by reading, and
       label each finding accordingly.
     - Report each finding using the plain-text FINDING format, including the Confidence and Evidence fields

--- a/skills/agent-team-review/SKILL.md
+++ b/skills/agent-team-review/SKILL.md
@@ -195,6 +195,7 @@ Task tool (general-purpose):
     - Error messages leaking sensitive information
 
     ## Context
+    Review range: {base_sha}..{head_sha}
     Design doc: {design_doc}
     Diff: {diff}
     Files changed: {files}
@@ -203,8 +204,9 @@ Task tool (general-purpose):
     - Read-only in the shared tree: do NOT modify any files there.
     - Own worktree for anything that executes or mutates. If your lens needs to run
       tests, builds, or mutation testing, make a PRIVATE one first:
-      `W="$(mktemp -d)/wt" && git worktree add --detach "$W" <the HEAD sha in your
-      Context>`. Never a fixed path like `/tmp/review-<lens>`: a re-dispatched
+      `W="$(mktemp -d)/wt" && git worktree add --detach "$W" {head_sha}` — the sha
+      from your Context, never a bare `HEAD`, which in the shared tree may have moved
+      on. Never a fixed path like `/tmp/review-<lens>` either: a re-dispatched
       reviewer carries the same name, so a fixed path fails with `fatal: already
       exists` on its first command, and two overlapping rounds collide the same way.
       Work only inside `$W`, then `git worktree remove "$W"`.
@@ -259,6 +261,7 @@ Task tool (general-purpose):
     - Maintainability
 
     ## Context
+    Review range: {base_sha}..{head_sha}
     Design doc: {design_doc}
     Diff: {diff}
     Files changed: {files}
@@ -267,8 +270,9 @@ Task tool (general-purpose):
     - Read-only in the shared tree: do NOT modify any files there.
     - Own worktree for anything that executes or mutates. If your lens needs to run
       tests, builds, or mutation testing, make a PRIVATE one first:
-      `W="$(mktemp -d)/wt" && git worktree add --detach "$W" <the HEAD sha in your
-      Context>`. Never a fixed path like `/tmp/review-<lens>`: a re-dispatched
+      `W="$(mktemp -d)/wt" && git worktree add --detach "$W" {head_sha}` — the sha
+      from your Context, never a bare `HEAD`, which in the shared tree may have moved
+      on. Never a fixed path like `/tmp/review-<lens>` either: a re-dispatched
       reviewer carries the same name, so a fixed path fails with `fatal: already
       exists` on its first command, and two overlapping rounds collide the same way.
       Work only inside `$W`, then `git worktree remove "$W"`.
@@ -317,6 +321,7 @@ Task tool (general-purpose):
     - Are edge cases from the spec handled?
 
     ## Context
+    Review range: {base_sha}..{head_sha}
     Design doc: {design_doc}
     Plan: {plan}
     Diff: {diff}
@@ -326,8 +331,9 @@ Task tool (general-purpose):
     - Read-only in the shared tree: do NOT modify any files there.
     - Own worktree for anything that executes or mutates. If your lens needs to run
       tests, builds, or mutation testing, make a PRIVATE one first:
-      `W="$(mktemp -d)/wt" && git worktree add --detach "$W" <the HEAD sha in your
-      Context>`. Never a fixed path like `/tmp/review-<lens>`: a re-dispatched
+      `W="$(mktemp -d)/wt" && git worktree add --detach "$W" {head_sha}` — the sha
+      from your Context, never a bare `HEAD`, which in the shared tree may have moved
+      on. Never a fixed path like `/tmp/review-<lens>` either: a re-dispatched
       reviewer carries the same name, so a fixed path fails with `fatal: already
       exists` on its first command, and two overlapping rounds collide the same way.
       Work only inside `$W`, then `git worktree remove "$W"`.
@@ -377,6 +383,7 @@ Task tool (general-purpose):
     - Destructive operations added without confirmation gates
 
     ## Context
+    Review range: {base_sha}..{head_sha}
     Design doc: {design_doc}
     Diff: {diff}
     Files changed: {files}
@@ -385,8 +392,9 @@ Task tool (general-purpose):
     - Read-only in the shared tree: do NOT modify any files there.
     - Own worktree for anything that executes or mutates. If your lens needs to run
       tests, builds, or mutation testing, make a PRIVATE one first:
-      `W="$(mktemp -d)/wt" && git worktree add --detach "$W" <the HEAD sha in your
-      Context>`. Never a fixed path like `/tmp/review-<lens>`: a re-dispatched
+      `W="$(mktemp -d)/wt" && git worktree add --detach "$W" {head_sha}` — the sha
+      from your Context, never a bare `HEAD`, which in the shared tree may have moved
+      on. Never a fixed path like `/tmp/review-<lens>` either: a re-dispatched
       reviewer carries the same name, so a fixed path fails with `fatal: already
       exists` on its first command, and two overlapping rounds collide the same way.
       Work only inside `$W`, then `git worktree remove "$W"`.

--- a/tests/fixtures/agent-team-review/dispatch-brief/pinned-range.txt
+++ b/tests/fixtures/agent-team-review/dispatch-brief/pinned-range.txt
@@ -26,5 +26,7 @@
 # .github/workflows/done-gates.yml. Do not restate that as "runs in CI" without
 # checking done-gates.yml: .verify.yml is `substrate: local` and is read by no
 # workflow, so a test reachable only through run-tests.sh is NOT a CI check.
+# Nor is "runs in CI" the same as "blocks merge" — that needs "Done Gates" marked
+# Required in branch protection, a manual setting outside this repo (docs/CI.md).
 base=5076a7ddfd74c6660dac2a7130704b8903d5acd5^
 head=5076a7ddfd74c6660dac2a7130704b8903d5acd5

--- a/tests/fixtures/agent-team-review/dispatch-brief/pinned-range.txt
+++ b/tests/fixtures/agent-team-review/dispatch-brief/pinned-range.txt
@@ -1,0 +1,21 @@
+# Pinned sha-bound range for the BEHAVIORAL leg of the issue #204 A/B contract.
+# NEVER DELETE — the candidate run is only comparable to the baseline when both
+# review the same subject.
+#
+# Baseline sha (issue #204 "Verified at"): 5076a7ddfd74c6660dac2a7130704b8903d5acd5
+# Review range: dispatch the 4-lens team over BASE..HEAD below.
+#
+# base=5076a7ddfd74c6660dac2a7130704b8903d5acd5^
+# head=5076a7ddfd74c6660dac2a7130704b8903d5acd5
+#
+# Pre-registered metric: unprompted delivery rate = reviewers whose findings
+# reached the lead with NO follow-up request / reviewers dispatched.
+#   baseline (observed, n=4): 0/4 unprompted, 1 timeout, 8 shared-tree mutations
+#   candidate target:         >= 3/4 unprompted AND zero main-tree mutations
+#
+# The behavioral leg needs live multi-agent dispatch: slow, nondeterministic,
+# and explicitly NOT a merge precondition (issue #204, "Note on sequencing").
+# The deterministic leg is required-clauses.txt, asserted by
+# tests/test-reviewer-dispatch-brief.sh and run in CI.
+base=5076a7ddfd74c6660dac2a7130704b8903d5acd5^
+head=5076a7ddfd74c6660dac2a7130704b8903d5acd5

--- a/tests/fixtures/agent-team-review/dispatch-brief/pinned-range.txt
+++ b/tests/fixtures/agent-team-review/dispatch-brief/pinned-range.txt
@@ -5,17 +5,26 @@
 # Baseline sha (issue #204 "Verified at"): 5076a7ddfd74c6660dac2a7130704b8903d5acd5
 # Review range: dispatch the 4-lens team over BASE..HEAD below.
 #
-# base=5076a7ddfd74c6660dac2a7130704b8903d5acd5^
-# head=5076a7ddfd74c6660dac2a7130704b8903d5acd5
-#
 # Pre-registered metric: unprompted delivery rate = reviewers whose findings
 # reached the lead with NO follow-up request / reviewers dispatched.
 #   baseline (observed, n=4): 0/4 unprompted, 1 timeout, 8 shared-tree mutations
-#   candidate target:         >= 3/4 unprompted AND zero main-tree mutations
+#   candidate target:         >= 3/4 unprompted AND zero shared-repo mutations
+#
+# "Zero shared-repo mutations" is measured with BOTH of:
+#     git status --porcelain          (main working tree)
+#     git worktree list               (worktree registrations)
+# `git status --porcelain` alone is BLIND to the capability this change grants:
+# `git worktree add` writes under the shared repo's .git/worktrees/ and never
+# shows up in porcelain output, so a main-tree-only metric would score a leaked
+# reviewer worktree as a clean run.
 #
 # The behavioral leg needs live multi-agent dispatch: slow, nondeterministic,
 # and explicitly NOT a merge precondition (issue #204, "Note on sequencing").
 # The deterministic leg is required-clauses.txt, asserted by
-# tests/test-reviewer-dispatch-brief.sh and run in CI.
+# tests/test-reviewer-dispatch-brief.sh — which runs BOTH in the local
+# .verify.yml suite (via tests/run-tests.sh) AND as a step in
+# .github/workflows/done-gates.yml. Do not restate that as "runs in CI" without
+# checking done-gates.yml: .verify.yml is `substrate: local` and is read by no
+# workflow, so a test reachable only through run-tests.sh is NOT a CI check.
 base=5076a7ddfd74c6660dac2a7130704b8903d5acd5^
 head=5076a7ddfd74c6660dac2a7130704b8903d5acd5

--- a/tests/fixtures/agent-team-review/dispatch-brief/required-clauses.txt
+++ b/tests/fixtures/agent-team-review/dispatch-brief/required-clauses.txt
@@ -5,6 +5,15 @@
 # so a clause stated once in the protocol prose reaches nobody — the assertion
 # is deliberately per-block, not whole-file.
 #
+# THIS FILE IS NOT THE SOLE AUTHORITY. tests/test-reviewer-dispatch-brief.sh
+# independently hardcodes the issue-#204 clause anchors and asserts they are
+# present HERE, so deleting a needle fails the gate instead of silently deleting
+# an assertion. Adding needles is safe; removing one is not.
+#
+# A needle must stay on ONE physical line in SKILL.md. Re-wrapping a prompt
+# bullet across lines breaks the literal match and fails the gate — that is the
+# safe direction (false FAIL, never false PASS), but reflow deliberately.
+#
 # Provenance: issue #204, from memory/background-reviewers-need-explicit-report-request.md
 # (observed 2026-08-12/14: 4 reviewers dispatched, 3 went idle with no findings and
 # reported only when asked, 1 timed out and delivered nothing; separately one
@@ -23,8 +32,12 @@ SendMessage to `main`
 
 # --- Clause 4: own worktree for any reviewer that RUNS or MUTATES ---
 git worktree add --detach
+mktemp -d
+Never write to the shared working tree
+Confirm your worktree matches the subject
 
 # --- Safety / no-regression: the delivery metric must not be gameable ---
-Read-only: do NOT modify any files
+Read-only in the shared tree
+do NOT modify any files
 do not manufacture findings
 VERIFIED by running from what you INFERRED by reading

--- a/tests/fixtures/agent-team-review/dispatch-brief/required-clauses.txt
+++ b/tests/fixtures/agent-team-review/dispatch-brief/required-clauses.txt
@@ -1,0 +1,30 @@
+# Pinned eval set for issue #204 — agent-team-review dispatch brief.
+# NEVER DELETE. Each non-comment, non-blank line is a LITERAL needle (grep -F)
+# that MUST appear inside EVERY reviewer lens prompt block in
+# skills/agent-team-review/SKILL.md. A reviewer only ever sees its own prompt,
+# so a clause stated once in the protocol prose reaches nobody — the assertion
+# is deliberately per-block, not whole-file.
+#
+# Provenance: issue #204, from memory/background-reviewers-need-explicit-report-request.md
+# (observed 2026-08-12/14: 4 reviewers dispatched, 3 went idle with no findings and
+# reported only when asked, 1 timed out and delivered nothing; separately one
+# reviewer mutation-tested in the SHARED tree during a 12-minute suite run).
+
+# --- Clause 1: time-box, and report even if incomplete ---
+Time-box yourself to 15 minutes
+REPORT EVEN IF INCOMPLETE
+
+# --- Clause 2: a timeout / dead end is not a pass (reviewer-side mirror) ---
+Silence is not a pass
+
+# --- Clause 3: unprompted delivery — do not go idle holding the report ---
+Deliver unprompted
+SendMessage to `main`
+
+# --- Clause 4: own worktree for any reviewer that RUNS or MUTATES ---
+git worktree add --detach
+
+# --- Safety / no-regression: the delivery metric must not be gameable ---
+Read-only: do NOT modify any files
+do not manufacture findings
+VERIFIED by running from what you INFERRED by reading

--- a/tests/fixtures/agent-team-review/dispatch-brief/required-clauses.txt
+++ b/tests/fixtures/agent-team-review/dispatch-brief/required-clauses.txt
@@ -31,6 +31,11 @@ Deliver unprompted
 SendMessage to `main`
 
 # --- Clause 4: own worktree for any reviewer that RUNS or MUTATES ---
+# The Context template must SUPPLY the sha the worktree command consumes: an
+# instruction referencing a field the prompt does not carry is unfollowable, and
+# a reviewer improvising `HEAD` reintroduces the wrong-tree defect believing it
+# complied.
+Review range: {base_sha}..{head_sha}
 git worktree add --detach
 mktemp -d
 Never write to the shared working tree

--- a/tests/test-done-gate-ci.sh
+++ b/tests/test-done-gate-ci.sh
@@ -39,6 +39,11 @@ assert_contains "workflow RUNS the routing-fixture coverage gate" \
     "tests/test-fixture-coverage.sh" "${_run_lines}"
 assert_contains "workflow RUNS the skill-content coverage gate" \
     "tests/test-skill-content-coverage.sh" "${_run_lines}"
+# Issue #204: the pinned fixture and the openspec proposal both claim the reviewer
+# dispatch-brief leg runs in CI. Reachable only through tests/run-tests.sh, that
+# claim was false — .verify.yml is `substrate: local` and no workflow reads it.
+assert_contains "workflow RUNS the reviewer dispatch-brief gate" \
+    "tests/test-reviewer-dispatch-brief.sh" "${_run_lines}"
 
 # Must fire on PRs, or it cannot back a merge-time claim. Asserted against the YAML
 # key (line-anchored, with colon), not the prose word — the header comment discusses
@@ -60,5 +65,7 @@ assert_file_exists "fixture-coverage gate script exists" \
     "${PROJECT_ROOT}/tests/test-fixture-coverage.sh"
 assert_file_exists "skill-content coverage gate script exists" \
     "${PROJECT_ROOT}/tests/test-skill-content-coverage.sh"
+assert_file_exists "reviewer dispatch-brief gate script exists" \
+    "${PROJECT_ROOT}/tests/test-reviewer-dispatch-brief.sh"
 
 print_summary

--- a/tests/test-reviewer-dispatch-brief.sh
+++ b/tests/test-reviewer-dispatch-brief.sh
@@ -69,13 +69,20 @@ _fixture_has() {
 # needle must be present verbatim as a whole line, not merely as a substring of
 # some other needle.
 #
-# Keep this list in step with issue #204: clauses 1-4 plus the safety clauses its
-# "Hard no-regression clause" section requires.
+# Keep this list in step with THE FIXTURE, not with issue #204. Tracking the issue
+# is what opened the second leak: the anchors covered #204's own clauses while the
+# fixture grew past them, so the three post-#204 needles (`mktemp -d`, the
+# subject-confirmation rule, the VERIFIED/INFERRED rule) were unanchored — and with
+# the floor set to the ANCHOR count rather than the fixture count, deleting exactly
+# those three landed on the floor and ran 82/82 green. That green run reinstated the
+# fixed-path worktree collision in all four prompts. Every needle is anchored now,
+# and the floor below equals the fixture size, so Control 2 backstops rather than
+# duplicating Control 1.
 _require_needle() {
     if _fixture_has "$1"; then
-        _record_pass "fixture carries #204 anchor [$1]"
+        _record_pass "fixture carries required anchor [$1]"
     else
-        _record_fail "fixture carries #204 anchor [$1]" \
+        _record_fail "fixture carries required anchor [$1]" \
             "needle missing from required-clauses.txt — deleting a needle deletes its per-lens assertion"
     fi
 }
@@ -89,16 +96,24 @@ _require_needle "Never write to the shared working tree"
 _require_needle "Read-only in the shared tree"
 _require_needle "do NOT modify any files"
 _require_needle "do not manufacture findings"
+_require_needle "VERIFIED by running from what you INFERRED by reading"
+_require_needle "mktemp -d"
+_require_needle "Confirm your worktree matches the subject"
+_require_needle "Review range: {base_sha}..{head_sha}"
 
 # --- Control 2: non-vacuity floor ------------------------------------------
 # Secondary to Control 1 (which a shrinking fixture trips first), but it also
 # catches an unreadable or wholly-commented fixture, where the per-lens loop
 # would iterate zero needles and every clause assertion would silently vanish.
-if [ "${CLAUSE_COUNT}" -ge 10 ]; then
+# The floor MUST equal the fixture's needle count, never the anchor count. Any
+# headroom between them is a set of needles that can be deleted without tripping
+# either control — which is exactly how the second leak opened. Raise both together
+# when adding a needle.
+if [ "${CLAUSE_COUNT}" -ge 14 ]; then
     _record_pass "clause fixture non-vacuous (${CLAUSE_COUNT} needles)"
 else
     _record_fail "clause fixture non-vacuous" \
-        "expected >= 10 needles, got ${CLAUSE_COUNT} — assertions below prove nothing"
+        "expected >= 14 needles, got ${CLAUSE_COUNT} — assertions below prove nothing"
 fi
 
 # --- Discover the lens population -------------------------------------------

--- a/tests/test-reviewer-dispatch-brief.sh
+++ b/tests/test-reviewer-dispatch-brief.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# test-reviewer-dispatch-brief.sh — issue #204 deterministic leg.
+#
+# Asserts that skills/agent-team-review/SKILL.md's dispatch brief carries the
+# clauses the observed failures require, and that the lead-side collection
+# protocol exists as a MECHANISM rather than as an asserted outcome.
+#
+# Why per-lens-block and not whole-file: a reviewer subagent sees ONLY its own
+# prompt. A clause present once in the protocol prose reaches no reviewer, and a
+# whole-file needle cannot tell "in all four prompts" from "in one of them".
+# Needles come from tests/fixtures/agent-team-review/dispatch-brief/ (pinned eval
+# set, never delete) rather than being inlined here, so the fixture stays the
+# single authority for the A/B contract.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+. "${SCRIPT_DIR}/test-helpers.sh"
+
+echo "=== test-reviewer-dispatch-brief.sh ==="
+
+SKILL="${PROJECT_ROOT}/skills/agent-team-review/SKILL.md"
+FIXTURE_DIR="${PROJECT_ROOT}/tests/fixtures/agent-team-review/dispatch-brief"
+CLAUSES_FILE="${FIXTURE_DIR}/required-clauses.txt"
+RANGE_FILE="${FIXTURE_DIR}/pinned-range.txt"
+
+assert_file_exists "pinned eval set: required-clauses.txt present" "${CLAUSES_FILE}"
+assert_file_exists "pinned eval set: pinned-range.txt present" "${RANGE_FILE}"
+
+# The behavioral leg is only comparable across runs if the subject is pinned.
+if [ -f "${RANGE_FILE}" ]; then
+    RANGE_CONTENT="$(cat "${RANGE_FILE}")"
+    assert_contains "pinned range: base sha recorded" "base=" "${RANGE_CONTENT}"
+    assert_contains "pinned range: head sha recorded" "head=" "${RANGE_CONTENT}"
+    assert_contains "pinned range: unprompted delivery metric named" \
+        "unprompted delivery rate" "${RANGE_CONTENT}"
+fi
+
+# --- Load the needles -------------------------------------------------------
+# Read into a newline-delimited string, iterated with `while IFS= read -r`.
+# NEVER `for c in $CLAUSES`: under zsh an unquoted scalar does not word-split
+# (CLAUDE.md), and every needle here contains spaces anyway.
+CLAUSES=""
+if [ -f "${CLAUSES_FILE}" ]; then
+    CLAUSES="$(grep -v '^[[:space:]]*#' "${CLAUSES_FILE}" | grep -v '^[[:space:]]*$')"
+fi
+
+CLAUSE_COUNT=0
+if [ -n "${CLAUSES}" ]; then
+    CLAUSE_COUNT="$(printf '%s\n' "${CLAUSES}" | wc -l | tr -d ' ')"
+fi
+
+# Red control: an empty or unreadable fixture would make every per-lens
+# assertion below vacuously pass, which is exactly the shape this test exists to
+# prevent. Floor is the 4 issue-#204 clauses + the 3 safety clauses = 7 lines.
+if [ "${CLAUSE_COUNT}" -ge 7 ]; then
+    _record_pass "clause fixture non-vacuous (${CLAUSE_COUNT} needles)"
+else
+    _record_fail "clause fixture non-vacuous" \
+        "expected >= 7 needles, got ${CLAUSE_COUNT} — assertions below prove nothing"
+fi
+
+# --- Per-lens prompt blocks -------------------------------------------------
+# Range starts at this lens's `name:` line and STOPS at the next `name: "` line
+# or the next top-level `## ` heading (the last lens block would otherwise run to
+# EOF and absorb the Red Flags / Verification prose, so a clause misplaced there
+# would false-pass). Anchored on `^\s*name:` so the sibling `team_name:` line
+# cannot terminate the range early.
+_lens_block() {
+    awk -v lens="$1" '
+        $0 ~ "^[[:space:]]*name: \"" lens "\"" { f=1; next }
+        f && /^[[:space:]]*name: "/ { exit }
+        f && /^## / { exit }
+        f
+    ' "${SKILL}"
+}
+
+# Literal (not regex) containment: needles carry backticks and hyphens.
+_block_has() {
+    printf '%s\n' "$2" | grep -qF -- "$1"
+}
+
+for lens in security-reviewer quality-reviewer spec-reviewer adversarial-reviewer; do
+    BLOCK="$(_lens_block "${lens}")"
+    if [ -z "${BLOCK}" ]; then
+        _record_fail "${lens}: prompt block extracted" \
+            "non-empty block — anchors moved, clause assertions for this lens prove nothing"
+        continue
+    fi
+    _record_pass "${lens}: prompt block extracted"
+
+    while IFS= read -r needle; do
+        [ -n "${needle}" ] || continue
+        if _block_has "${needle}" "${BLOCK}"; then
+            _record_pass "${lens}: carries clause [${needle}]"
+        else
+            _record_fail "${lens}: carries clause [${needle}]" \
+                "needle absent from this lens prompt"
+        fi
+    done <<EOF
+${CLAUSES}
+EOF
+done
+
+# --- Lead-side collection protocol -----------------------------------------
+# The Verification section already asserted the OUTCOME ("every spawned reviewer
+# returned a finding set"). Issue #204's point is that no mechanism produced it.
+SKILL_CONTENT="$(cat "${SKILL}")"
+
+assert_contains "lead: idle is not a report" "Idle is not a report" "${SKILL_CONTENT}"
+assert_contains "lead: a timeout is not a pass" "A timeout is not a pass" "${SKILL_CONTENT}"
+assert_contains "lead: errored reviewer is re-dispatched, not counted" \
+    "never count it toward coverage" "${SKILL_CONTENT}"
+assert_contains "lead: check the tree before re-dispatching" \
+    "git status" "${SKILL_CONTENT}"
+assert_contains "lead: chase twice before writing a reviewer off" \
+    "at least twice" "${SKILL_CONTENT}"
+assert_contains "lead: undelivered reviewer downgrades the verdict" \
+    "could-not-review" "${SKILL_CONTENT}"
+
+# --- Hard no-regression clauses (issue #204 safety section) -----------------
+assert_contains "lead: silent-drop red flag" \
+    "**Silent drop:**" "${SKILL_CONTENT}"
+assert_contains "lead: coverage counts reports, not spawns" \
+    "Coverage counts reports delivered, not agents spawned" "${SKILL_CONTENT}"
+
+assert_contains "no-regression: doubt-theater red flag retained" \
+    "doubt theater" "${SKILL_CONTENT}"
+assert_contains "no-regression: APPROVE verdict contract retained" \
+    "Before emitting an APPROVE verdict" "${SKILL_CONTENT}"
+assert_contains "no-regression: reviewers stay read-only in the shared tree" \
+    "Never write to the shared working tree" "${SKILL_CONTENT}"
+
+print_summary

--- a/tests/test-reviewer-dispatch-brief.sh
+++ b/tests/test-reviewer-dispatch-brief.sh
@@ -8,9 +8,14 @@
 # Why per-lens-block and not whole-file: a reviewer subagent sees ONLY its own
 # prompt. A clause present once in the protocol prose reaches no reviewer, and a
 # whole-file needle cannot tell "in all four prompts" from "in one of them".
-# Needles come from tests/fixtures/agent-team-review/dispatch-brief/ (pinned eval
-# set, never delete) rather than being inlined here, so the fixture stays the
-# single authority for the A/B contract.
+#
+# TWO authorities, deliberately. The fixture
+# tests/fixtures/agent-team-review/dispatch-brief/required-clauses.txt carries the
+# needles; this file independently hardcodes the issue-#204 clause anchors and
+# asserts the fixture still contains them. A single authority was the first cut
+# and it leaked: with only a count floor, deleting two needles from the fixture
+# AND inverting the matching clauses in all four prompts ran fully green (49/49),
+# because a deleted needle silently deletes its own assertion.
 set -u
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
@@ -33,6 +38,11 @@ if [ -f "${RANGE_FILE}" ]; then
     assert_contains "pinned range: head sha recorded" "head=" "${RANGE_CONTENT}"
     assert_contains "pinned range: unprompted delivery metric named" \
         "unprompted delivery rate" "${RANGE_CONTENT}"
+    # The metric must be able to SEE the capability the change grants. `git status
+    # --porcelain` cannot observe a worktree registered under .git/worktrees/, so a
+    # main-tree-only metric is blind to reviewer worktree leaks.
+    assert_contains "pinned range: metric covers worktree registration, not just the main tree" \
+        "git worktree list" "${RANGE_CONTENT}"
 fi
 
 # --- Load the needles -------------------------------------------------------
@@ -49,14 +59,72 @@ if [ -n "${CLAUSES}" ]; then
     CLAUSE_COUNT="$(printf '%s\n' "${CLAUSES}" | wc -l | tr -d ' ')"
 fi
 
-# Red control: an empty or unreadable fixture would make every per-lens
-# assertion below vacuously pass, which is exactly the shape this test exists to
-# prevent. Floor is the 4 issue-#204 clauses + the 3 safety clauses = 7 lines.
-if [ "${CLAUSE_COUNT}" -ge 7 ]; then
+_fixture_has() {
+    printf '%s\n' "${CLAUSES}" | grep -qFx -- "$1"
+}
+
+# --- Control 1: the fixture still carries every issue-#204 clause anchor ----
+# Hardcoded HERE, not read from the fixture: a floor computed from the fixture's
+# own contents cannot notice the fixture shrinking. Matched with `grep -Fx` so a
+# needle must be present verbatim as a whole line, not merely as a substring of
+# some other needle.
+#
+# Keep this list in step with issue #204: clauses 1-4 plus the safety clauses its
+# "Hard no-regression clause" section requires.
+_require_needle() {
+    if _fixture_has "$1"; then
+        _record_pass "fixture carries #204 anchor [$1]"
+    else
+        _record_fail "fixture carries #204 anchor [$1]" \
+            "needle missing from required-clauses.txt — deleting a needle deletes its per-lens assertion"
+    fi
+}
+_require_needle "Time-box yourself to 15 minutes"
+_require_needle "REPORT EVEN IF INCOMPLETE"
+_require_needle "Silence is not a pass"
+_require_needle "Deliver unprompted"
+_require_needle "SendMessage to \`main\`"
+_require_needle "git worktree add --detach"
+_require_needle "Never write to the shared working tree"
+_require_needle "Read-only in the shared tree"
+_require_needle "do NOT modify any files"
+_require_needle "do not manufacture findings"
+
+# --- Control 2: non-vacuity floor ------------------------------------------
+# Secondary to Control 1 (which a shrinking fixture trips first), but it also
+# catches an unreadable or wholly-commented fixture, where the per-lens loop
+# would iterate zero needles and every clause assertion would silently vanish.
+if [ "${CLAUSE_COUNT}" -ge 10 ]; then
     _record_pass "clause fixture non-vacuous (${CLAUSE_COUNT} needles)"
 else
     _record_fail "clause fixture non-vacuous" \
-        "expected >= 7 needles, got ${CLAUSE_COUNT} — assertions below prove nothing"
+        "expected >= 10 needles, got ${CLAUSE_COUNT} — assertions below prove nothing"
+fi
+
+# --- Discover the lens population -------------------------------------------
+# Derived from SKILL.md, NEVER hardcoded: a hardcoded list silently exempts a
+# fifth lens added later, which is the population-enumeration vacuity this repo's
+# fixture/content-coverage gates exist to prevent. Scoped to the spawn-template
+# section so an unrelated `name:` elsewhere cannot enter the population.
+LENSES="$(awk '
+    /^## Reviewer Spawn Templates/ { in_s=1; next }
+    in_s && /^## / { exit }
+    in_s && match($0, /^[[:space:]]*name: "[^"]+"/) {
+        line=$0; sub(/^[[:space:]]*name: "/, "", line); sub(/".*$/, "", line); print line
+    }
+' "${SKILL}")"
+
+LENS_COUNT=0
+if [ -n "${LENSES}" ]; then
+    LENS_COUNT="$(printf '%s\n' "${LENSES}" | wc -l | tr -d ' ')"
+fi
+
+# Floor matches the four lenses the skill's Reviewer Composition table defines.
+if [ "${LENS_COUNT}" -ge 4 ]; then
+    _record_pass "lens population discovered (${LENS_COUNT} lenses)"
+else
+    _record_fail "lens population discovered" \
+        "expected >= 4 lens prompts under '## Reviewer Spawn Templates', found ${LENS_COUNT}"
 fi
 
 # --- Per-lens prompt blocks -------------------------------------------------
@@ -79,7 +147,9 @@ _block_has() {
     printf '%s\n' "$2" | grep -qF -- "$1"
 }
 
-for lens in security-reviewer quality-reviewer spec-reviewer adversarial-reviewer; do
+CONTRACT_REF=""
+while IFS= read -r lens; do
+    [ -n "${lens}" ] || continue
     BLOCK="$(_lens_block "${lens}")"
     if [ -z "${BLOCK}" ]; then
         _record_fail "${lens}: prompt block extracted" \
@@ -99,35 +169,93 @@ for lens in security-reviewer quality-reviewer spec-reviewer adversarial-reviewe
     done <<EOF
 ${CLAUSES}
 EOF
-done
+
+    # --- Control 3: the four Delivery Contract blocks must be IDENTICAL ------
+    # Duplication into every prompt is the deliberate design (a subagent reads
+    # only its own prompt), and its one cost is drift. Without this, a lens whose
+    # contract was reworded still passes as long as it retains every needle.
+    CONTRACT="$(printf '%s\n' "${BLOCK}" | awk '
+        /^[[:space:]]*## Delivery Contract/ { f=1; next }
+        f && /^[[:space:]]*## / { exit }
+        f
+    ')"
+    if [ -z "${CONTRACT}" ]; then
+        _record_fail "${lens}: Delivery Contract block extracted" "empty"
+    elif [ -z "${CONTRACT_REF}" ]; then
+        CONTRACT_REF="${CONTRACT}"
+        _record_pass "${lens}: Delivery Contract block extracted (reference copy)"
+    elif [ "${CONTRACT}" = "${CONTRACT_REF}" ]; then
+        _record_pass "${lens}: Delivery Contract identical to the other lenses"
+    else
+        _record_fail "${lens}: Delivery Contract identical to the other lenses" \
+            "this lens's contract has drifted from the reference copy"
+    fi
+done <<EOF
+${LENSES}
+EOF
 
 # --- Lead-side collection protocol -----------------------------------------
 # The Verification section already asserted the OUTCOME ("every spawned reviewer
 # returned a finding set"). Issue #204's point is that no mechanism produced it.
-SKILL_CONTENT="$(cat "${SKILL}")"
+#
+# SCOPED to Protocol §3, not whole-file: these needles are generic enough that
+# unrelated prose elsewhere in the skill would satisfy them, which would let the
+# mechanism be relocated out of the protocol and still pass.
+LEAD_BLOCK="$(awk '/^### 3\. Parallel Review/{f=1;next} f && /^### /{exit} f' "${SKILL}")"
+if [ -z "${LEAD_BLOCK}" ]; then
+    _record_fail "lead: Protocol §3 block extracted" \
+        "non-empty block — heading moved, lead-side assertions below prove nothing"
+else
+    _record_pass "lead: Protocol §3 block extracted"
+fi
 
-assert_contains "lead: idle is not a report" "Idle is not a report" "${SKILL_CONTENT}"
-assert_contains "lead: a timeout is not a pass" "A timeout is not a pass" "${SKILL_CONTENT}"
+assert_contains "lead: idle is not a report" "Idle is not a report" "${LEAD_BLOCK}"
+assert_contains "lead: a timeout is not a pass" "A timeout is not a pass" "${LEAD_BLOCK}"
 assert_contains "lead: errored reviewer is re-dispatched, not counted" \
-    "never count it toward coverage" "${SKILL_CONTENT}"
+    "never count it toward coverage" "${LEAD_BLOCK}"
+# Both halves: spec requires `git status` AND `git log` before re-dispatch, and
+# the anchor is the full sentence — a bare "git status" needle is satisfied by any
+# unrelated future mention.
 assert_contains "lead: check the tree before re-dispatching" \
-    "git status" "${SKILL_CONTENT}"
+    "Before re-dispatching anything, run \`git status\` and \`git log\`" "${LEAD_BLOCK}"
 assert_contains "lead: chase twice before writing a reviewer off" \
-    "at least twice" "${SKILL_CONTENT}"
-assert_contains "lead: undelivered reviewer downgrades the verdict" \
-    "could-not-review" "${SKILL_CONTENT}"
+    "at least twice" "${LEAD_BLOCK}"
+# Anchored on the NEW sentence. `could-not-review` alone pre-existed this change
+# in "## Record the Review Verdict", so a bare-token needle was satisfied by that
+# fallback and pinned nothing — deleting this entire paragraph ran green.
+assert_contains "lead: undelivered lens downgrades the verdict" \
+    "Coverage is what was delivered, not what was spawned" "${LEAD_BLOCK}"
+assert_contains "lead: undelivered lens routes to could-not-review" \
+    "record \`--verdict could-not-review\`" "${LEAD_BLOCK}"
+# The worktree capability this change grants leaks into the shared repo's
+# .git/worktrees/, which the main-tree cleanliness check cannot see.
+assert_contains "lead: reviewer worktrees are reaped" \
+    "git worktree prune" "${LEAD_BLOCK}"
+
+# --- Verification cites the mechanism --------------------------------------
+# spec.md requires the outcome assertion to reference Protocol §3 rather than
+# stand alone. That is the diff's headline claim, and nothing asserted it —
+# deleting these lines ran fully green.
+VERIF_BLOCK="$(awk '/^## Verification/{f=1;next} f && /^## /{exit} f' "${SKILL}")"
+if [ -z "${VERIF_BLOCK}" ]; then
+    _record_fail "verification block extracted" "non-empty block"
+else
+    _record_pass "verification block extracted"
+fi
+assert_contains "verification: outcome names its mechanism" \
+    "Protocol §3 is the mechanism" "${VERIF_BLOCK}"
+assert_contains "verification: undelivered lens is not APPROVE" \
+    "\`could-not-review\`, not APPROVE" "${VERIF_BLOCK}"
 
 # --- Hard no-regression clauses (issue #204 safety section) -----------------
-assert_contains "lead: silent-drop red flag" \
-    "**Silent drop:**" "${SKILL_CONTENT}"
-assert_contains "lead: coverage counts reports, not spawns" \
-    "Coverage counts reports delivered, not agents spawned" "${SKILL_CONTENT}"
-
+SKILL_CONTENT="$(cat "${SKILL}")"
 assert_contains "no-regression: doubt-theater red flag retained" \
     "doubt theater" "${SKILL_CONTENT}"
 assert_contains "no-regression: APPROVE verdict contract retained" \
     "Before emitting an APPROVE verdict" "${SKILL_CONTENT}"
-assert_contains "no-regression: reviewers stay read-only in the shared tree" \
-    "Never write to the shared working tree" "${SKILL_CONTENT}"
+assert_contains "lead: silent-drop red flag" \
+    "**Silent drop:**" "${SKILL_CONTENT}"
+assert_contains "lead: coverage counts reports, not spawns" \
+    "Coverage counts reports delivered, not agents spawned" "${SKILL_CONTENT}"
 
 print_summary


### PR DESCRIPTION
Fixes #204.

## Problem

From one push-gate review round, recorded in local memory and cited by the issue: **4 reviewers dispatched, 3 went idle holding complete reports** and delivered only when explicitly asked, **1 timed out** and delivered nothing. Unprompted delivery rate **0/4**. Separately, a reviewer doing mutation testing **edited the shared working tree** while a 12-minute suite ran against it, invalidating the run.

At the issue's verified sha every lens prompt said only:

```
- Read-only: do NOT modify any files
- Send all findings to the lead via SendMessage
```

And `Verification` asserted the *outcome* — "Every spawned reviewer returned a finding set this session -- no reviewer silently dropped" — with **no mechanism producing it**. That is why 0/4 delivery could still pass the skill as written.

## Changes

**Reviewer-side — a `## Delivery Contract (read this first)` in all four lens prompts**, ahead of the lens itself: time-box 15 min then `REPORT EVEN IF INCOMPLETE` naming what was not covered; `Deliver unprompted` (an agent's final text is a return value, not a message to the lead); `Silence is not a pass`; say plainly if you find nothing — `do not manufacture findings`.

Plus, per lens: a private-worktree rule (`mktemp -d` + `git worktree add --detach {head_sha}`) for any reviewer that RUNS or MUTATES; confirm the worktree matches the subject; label VERIFIED-by-running vs INFERRED-by-reading; and a `Review range: {base_sha}..{head_sha}` Context field so the worktree command has a sha to consume.

The clauses are duplicated **into each prompt, not stated once in protocol prose** — a reviewer subagent reads only its own prompt, which is the bug.

**Lead-side — Protocol §3 gains a reviewer-state table:** idle is not a report → ask; chase **at least twice**; **a timeout is not a pass** → re-dispatch, never count toward coverage; still nothing → uncovered lens ⇒ `--verdict could-not-review`. Run `git status`/`git log` **before** re-dispatching (stalled subagents here routinely leave finished work uncommitted). Reap reviewer worktrees with `git worktree list` → remove → `prune`. New **silent drop** red flag. `Verification` now cites §3 as its mechanism.

## Tests

Pinned eval set `tests/fixtures/agent-team-review/dispatch-brief/` (never delete) + `tests/test-reviewer-dispatch-brief.sh`, **102 assertions**, every clause asserted **per lens block** — a whole-file needle cannot tell "in all four prompts" from "in one". Registered as a `done-gates.yml` step and pinned by `tests/test-done-gate-ci.sh`.

## Review — three lenses, two rounds, and both rounds found a green mutation against this gate

Reviewers: quality/spec, governance/silent-failure, senior code review. All three worked in private detached worktrees and left the shared tree unmutated.

**They went after the test, not the prose, and each round they broke it.**

Round 1 — four green mutations, all fixed in `eca3fd6`:

| Leak | Green mutation |
|---|---|
| Fixture was the sole authority | delete 2 needles (9→7, the floor) + invert clauses 1–2 in all four prompts ⇒ **49/49 green** |
| Lens list hardcoded | append a 5th lens with none of the clauses ⇒ green |
| Assertion satisfied by a pre-existing fallback | `could-not-review` predated the change, so deleting the entire new §3 paragraph ⇒ green. Same class hit bare `git status` and the `## Verification` mechanism lines — the diff's headline claim, wholly unasserted |
| Whole-file where the spec says per-lens | strip "Never write to the shared working tree" from 3 of 4 lenses ⇒ green |

Round 2 — the confirmation pass found the same class again, fixed in `897d5fc`: the anchor set tracked **issue #204** while the fixture had grown past it, and the floor tracked the *anchor* count, so deleting the three post-#204 needles landed on the floor ⇒ **82/82 green** — a green run that reinstated the fixed-path worktree collision the previous commit had just fixed. Anchors now track the fixture (14 == 14) and the floor equals the needle count, so the two controls are independent. That mutation now fails 4 assertions.

Also from review:

- **`/tmp/review-<lens>` collides by construction** — reproduced as `fatal: already exists`, caused by the re-dispatch rule this PR adds. Now `mktemp -d`. (One reviewer used a fixed path *while reviewing the brief that forbids it*.)
- **The worktree instruction was unfollowable** — it referenced "the HEAD sha in your Context" and the Context block had no sha field; a reviewer improvising `HEAD` reintroduces the wrong-tree defect believing it complied.
- **A detached worktree at HEAD omits uncommitted changes**, so a reviewer runs against a different tree while the new VERIFIED-vs-INFERRED clause raises confidence in the wrong answer.
- **The A/B metric was blind to the capability this PR grants** — `git status --porcelain` cannot see `.git/worktrees/`. Widened to include `git worktree list`, and that widening is itself asserted.
- **"Runs in CI" was false** — `done-gates.yml` ran exactly three tests and `.verify.yml` is `substrate: local`, read by no workflow. Made true rather than retracted. Noted that runs-in-CI is still not hard-blocking without branch protection.
- **Three published numbers were wrong** ("25 needles" was 9 — `grep -c .` counted comments). Corrected from the reviewers' own measurements.

Round 2 verdict: all three CONFIRMED the round-1 fixes closed, with the one new finding above. Recorded review verdict: **`clean`**, 0 unresolved blocking.

## Evidence

- Gate `102/102` under `/bin/bash 3.2.57`; every reviewer mutation fails with a green control either side.
- `.verify.yml` suite at `897d5fc`: `passed:["tests"]`, `failed:[]`, `could_not_verify:[]`, `gate_gaming_status:"clean"`, `test_delta:"covered"`, sha = HEAD, no straddle.
- `gitleaks`: no leaks. `openspec validate reviewer-dispatch-brief`: valid.

## Not in scope

- The behavioral A/B leg (live 4-lens dispatch over the pinned range). Explicitly optional evidence per #204's sequencing note; subject pinned in `pinned-range.txt` so a later run stays comparable.
- The reviewer-ran push-gate evidence leg (#212, parked pending reconciliation with #197).
- The `Task tool (general-purpose)` label in the prompt headers — this harness names the subagent tool `Agent`; that belongs with the `^Task$` → `^(Task|Agent)$` matcher work.

## Footnote

Both review rounds, every reviewer went idle holding a complete report and delivered only after being chased twice — the failure #204 describes, reproducing itself twice during its own fix. The "chase at least twice" floor this PR adds is not theoretical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
