### PR TITLE
fix: stop the cozempic wrapper writing to a hook's stdout channel

### DIFF
--- a/hooks/cozempic-wrapper.sh
+++ b/hooks/cozempic-wrapper.sh
@@ -7,16 +7,26 @@
 # context-economy monorepo-subdir detector and prints any hint on stdout
 # BEFORE exec'ing cozempic. Respects ACSM_QUIET_SUBDIR=1.
 #
-# `checkpoint` is registered on hooks.json's `^(Task|Agent)$` PostToolUse
-# matcher (observed-dispatch-telemetry, R3: widened from a dead `^Task$`-only
-# matcher), so on any machine with cozempic installed this now execs on EVERY
-# subagent dispatch. Measured (this machine, cozempic 1.8.39, three runs):
-# wall time ~0.19-0.21s (`timeout: 5` in hooks.json has ample headroom), but
-# it DOES write to both streams every time — stdout: "  No team state
-# detected." (26 bytes); stderr: "  Cozempic: local hooks redundant (global
-# hooks active) — …" (140 bytes). A PostToolUse hook writing to stdout is a
-# harness-visible side effect; this was flagged as a concern for the
-# controller to weigh, not fixed here.
+# STDOUT IS SUPPRESSED FOR EVERY VERB EXCEPT `doctor`.
+#
+# All four hooks.json registrations of this wrapper are hooks — `guard
+# --daemon` (SessionStart) and three `checkpoint` entries (PostToolUse) — and
+# stdout is the harness's structured channel for a hook, so passing the child's
+# stdout through is a harness-visible side effect on every fire. Measured (this
+# machine, cozempic 1.8.39, three runs): ~0.19-0.21s wall time, writing 26
+# bytes to stdout ("  No team state detected.") and 140 to stderr every time.
+# That was tolerable while the `^Task$` matcher was dead; the
+# observed-dispatch-telemetry change widened it to `^(Task|Agent)$`, so it now
+# fires on EVERY subagent dispatch.
+#
+# STDERR IS DELIBERATELY LEFT ALONE. It is not part of any hook's contract, and
+# it is where a genuine cozempic failure would surface — silencing it would buy
+# quiet by deleting diagnostics. Redirect stdout only.
+#
+# `doctor` is the one user-facing verb (it prints the monorepo-subdir hint
+# above, then cozempic's own report) and KEEPS stdout. Any future verb added to
+# hooks.json inherits the suppression; `tests/test-cozempic-wrapper.sh` pins
+# the verb population so a new one cannot slip in unexercised.
 
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
@@ -33,5 +43,13 @@ if ! command -v cozempic >/dev/null 2>&1; then
     done
 fi
 
-command -v cozempic >/dev/null 2>&1 && exec cozempic "$@"
+if command -v cozempic >/dev/null 2>&1; then
+    # `doctor` is user-facing; every other verb is hook-invoked and must not
+    # write to the harness's stdout channel. stderr passes through in both.
+    if [ "${1:-}" = "doctor" ]; then
+        exec cozempic "$@"
+    else
+        exec cozempic "$@" >/dev/null
+    fi
+fi
 exit 0

