### PR TITLE
test: restore the declared gate to green — two stale assertions on main

### DIFF
--- a/.claude/knowledge/hook-ab-needs-real-checkout.md
+++ b/.claude/knowledge/hook-ab-needs-real-checkout.md
@@ -3,7 +3,7 @@ type: gotcha
 title: A/B-testing a hook needs a real checkout on both sides
 description: Running a hook from a scratch copy repoints CLAUDE_PLUGIN_ROOT, so its libs fall open and the comparison differs for reasons unrelated to the diff.
 tags: [hooks, testing, fail-open, push-gate]
-source: hooks/openspec-guard.sh:336
+source: hooks/openspec-guard.sh:381
 timestamp: 2026-08-28T00:00:00Z
 ---
 

--- a/tests/fixtures/scenarios/intent-30-fires-underspecified.json
+++ b/tests/fixtures/scenarios/intent-30-fires-underspecified.json
@@ -1,7 +1,9 @@
 {
   "name": "intent-30-fires-underspecified",
+  "_comment": "Needles pin the four load-bearing parts of the DESIGN intent-extraction directive: the header, the probe for the real goal behind the literal ask, the out-of-scope framing of the convergence block, and the instruction to PERSIST the confirmed intent. PR #221 rewrote the directive (shorter probe; persistence single-sourced into scripts/persist-state.sh), leaving two needles naming text that no longer exists — a paired update that PR missed. It made this the only red scenario file, and since .verify.yml declares the whole suite as the gate, no clean verification verdict could be produced repo-wide.",
+  "_comment_needle_choice": "EACH needle is mutation-verified to fail when its part is deleted from hooks/skill-activation-hook.sh. Two traps found by doing that rather than assuming it: (1) the bare needle 'out-of-scope' was VACUOUS for the convergence block — deleting the '**Out-of-scope:**' line left this fixture green, because the phrase also occurs in the persistence command's argument and in unrelated DESIGN guidance; it is now the marked-up form, which occurs once. (2) These are still PROSE needles, not semantic ones — 'the underlying need' is a slice of the current wording and WILL need updating if the directive is reworded again. That is accepted: the alternative is a needle so generic it pins nothing, which is exactly trap (1).",
   "prompt": "I want to add notifications to the app",
   "expected_phase": "DESIGN",
   "expected_skills": ["brainstorming"],
-  "must_match": ["INTENT EXTRACTION:", "what would you actually want", "out-of-scope", "openspec_state_set_intent"]
+  "must_match": ["INTENT EXTRACTION:", "the underlying need", "**Out-of-scope:**", "set-intent"]
 }


### PR DESCRIPTION
Follow-up to #221. Two one-line assertion updates that restore the repo's declared gate to green.

## Why this is worth landing first

`.verify.yml` declares the whole suite as the gate, and `main` was red on two files. While that is true, `verify-and-record.sh` writes `failed:["tests"]`, so **no clean verification verdict can be produced at all** — which means routing-governance denies every push touching `skills/|config/|hooks/`, from every session. The blast radius is repo-wide; both fixes are one line each.

Neither red was a real defect. Both were assertions that had drifted away from deliberate changes.

## 1. `tests/fixtures/scenarios/intent-30-fires-underspecified.json`

#221 rewrote the DESIGN intent-extraction injection — a shorter probe, and the persistence incantation single-sourced into `scripts/persist-state.sh`, which was that PR's stated purpose. Two needles still named the old prose:

```
must contain 'what would you actually want'
must contain 'openspec_state_set_intent'
```

Replaced, and a third tightened:

| old | new |
|---|---|
| `what would you actually want` | `the underlying need` |
| `openspec_state_set_intent` | `set-intent` |
| `out-of-scope` | `**Out-of-scope:**` |

**That third change is the one that matters, and it was not in the first cut.** Review asked whether the needles really pin the four load-bearing parts they claim to. The bare `out-of-scope` did not: deleting the convergence block's `**Out-of-scope:**` line left the fixture **green**, because the phrase also appears in the persistence command's argument and in unrelated DESIGN guidance. Measured, not reasoned about.

All four needles are now mutation-verified independently — deleting the header, the probe, the out-of-scope line, or the persistence instruction each fails the fixture, against a 72/72 unmutated baseline.

These remain *prose* needles and the fixture now says so rather than claiming otherwise. `the underlying need` is a slice of the current wording and will need updating on the next reword; the alternative is a needle generic enough to pin nothing, which is exactly the trap above.

## 2. `.claude/knowledge/hook-ab-needs-real-checkout.md`

Its `source:` cited `hooks/openspec-guard.sh:336`; the cited code has been at 381 for some time, so the exact-line drift check failed. Retargeted.

That check is bespoke logic in `tests/test-knowledge.sh`, **not** `scripts/knowledge-validate.sh` — the validator only checks the path resolves, and would accept a line-number-free `source:`. So the brittleness is enforced by the test rather than the validator, which is arguably worth its own issue.

## Verification

Full suite **126/126** on this branch, up from 124/126 on `main`. Clean verdict recorded at `0371924` (`passed:["tests"]`, `gate_gaming_status:"clean"`).

## Note for merge order

The `#219` branch moves that same cited code to line 390 and updates the same line, so merging it after this produces a one-line conflict — take **390**, which is correct for the merged tree.
