### PR TITLE
fix: secure the zero-match diagnostic log (0600), including across rotation

### DIFF
--- a/hooks/skill-activation-hook.sh
+++ b/hooks/skill-activation-hook.sh
@@ -982,19 +982,37 @@ _format_output() {
 
     # Log the zero-match prompt for diagnostics (rotate at 100 entries, cap at 50KB)
     _ZM_LOG="${HOME}/.claude/.skill-zero-match-log"
+    # Secure BEFORE the first content write: this log holds RAW PROMPT TEXT,
+    # the most sensitive of the local diagnostic corpora, and a pre-existing
+    # 0644 file would leak every record appended to it. Same shape as
+    # scripts/push-gate-capture.sh -- umask covers a fresh file, the explicit
+    # chmod fixes an already-loose one. The prompt is deliberately NOT hashed:
+    # seeing which prompts matched no trigger IS the diagnostic value.
+    ( umask 077; : >> "$_ZM_LOG" ) 2>/dev/null || true
+    chmod 0600 "$_ZM_LOG" 2>/dev/null || true
     # Truncate prompt to 200 chars to prevent unbounded log growth
     printf '%.200s\n' "$P" >> "$_ZM_LOG" 2>/dev/null || true
     if [[ -f "$_ZM_LOG" ]]; then
       # Rotate by line count
       _lc="$(wc -l < "$_ZM_LOG" 2>/dev/null | tr -d ' ')"
       if [[ "$_lc" =~ ^[0-9]+$ ]] && [[ "$_lc" -gt 100 ]]; then
-        tail -n 100 "$_ZM_LOG" > "${_ZM_LOG}.tmp" 2>/dev/null && mv "${_ZM_LOG}.tmp" "$_ZM_LOG" 2>/dev/null || true
+        ( umask 077; tail -n 100 "$_ZM_LOG" > "${_ZM_LOG}.tmp" ) 2>/dev/null && mv "${_ZM_LOG}.tmp" "$_ZM_LOG" 2>/dev/null || true
       fi
       # Rotate by byte size (50KB cap)
       _zm_size="$(wc -c < "$_ZM_LOG" 2>/dev/null | tr -d ' ')"
       if [[ "$_zm_size" =~ ^[0-9]+$ ]] && [[ "$_zm_size" -gt 51200 ]]; then
-        tail -n 50 "$_ZM_LOG" > "${_ZM_LOG}.tmp" 2>/dev/null && mv "${_ZM_LOG}.tmp" "$_ZM_LOG" 2>/dev/null || true
+        ( umask 077; tail -n 50 "$_ZM_LOG" > "${_ZM_LOG}.tmp" ) 2>/dev/null && mv "${_ZM_LOG}.tmp" "$_ZM_LOG" 2>/dev/null || true
       fi
+      # The .tmp holds the SAME raw prompt text as the log, so it is created
+      # under `umask 077` too -- otherwise it sits world-readable in the window
+      # between `tail >` and `mv`, which would defeat the point of securing the
+      # log at all. push-gate-capture.sh has this same gap; matching an
+      # existing gap is not a reason to keep one.
+      # Both rotations write a FRESH .tmp under the ambient umask and mv it
+      # over the log, so the mv carries the .tmp's mode across and undoes the
+      # write-path chmod above. Re-secure after rotating, or the log reverts
+      # to 0644 the first time it fills up.
+      chmod 0600 "$_ZM_LOG" 2>/dev/null || true
     fi
 
     # Zero-match: emit nothing (no additionalContext)

--- a/tests/test-zero-match-log-perms.sh
+++ b/tests/test-zero-match-log-perms.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# test-zero-match-log-perms.sh — the zero-match diagnostic log holds RAW PROMPT
+# TEXT (truncated to 200 chars), so it must be 0600 like every other local
+# diagnostic corpus. `.push-gate-invocation-log` stores only a command SHA and
+# is already secured (scripts/push-gate-capture.sh); this file stores the more
+# sensitive content and was world-readable (0644) until this test existed.
+#
+# The prompt text is deliberately NOT hashed: it IS the diagnostic value — the
+# log exists so an author can see which prompts matched no trigger and write a
+# trigger for them. Hashing would leave an unusable log. Securing the file is
+# the fix; redacting it is not.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+. "${SCRIPT_DIR}/test-helpers.sh"
+
+HOOK="${PROJECT_ROOT}/hooks/skill-activation-hook.sh"
+_TMP="$(mktemp -d)"
+trap 'rm -rf "${_TMP}"' EXIT
+
+_mode() { stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1" 2>/dev/null; }
+
+# MUTATION NOTE (measured, do not assume otherwise): deleting the WRITE-PATH
+# `umask 077` + chmod leaves every cell below GREEN, because the post-rotation
+# chmod runs on every invocation and tightens the file before this test can
+# observe it. Cells (1) and (2) are therefore satisfied by EITHER mechanism and
+# pin neither on its own; only cell (4) pins the rotation chmod (mutation-
+# verified: removing it fails cell 4 alone).
+#
+# The write-path securing is still correct and must not be deleted as "dead".
+# In the FIXED code the chmod PRECEDES the append, so no prompt text is ever
+# written to a 0644 file. Remove that chmod and the append lands on a
+# pre-existing 0644 log first, leaking that record, with only the later
+# post-rotation chmod tightening it afterwards. It is a pre-write ORDERING
+# property, not a final state.
+# That window is what scripts/push-gate-capture.sh's "secure BEFORE the first
+# content write" comment exists to close. It is not observable from outside the
+# hook, so no assertion here covers it — that is a known gap, not an oversight.
+
+# A prompt that matches no trigger, so the zero-match writer runs.
+_ZM_PROMPT='xyzzy plugh frobnicate qwertyuiop'
+
+# --- (1) fresh log is created 0600 -----------------------------------------
+export HOME="${_TMP}/h1"; mkdir -p "${HOME}/.claude"
+cp "${PROJECT_ROOT}/config/fallback-registry.json" "${HOME}/.claude/.skill-registry-cache.json" 2>/dev/null
+printf '%s' "$(jq -nc --arg p "${_ZM_PROMPT}" '{"prompt":$p}')" \
+  | CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${HOOK}" >/dev/null 2>&1
+_LOG="${HOME}/.claude/.skill-zero-match-log"
+assert_file_exists "zero-match log is written for an unmatched prompt" "${_LOG}"
+assert_equals "fresh zero-match log is mode 0600" "600" "$(_mode "${_LOG}")"
+
+# --- (2) a PRE-EXISTING 0644 log is tightened before the next append --------
+# This is the leak that matters: an already-loose file keeps leaking every new
+# prompt appended to it. umask alone does not fix an existing file.
+export HOME="${_TMP}/h2"; mkdir -p "${HOME}/.claude"
+cp "${PROJECT_ROOT}/config/fallback-registry.json" "${HOME}/.claude/.skill-registry-cache.json" 2>/dev/null
+_LOG2="${HOME}/.claude/.skill-zero-match-log"
+printf 'pre-existing loose line\n' > "${_LOG2}"
+chmod 0644 "${_LOG2}"
+assert_equals "control: log starts 0644" "644" "$(_mode "${_LOG2}")"
+printf '%s' "$(jq -nc --arg p "${_ZM_PROMPT}" '{"prompt":$p}')" \
+  | CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${HOOK}" >/dev/null 2>&1
+assert_equals "pre-existing 0644 log is tightened to 0600" "600" "$(_mode "${_LOG2}")"
+
+# --- (3) the prompt text is still recorded (the fix must not redact) --------
+assert_contains "prompt text is still logged (diagnostic value preserved)" \
+  "frobnicate" "$(cat "${_LOG2}" 2>/dev/null)"
+
+# --- (4) ROTATION must not reset the mode -----------------------------------
+# Rotation is `tail > $LOG.tmp; mv $LOG.tmp $LOG`. The .tmp file is created
+# fresh under the AMBIENT umask, and mv carries its mode onto the log — so a
+# log secured at write time silently reverts to 0644 on the next rotation.
+# Securing only the write path is an incomplete fix.
+export HOME="${_TMP}/h3"; mkdir -p "${HOME}/.claude"
+cp "${PROJECT_ROOT}/config/fallback-registry.json" "${HOME}/.claude/.skill-registry-cache.json" 2>/dev/null
+_LOG3="${HOME}/.claude/.skill-zero-match-log"
+# 150 lines forces the >100 line-count rotation on the next append
+_i=0; : > "${_LOG3}"
+while [ "${_i}" -lt 150 ]; do printf 'filler line %s\n' "${_i}" >> "${_LOG3}"; _i=$((_i+1)); done
+chmod 0600 "${_LOG3}"
+assert_equals "control: log starts 0600 with 150 lines" "600" "$(_mode "${_LOG3}")"
+printf '%s' "$(jq -nc --arg p "${_ZM_PROMPT}" '{"prompt":$p}')" \
+  | CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${HOOK}" >/dev/null 2>&1
+_lines3="$(wc -l < "${_LOG3}" 2>/dev/null | tr -d ' ')"
+assert_equals "control: rotation actually ran (trimmed to 100)" "100" "${_lines3}"
+assert_equals "log is still 0600 AFTER rotation" "600" "$(_mode "${_LOG3}")"
+
+# --- (5) STRUCTURAL: the rotation .tmp is created under umask 077 -----------
+# The .tmp holds the same raw prompt text as the log and exists only between
+# `tail >` and `mv`, so its mode cannot be sampled at rest from here. This is a
+# source-shape assertion, weaker than the behavioural cells above, and labelled
+# as such: it pins that the umask wrapper was not dropped, nothing more. BOTH
+# rotation branches must be wrapped -- checking one would pass while the other
+# leaked.
+_wrapped="$(grep -c 'umask 077; tail -n .* > "${_ZM_LOG}.tmp"' "${HOOK}" 2>/dev/null)"
+assert_equals "both rotation .tmp writes are umask-077 wrapped (structural)" "2" "${_wrapped}"
+
+print_summary
+exit $?


### PR DESCRIPTION
## Why

`~/.claude/.skill-zero-match-log` holds **raw prompt text** (truncated to 200 chars) and was created `0644` — world-readable. Measured on a live machine:

```
-rw-------  .push-gate-invocation-log   <- stores only a command SHA
-rw-r--r--  .skill-zero-match-log       <- stores raw prompts
```

The log with the *more* sensitive content was the unsecured one. `scripts/push-gate-capture.sh` already does `umask 077` + touch + `chmod 0600` before its first content write, with a comment explaining why; this applies the same shape.

**The prompt text is deliberately NOT hashed.** Seeing which prompts matched no trigger *is* the diagnostic value of this log — it exists so an author can write a trigger for them. Hashing would leave an unusable file. Securing it is the fix; redacting it is not. (Hashing was my first instinct and it was wrong.)

## The non-obvious half: rotation undoes it

Both rotations do `tail -n N "$LOG" > "$LOG.tmp" && mv "$LOG.tmp" "$LOG"`. The `.tmp` is created fresh under the **ambient** umask, and `mv` carries its mode onto the log — so a log secured at write time silently reverts to `0644` the first time it fills up. Securing only the write path is an incomplete fix.

## Test

`tests/test-zero-match-log-perms.sh` — 8 assertions:

1. fresh log is `0600`
2. a pre-existing `0644` log is tightened
3. prompt text is still recorded (the fix must not redact)
4. log is still `0600` **after rotation**

Every cell is paired with a control that must hold independently — *log starts 0644*, *log starts 0600 with 150 lines*, *rotation actually trimmed to 100* — so no cell can pass vacuously.

## Mutation result, including one that is recorded rather than papered over

| mutation | outcome |
|---|---|
| delete the **rotation** chmod | fails cell 4 alone ✓ |
| delete the **write-path** chmod | **fails nothing** |

The second is the interesting one. The post-rotation `chmod` runs on *every* invocation, so it tightens the file before the test can observe it — meaning cells 1–2 pin **neither** mechanism on its own.

The write-path securing is still correct and must not be deleted as dead code: the append happens *before* that chmod, so a pre-existing `0644` file leaks its first appended record. That is exactly the window `push-gate-capture.sh`'s *"secure BEFORE the first content write"* comment exists to close. It is not observable from outside the hook, so **no assertion here covers it** — a known gap, documented in the test file rather than left for someone to rediscover.

## Verification

- Declared gate (`.verify.yml` → `bash tests/run-tests.sh`) ran via `scripts/verify-and-record.sh`: **`gate tests: PASS (exit 0)`**. The runner exits non-zero if any file fails, so exit 0 covers the whole suite.
- Verdict: `{"passed":["tests"],"failed":[],"could_not_verify":[],"gate_gaming_status":"clean","test_delta":"covered","sha":"74c9fd9..."}` — clean, `sha` = HEAD, no straddle.
- New test: 8 passed, 0 failed.
- `/bin/bash -n hooks/skill-activation-hook.sh` clean (bash 3.2).
- Push gate replay: all six legs pass, including `routing governance: pass (clean verdict at HEAD)`.

## Scope note — a broader finding I deliberately did NOT fix here

Probing the class rather than the reported case: most `~/.claude` state files are `0644`. Nearly all hold only skill names, but one family holds user-authored prose:

```
644  .skill-confirmed-intent-session-*  | "Fix plugin Serena MCP registration to use serena's..."
```

That is comparable in sensitivity to prompts. Fixing it means touching several writers across multiple hooks — materially larger than this change — so it is flagged, not bundled. Worth a follow-up issue.

## Reviewer disclosure

Not reviewed by a subagent. Four dispatches across three agent types earlier in this session all returned nothing; the CI `review` action was separately failing with `529 Overloaded`, which is likely the shared cause.

The push gate flagged, correctly, that **no review verdict covers this HEAD** — the REVIEW leg is green from session state, not from a review of this diff. Treat as self-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqB8xtb2RfGXrFgiuB3JQ7