--- a/tests/test-cozempic-wrapper.sh
+++ b/tests/test-cozempic-wrapper.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# test-cozempic-wrapper.sh — hooks/cozempic-wrapper.sh must not pollute stdout.
+#
+# Every hooks.json registration of this wrapper is a HOOK: `guard --daemon`
+# (SessionStart) and three `checkpoint` entries (PostToolUse). Stdout is the
+# harness's structured channel for a hook, so a wrapper that passes the child's
+# stdout through is a harness-visible side effect on every fire. Measured on a
+# machine with cozempic installed: `checkpoint` wrote 26 bytes to stdout and
+# 140 to stderr per run, and the `^(Task|Agent)$` matcher fires on every
+# subagent dispatch.
+#
+# STDERR IS DELIBERATELY LEFT ALONE. It is not part of any hook's contract, and
+# it is where a genuine failure would surface — silencing it would buy quiet by
+# deleting diagnostics, which is the failure mode CLAUDE.md warns about
+# repeatedly. Only stdout is suppressed, and only for the non-`doctor` verbs.
+#
+# `doctor` is the one user-facing verb (it prints the monorepo-subdir hint) and
+# MUST keep stdout.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WRAPPER="${PROJECT_ROOT}/hooks/cozempic-wrapper.sh"
+
+# shellcheck source=test-helpers.sh
+. "${SCRIPT_DIR}/test-helpers.sh"
+
+echo "=== test-cozempic-wrapper.sh ==="
+
+_TMP="$(mktemp -d /tmp/cozwrap-XXXXXX)"
+_BIN="${_TMP}/bin"
+mkdir -p "${_BIN}"
+
+# A stand-in cozempic that writes to BOTH streams and echoes its argv, so the
+# assertions below distinguish "stdout suppressed" from "child never ran".
+cat > "${_BIN}/cozempic" <<'FAKE'
+#!/bin/bash
+echo "  No team state detected."
+echo "  Cozempic: local hooks redundant (global hooks active)" >&2
+echo "ARGV:$*" >> "${COZWRAP_ARGV_LOG}"
+exit 0
+FAKE
+chmod +x "${_BIN}/cozempic"
+
+_ARGV_LOG="${_TMP}/argv.log"
+export COZWRAP_ARGV_LOG="${_ARGV_LOG}"
+
+# $1 = label, $@ = wrapper args. Captures the two streams separately.
+_run() {
+    _OUT="$(PATH="${_BIN}:$PATH" bash "${WRAPPER}" "$@" 2>"${_TMP}/err" < /dev/null)"
+    _ERR="$(cat "${_TMP}/err" 2>/dev/null)"
+}
+
+# ---- the hook verbs: stdout silent, child still ran ------------------------
+: > "${_ARGV_LOG}"
+_run checkpoint
+assert_equals "checkpoint writes nothing to stdout" "" "${_OUT}"
+if grep -q "ARGV:checkpoint" "${_ARGV_LOG}" 2>/dev/null; then
+    _record_pass "checkpoint still execs cozempic (stdout suppressed, not skipped)"
+else
+    _record_fail "checkpoint still execs cozempic (stdout suppressed, not skipped)" \
+        "cozempic was never invoked"
+fi
+
+# The distinction that makes the assertion above meaningful: a wrapper that
+# simply never ran the child would also produce empty stdout.
+case "${_ERR}" in
+    *"local hooks redundant"*)
+        _record_pass "checkpoint preserves stderr (diagnostics are not silenced)" ;;
+    *)  _record_fail "checkpoint preserves stderr (diagnostics are not silenced)" \
+            "stderr was: ${_ERR}" ;;
+esac
+
+: > "${_ARGV_LOG}"
+_run guard --daemon
+assert_equals "guard --daemon writes nothing to stdout" "" "${_OUT}"
+if grep -q "ARGV:guard --daemon" "${_ARGV_LOG}" 2>/dev/null; then
+    _record_pass "guard --daemon passes its flags through"
+else
+    _record_fail "guard --daemon passes its flags through" \
+        "argv log: $(cat "${_ARGV_LOG}" 2>/dev/null)"
+fi
+
+# ---- doctor is user-facing and KEEPS stdout --------------------------------
+: > "${_ARGV_LOG}"
+_run doctor
+case "${_OUT}" in
+    *"No team state detected"*)
+        _record_pass "doctor keeps stdout (it is the user-facing verb)" ;;
+    *)  _record_fail "doctor keeps stdout (it is the user-facing verb)" \
+            "stdout was: ${_OUT}" ;;
+esac
+
+# ---- cozempic absent: still silent, still exit 0 ---------------------------
+# The curated PATH keeps /usr/bin:/bin (the wrapper shells out to `dirname`,
+# and `bash` itself must resolve) and drops only the fake bin. HOME is moved so
+# the wrapper's own ~/.local/bin and ~/Library/Python discovery finds nothing.
+_EMPTY="${_TMP}/empty"; mkdir -p "${_EMPTY}"
+_NOCOZ_PATH="${_EMPTY}:/usr/bin:/bin"
+
+# Assert the harness ACTUALLY removed cozempic before asserting degradation --
+# otherwise a harness that silently still resolves it makes this cell vacuous.
+if PATH="${_NOCOZ_PATH}" HOME="${_TMP}" command -v cozempic >/dev/null 2>&1; then
+    _record_fail "no-cozempic harness actually removes cozempic" "still resolvable"
+else
+    _record_pass "no-cozempic harness actually removes cozempic"
+fi
+
+_out2="$(PATH="${_NOCOZ_PATH}" HOME="${_TMP}" bash "${WRAPPER}" checkpoint 2>/dev/null < /dev/null; echo "rc=$?")"
+assert_equals "absent cozempic degrades silently with exit 0" "rc=0" "${_out2}"
+
+# ---- every hooks.json registration is covered by the rule above ------------
+# Pins the population: if a future entry introduces a verb this test does not
+# exercise, this assertion fails rather than the gap going unnoticed.
+if command -v jq >/dev/null 2>&1; then
+    _verbs="$(jq -r '.hooks | to_entries[] | .value[]? | .hooks[]? | .command
+                     | select(test("cozempic-wrapper\\.sh"))
+                     | sub("^.*cozempic-wrapper\\.sh +"; "")' \
+              "${PROJECT_ROOT}/hooks/hooks.json" 2>/dev/null | sort -u | tr '\n' ',')"
+    assert_equals "hooks.json invokes only the verbs this test covers" \
+        "checkpoint,guard --daemon," "${_verbs}"
+else
+    _record_pass "hooks.json verb population (skipped: no jq)"
+fi
+
+rm -rf "${_TMP}"
+print_summary
+exit $?


