### PR TITLE
fix: put the RFC 2119 modal on line 1 of three pdlc-safety requirements

### DIFF
--- a/openspec/changes/partial-push-subjects/specs/pdlc-safety/spec.md
+++ b/openspec/changes/partial-push-subjects/specs/pdlc-safety/spec.md
@@ -4,10 +4,10 @@
 
 ### Requirement: A push that ships no content is not measured at the checkout's HEAD
 
-When every `git push` segment in a gated command deletes a ref, the command
-ships no content, and the push gate's **content-dependent** checks MUST be
-skipped rather than evaluated against the subject directory's `HEAD`, which the
-command does not push. The content-dependent checks are routing-governance,
+When every `git push` segment in a gated command deletes a ref, the gate MUST
+treat the command as shipping no content, and its **content-dependent** checks
+MUST be skipped rather than evaluated against the subject directory's `HEAD`,
+which the command does not push. The content-dependent checks are routing-governance,
 verify-verdict hardening, the evaluator-surface advisory, and the
 IMPLEMENT-evidence leg.
 
@@ -140,10 +140,10 @@ state that the review and verification gates still applied.
 
 ### Requirement: A multi-ref push is reported as possibly under-measuring
 
-When a gated push carries more than one ref — `--all`, `--mirror`, `--tags`, or
-two or more refspecs — the gate MUST continue to measure the subject
-directory's `HEAD`, and MUST state that `HEAD` is at best one of the refs being
-pushed so the checks may under-measure what the command ships.
+The gate MUST continue to measure the subject directory's `HEAD` when a gated
+push carries more than one ref — `--all`, `--mirror`, `--tags`, or two or more
+refspecs — and MUST state that `HEAD` is at best one of the refs being pushed,
+so the checks may under-measure what the command ships.
 
 That statement MUST be distinct from the statement made for a deletion. A single
 shared message for both shapes is what allowed the deletion false block to go
@@ -160,9 +160,9 @@ unnoticed, and the two shapes are now resolved differently.
 
 ### Requirement: Group punctuation is not counted as a refspec
 
-A command word made up entirely of group closers (`)`, `}`) is punctuation, not
-a refspec, and the push-command parsers MUST NOT count it as a positional
-argument.
+The push-command parsers MUST NOT count a command word made up entirely of
+group closers (`)`, `}`) as a positional argument: such a word is punctuation,
+not a refspec.
 
 #### Scenario: a parenthesised push resolves its ref
 


### PR DESCRIPTION
## Why

`OpenSpec Validate` has been **failing on `main`** since #233 merged, on all three ADDED requirements in `openspec/changes/partial-push-subjects/specs/pdlc-safety/spec.md`:

```
✗ [ERROR] pdlc-safety/spec.md: ADDED "A push that ships no content is not measured at the checkout's HEAD" must contain SHALL or MUST
✗ [ERROR] pdlc-safety/spec.md: ADDED "A multi-ref push is reported as possibly under-measuring" must contain SHALL or MUST
✗ [ERROR] pdlc-safety/spec.md: ADDED "Group punctuation is not counted as a refspec" must contain SHALL or MUST
```

Surfaced as an inherited red on #234, which touches no `openspec/` files.

## Root cause

All three bodies **already contained `MUST`**. The pinned CLI parses a requirement's text as **only the first line** of its body, and hard wrapping had pushed the modal onto line 2:

```json
"text": "When every `git push` segment in a gated command deletes a ref, the command"
```

The modal was on the next line — `ships no content, and ... checks MUST be`. Requirements that pass have it on line 1, e.g. `verify-and-record`'s *"The verification verdict SHALL be written by ..."*.

## Fix

Reflow the three first paragraphs so the modal lands on line 1. No requirement changes meaning. **Headings are untouched** — adding `MUST` to the headings was tried first and does *not* fix it, which is what proved the check reads the body, not the heading.

## Why it was invisible locally

CI pins `@fission-ai/openspec@1.3.0` (`.github/workflows/openspec-validate.yml:46`); a current local install is **1.7.0**, which no longer enforces this. So the spec validates locally and fails in CI.

Worth noting: the version gap was hiding a **real conformance defect**, not just a technicality. The repo's own DESIGN→PLAN contract requires RFC 2119 keywords, and these three requirements did not satisfy the rule as the pinned CLI reads it. Any spec authored against 1.7.0 today can pass locally and fail CI the same way.

## Verification — against the pinned CLI, not the local one

Installed `@fission-ai/openspec@1.3.0` locally to reproduce, so the red control is real rather than assumed:

| run | result |
|---|---|
| 1.3.0, before fix | **FAIL** — 3 errors (red control reproduced) |
| 1.3.0, after fix | `All active changes passed validation` |
| 1.7.0, after fix | `All active changes passed validation` |

`openspec change show partial-push-subjects --json --deltas-only` under 1.3.0 now shows a modal in `requirement.text` for all three.

Also checked that nothing pins this wording: the `ships no content` matches in `tests/test-push-gate-subject.sh` assert on the **guard's runtime output**, not on the spec file, so they are unaffected. `tests/test-openspec-*.sh` all pass.

## Reviewer disclosure

Not reviewed by a subagent. Three reviewers were dispatched on the companion PR (#234) across three agent types and all returned nothing, so I did not spend a fourth attempt here.

The push gate's REVIEW/VERIFY legs show green from **session-level** state carried over from #234's work — there is no review SHA recorded on this branch (`gate-status.sh`: *"no review SHA recorded on this branch"*). Treat this as self-reviewed.

It is a 22-line reflow of one markdown file with a reproduced red→green control, so the review surface is small — but it is still unreviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqB8xtb2RfGXrFgiuB3JQ7