### PR DESCRIPTION
## Why

`hooks/cozempic-wrapper.sh` `exec`s the real `cozempic` binary and passes its stdout straight through. All four of its `hooks.json` registrations are hooks — `guard --daemon` on `SessionStart`, and three `checkpoint` entries on `PostToolUse` — and **stdout is the harness's structured channel for a hook**, so every fire is a harness-visible side effect.

Measured on a machine with cozempic installed (1.8.39, three runs): **~0.19–0.21s wall time, 26 bytes to stdout** (`"  No team state detected."`) **and 140 to stderr**, per fire.

This was tolerable while one of those matchers was a dead `^Task$`-only entry. #220 widened it to `^(Task|Agent)$` — correctly, since the subagent tool is named `Agent` on current Claude Code — so it now fires on **every subagent dispatch**, which in this repo's agent-team and subagent-driven workflows is many per session.

Surfaced by #220's whole-branch review as M5, deliberately left out of that PR as an unrelated pre-existing defect.

## What changes

Stdout is suppressed for every verb except `doctor`:

```bash
if [ "${1:-}" = "doctor" ]; then
    exec cozempic "$@"
else
    exec cozempic "$@" >/dev/null
fi
```

`doctor` is the one user-facing verb — it prints the monorepo-subdir hint and then cozempic's own report — and keeps stdout. Every other verb is hook-invoked and inherits the suppression, including any future one.

## stderr is deliberately left alone

It is not part of any hook's contract, and it is where a genuine cozempic failure would surface. Silencing it would buy quiet by deleting diagnostics — the failure mode `CLAUDE.md` documents repeatedly (the `_json_escape` and degradation-advisory bullets are both instances of exactly this). Only stdout is redirected.

## Tests

`tests/test-cozempic-wrapper.sh` (new, 9 assertions). Two properties are worth calling out because they are what makes the suite non-vacuous:

- **It distinguishes "stdout suppressed" from "the child never ran."** An empty-stdout assertion passes equally in both cases, so the fake `cozempic` appends its argv to a log and the test asserts the child was actually invoked with the right flags.
- **It pins the `hooks.json` verb population.** A `jq` filter walks every event → matcher group → hook object and asserts the full deduped verb set is exactly `checkpoint,guard --daemon,`. A fifth registration with a new verb breaks the assertion rather than slipping in unexercised.

Plus: stderr survives suppression, `doctor` keeps stdout, and absent-cozempic still exits 0 — with a control asserting the harness *actually* removed `cozempic` from `PATH` first, so the degradation cell cannot pass vacuously.

Verified RED before the fix: exactly 2 failures, both stdout assertions.

## Verification

- `bash tests/run-tests.sh` — **Files run: 124, Files passed: 124, Files failed: 0**
- `bash scripts/verify-and-record.sh` — `failed[]` empty, `could_not_verify[]` empty, `gate_gaming_status: clean`, `test_delta: covered`, `sha` == HEAD
- Reviewed by a dispatched reviewer subagent: Approved, 0 Critical, 0 Important. Its one Minor — a dead `_RC` that captured the wrong command's exit status and would mislead anyone who later asserted on it — is fixed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
