### PR TITLE
Credit REVIEW on an observed subagent completion, not on a spawn

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -193,6 +193,17 @@
         ]
       }
     ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/reviewer-completion-hook.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "TeammateIdle": [
       {
         "hooks": [

--- a/hooks/lib/branch-ledger.sh
+++ b/hooks/lib/branch-ledger.sh
@@ -30,13 +30,30 @@ branch_ledger_dir() {
     printf '%s' "${HOME}/.claude/.skill-branch-ledger-${k}"
 }
 
+# branch_ledger_record <milestone> [<proj_root>] [<sha>]
+#
+# <sha> is OPTIONAL and records the commit the milestone is ABOUT, which is not
+# always HEAD at call time. Omitting it resolves HEAD exactly as before, so every
+# existing caller is byte-identical — the same shape #219 used when it gave
+# verdict.sh's helpers an optional trailing <commit>.
+#
+# It exists because an event can be observed long after the tree it describes:
+# a backgrounded reviewer finishes while the session keeps committing, and
+# stamping HEAD at completion names a tree the reviewer never read. Ledger
+# records are consumed with HEAD-or-ancestor acceptance, so an over-late sha
+# silently covers commits nothing reviewed — the over-claim #181 removed from
+# verdicts. A caller that knows the real subject should pass it.
 branch_ledger_record() {
-    local milestone="${1:-}" proj_root="${2:-}" dir sha
+    local milestone="${1:-}" proj_root="${2:-}" sha_in="${3:-}" dir sha
     [ -z "$milestone" ] && return 0
     dir="$(branch_ledger_dir "$proj_root")" || return 0
     [ -z "$dir" ] && return 0
     [ -z "$proj_root" ] && proj_root="$(git rev-parse --show-toplevel 2>/dev/null)"
-    sha="$(git -C "${proj_root:-.}" rev-parse HEAD 2>/dev/null || true)"
+    case "$sha_in" in
+        "") sha="$(git -C "${proj_root:-.}" rev-parse HEAD 2>/dev/null || true)" ;;
+        *[!0-9a-fA-F]*) sha="$(git -C "${proj_root:-.}" rev-parse HEAD 2>/dev/null || true)" ;;
+        *) sha="$sha_in" ;;
+    esac
     mkdir -p "$dir" 2>/dev/null || return 0
     # per-milestone file (no shared-JSON read-modify-write → no concurrent race);
     # atomic write; content = "<sha> <utc-ts>"

--- a/hooks/lib/branch-ledger.sh
+++ b/hooks/lib/branch-ledger.sh
@@ -49,9 +49,24 @@ branch_ledger_record() {
     dir="$(branch_ledger_dir "$proj_root")" || return 0
     [ -z "$dir" ] && return 0
     [ -z "$proj_root" ] && proj_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+    # "no subject supplied" and "a BAD subject supplied" are different states and
+    # must not collapse. Empty means the caller has no opinion, so HEAD is right
+    # and every existing caller keeps its exact prior behaviour. A non-hex value
+    # means the caller HAD an opinion and it is corrupt — resolving HEAD there
+    # would silently reinstate the over-late stamp this argument exists to
+    # remove, in precisely the branch that fires when something is already wrong.
+    # `unknown` is the lib's existing sentinel and is REJECTED by
+    # branch_ledger_sha_is_branch_local, so a corrupt subject fails toward
+    # under-crediting instead.
+    #
+    # Neither arm is reachable from any current caller (the only non-empty
+    # producer is `git rev-parse HEAD`, and note_dispatch blanks anything else
+    # before storing it), so no test can catch their removal — mutation-verified,
+    # 0 failures either way. Stated here rather than presented as covered, which
+    # is this change's standing rule for a knowingly-unobservable guard.
     case "$sha_in" in
         "") sha="$(git -C "${proj_root:-.}" rev-parse HEAD 2>/dev/null || true)" ;;
-        *[!0-9a-fA-F]*) sha="$(git -C "${proj_root:-.}" rev-parse HEAD 2>/dev/null || true)" ;;
+        *[!0-9a-fA-F]*) sha="unknown" ;;
         *) sha="$sha_in" ;;
     esac
     mkdir -p "$dir" 2>/dev/null || return 0

--- a/hooks/lib/reviewer-pairing.sh
+++ b/hooks/lib/reviewer-pairing.sh
@@ -168,6 +168,12 @@ reviewer_pairing_note_dispatch() {
     [ -n "$aid" ] && [ -n "$key" ] || return 1
     case "$aid" in *[!A-Za-z0-9._-]*) return 1 ;; esac
     case "$key" in *[!A-Za-z0-9._-]*) return 1 ;; esac
+    # Unreachable from the only producer (`git rev-parse HEAD`), so no test can
+    # catch its removal — mutation-verified, 0 failures. Kept because it is the
+    # FIRST of the two guards and the one that decides what reaches the ledger;
+    # blanking here means the reader falls back to HEAD, which is the older
+    # stamp, whereas a corrupt value reaching branch_ledger_record becomes the
+    # `unknown` sentinel instead. Recorded rather than presented as covered.
     case "$sha" in *[!0-9a-fA-F]*) sha="" ;; esac
     f="$(_reviewer_pairing_file dispatch "$sid")" || return 1
     _reviewer_pairing_append "$f" "${aid} ${key} ${sha}" "$sid" dispatch

--- a/hooks/lib/reviewer-pairing.sh
+++ b/hooks/lib/reviewer-pairing.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# reviewer-pairing.sh — the session-scoped join between a reviewer subagent's
+# DISPATCH and its COMPLETION.
+#
+# Two hooks observe two halves of one fact and neither can credit alone:
+#
+#   reviewer-evidence-hook.sh   PostToolUse ^(Task|Agent)$   classifies (owns the
+#                                                            measured predicate)
+#   reviewer-completion-hook.sh SubagentStop                 observes completion
+#
+# NEITHER IS GUARANTEED TO RUN FIRST. Measured end-to-end against the real hooks
+# on Claude Code CLI 2.1.236:
+#
+#   background dispatch : DISPATCH fires 1.44s BEFORE completion
+#   foreground dispatch : COMPLETION fires ~30ms BEFORE dispatch (3 of 3)
+#
+# So the join is SYMMETRIC: each hook writes its own half first, then looks for
+# the other, and whichever runs second records the milestone. A one-directional
+# "dispatch writes, completion reads" design is a systematic no-op for foreground
+# dispatches — that was the first cut, and it recorded `reviewer-ran` with no
+# `reviewer-returned` for a foreground reviewer.
+#
+# The file format and the key derivation live HERE and only here, so the writer
+# and the reader cannot drift — the recurring failure class behind
+# #51/#97/#122/#131/#133/#151/#156.
+#
+# Sourced by HOOKS only (both are `#!/bin/bash`), never from a model Bash turn,
+# so the zsh-compatibility constraints that bind `session-token.sh` and
+# `phase-attest.sh` do not apply here. If that ever changes, re-read CLAUDE.md's
+# "the Bash tool is NOT bash" gotcha before touching this file.
+#
+# Every function is fail-open and best-effort: on any error the pairing simply
+# does not resolve, the milestone is not recorded, and the caller continues.
+# Under-recording is the accepted direction; a false credit is not.
+#
+# Bash 3.2 compatible.
+
+# _reviewer_pairing_file <kind> <session_id> — path of a session-scoped pairing
+# file, or nothing (return 1).
+#
+# The session id becomes a filename component, so it is validated as a single
+# path-safe segment rather than trusted: the payload is harness-supplied, but a
+# recorder must not be the component that turns a surprising value into a read
+# or a write outside ~/.claude.
+#
+# Naming mirrors _SESSION_TOKEN ("session-<id>") because `session_id` IS the
+# transcript basename, so session-start's GC excludes the live session with a
+# plain `! -name ".skill-reviewer-<kind>-${_SESSION_TOKEN}"` match. Both names
+# must stay in that GC block's glob list.
+_reviewer_pairing_file() {
+    local kind="${1:-}" sid="${2:-}"
+    [ -n "$kind" ] && [ -n "$sid" ] || return 1
+    case "$kind" in dispatch|complete) ;; *) return 1 ;; esac
+    case "$sid" in
+        *[!A-Za-z0-9._-]*|.|..) return 1 ;;
+    esac
+    printf '%s' "${HOME}/.claude/.skill-reviewer-${kind}-session-${sid}"
+}
+
+# _reviewer_pairing_append <file> <line> — bounded, race-tolerant append.
+#
+# A size CEILING, not a trim: parallel dispatches in one turn run their hooks
+# concurrently, so a read-modify-write rotation would be a genuine race, while a
+# short `printf >>` is a single write and interleaves safely at line
+# granularity. Dropping new records past the ceiling is strictly safer than
+# corrupting existing ones. ~40 bytes per line, so this bounds a pathological
+# session, not a real one.
+#
+# On the `wc -c` line the `|| bytes=0` is what makes this safe, NOT the `[ -f ]`:
+# `wc -c < missing` is a REDIRECTION failure that `2>/dev/null` does not
+# suppress, and an UNHANDLED one under a caller's `trap 'exit 0' ERR` silently
+# terminates the whole hook — that exact shape already cost this change one
+# regression, killing the pre-existing `reviewer-ran` record (CLAUDE.md
+# #137/#198). The `[ -f ]` only avoids a pointless fork on the common
+# first-write path; deleting it breaks nothing, so do not read it as the guard.
+_reviewer_pairing_append() {
+    local f="${1:-}" line="${2:-}" bytes=0
+    [ -n "$f" ] && [ -n "$line" ] || return 1
+    if [ -f "$f" ]; then
+        bytes="$(wc -c < "$f" 2>/dev/null | tr -d ' ')" || bytes=0
+        case "$bytes" in ''|*[!0-9]*) bytes=0 ;; esac
+    fi
+    [ "$bytes" -lt 65536 ] || return 1
+    printf '%s\n' "$line" >> "$f" 2>/dev/null || return 1
+    return 0
+}
+
+# reviewer_pairing_note_dispatch <session_id> <agent_id> <ledger_key>
+# Records "this agent was dispatched as a reviewer, on this branch".
+#
+# The ledger key is stored so the completion side can refuse to credit a branch
+# the reviewer never saw: branch_ledger_record derives its key from the cwd at
+# CALL time, and a backgrounded reviewer completes while the parent session is
+# free to check out something else.
+reviewer_pairing_note_dispatch() {
+    local sid="${1:-}" aid="${2:-}" key="${3:-}" f
+    [ -n "$aid" ] && [ -n "$key" ] || return 1
+    case "$aid" in *[!A-Za-z0-9._-]*) return 1 ;; esac
+    case "$key" in *[!A-Za-z0-9._-]*) return 1 ;; esac
+    f="$(_reviewer_pairing_file dispatch "$sid")" || return 1
+    _reviewer_pairing_append "$f" "${aid} ${key}"
+}
+
+# reviewer_pairing_note_complete <session_id> <agent_id>
+# Records "this agent finished and emitted output". NOT a credit on its own —
+# the dispatch side still has to have classified it as a reviewer.
+reviewer_pairing_note_complete() {
+    local sid="${1:-}" aid="${2:-}" f
+    [ -n "$aid" ] || return 1
+    case "$aid" in *[!A-Za-z0-9._-]*) return 1 ;; esac
+    f="$(_reviewer_pairing_file complete "$sid")" || return 1
+    _reviewer_pairing_append "$f" "${aid}"
+}
+
+# reviewer_pairing_dispatch_key <session_id> <agent_id> — prints the ledger key
+# recorded at dispatch for <agent_id>, or nothing (return 1) when this agent was
+# not dispatched as a reviewer.
+#
+# `awk '$1==a'` is an exact FIELD comparison, so no stored value can be read as
+# a pattern or match as a prefix, and the `#`-prefixed diagnostic lines written
+# by note_mismatch can never match an agent id. Absent or unreadable file is a
+# miss, not an error: a recorder degrades to "no record", never to a fabricated
+# one.
+reviewer_pairing_dispatch_key() {
+    local sid="${1:-}" aid="${2:-}" f out
+    [ -n "$aid" ] || return 1
+    f="$(_reviewer_pairing_file dispatch "$sid")" || return 1
+    [ -f "$f" ] || return 1
+    out="$(awk -v a="$aid" '$1==a {print $2; exit}' "$f" 2>/dev/null)" || return 1
+    [ -n "$out" ] || return 1
+    printf '%s' "$out"
+}
+
+# reviewer_pairing_has_complete <session_id> <agent_id> — 0 iff this agent has
+# already been observed completing with output.
+reviewer_pairing_has_complete() {
+    local sid="${1:-}" aid="${2:-}" f
+    [ -n "$aid" ] || return 1
+    f="$(_reviewer_pairing_file complete "$sid")" || return 1
+    [ -f "$f" ] || return 1
+    awk -v a="$aid" '$1==a {found=1; exit} END {exit !found}' "$f" 2>/dev/null
+}
+
+# reviewer_pairing_note_mismatch <session_id> <agent_id> <dispatch_key> <now_key>
+# A reviewer completed on a branch other than the one it was dispatched on, so
+# nothing was credited. Recorded as a `#` comment line in the completion file —
+# no new state family, no new GC entry, and `$1==a` lookups can never match it.
+#
+# This exists because a miss otherwise leaves NO trace anywhere, which is how
+# the foreground ordering defect nearly shipped as a silent no-op: "no reviewer
+# ran" and "a reviewer ran and the join failed" must not look identical.
+reviewer_pairing_note_mismatch() {
+    local sid="${1:-}" aid="${2:-}" dkey="${3:-}" nkey="${4:-}" f
+    f="$(_reviewer_pairing_file complete "$sid")" || return 1
+    _reviewer_pairing_append "$f" "# branch-mismatch ${aid} dispatched=${dkey} completed=${nkey}"
+}

--- a/hooks/lib/reviewer-pairing.sh
+++ b/hooks/lib/reviewer-pairing.sh
@@ -148,20 +148,29 @@ reviewer_pairing_saturated() {
     [ -f "$f" ]
 }
 
-# reviewer_pairing_note_dispatch <session_id> <agent_id> <ledger_key>
-# Records "this agent was dispatched as a reviewer, on this branch".
+# reviewer_pairing_note_dispatch <session_id> <agent_id> <ledger_key> [<sha>]
+# Records "this agent was dispatched as a reviewer, on this branch, against this
+# commit".
+#
+# The SHA is the tree the reviewer was pointed at. It is carried so the
+# completion side can stamp the milestone with the commit that was REVIEWED
+# rather than whatever HEAD happens to be when the reviewer finishes — a
+# backgrounded reviewer completes while the session keeps committing, and ledger
+# records are read with HEAD-or-ancestor acceptance, so a late sha silently
+# covers commits nothing reviewed.
 #
 # The ledger key is stored so the completion side can refuse to credit a branch
 # the reviewer never saw: branch_ledger_record derives its key from the cwd at
 # CALL time, and a backgrounded reviewer completes while the parent session is
 # free to check out something else.
 reviewer_pairing_note_dispatch() {
-    local sid="${1:-}" aid="${2:-}" key="${3:-}" f
+    local sid="${1:-}" aid="${2:-}" key="${3:-}" sha="${4:-}" f
     [ -n "$aid" ] && [ -n "$key" ] || return 1
     case "$aid" in *[!A-Za-z0-9._-]*) return 1 ;; esac
     case "$key" in *[!A-Za-z0-9._-]*) return 1 ;; esac
+    case "$sha" in *[!0-9a-fA-F]*) sha="" ;; esac
     f="$(_reviewer_pairing_file dispatch "$sid")" || return 1
-    _reviewer_pairing_append "$f" "${aid} ${key}" "$sid" dispatch
+    _reviewer_pairing_append "$f" "${aid} ${key} ${sha}" "$sid" dispatch
 }
 
 # reviewer_pairing_note_complete <session_id> <agent_id> <ledger_key>
@@ -214,6 +223,24 @@ reviewer_pairing_dispatch_key() {
     f="$(_reviewer_pairing_file dispatch "$sid")" || return 1
     [ -f "$f" ] || return 1
     out="$(awk -v a="$aid" '$1==a {print $2; exit}' "$f" 2>/dev/null)" || return 1
+    [ -n "$out" ] || return 1
+    printf '%s' "$out"
+}
+
+# reviewer_pairing_dispatch_sha <session_id> <agent_id> — prints the commit the
+# reviewer was dispatched against, or nothing.
+#
+# Empty is a legitimate answer, not an error: a record written before this field
+# existed has only two fields, and the caller then falls back to HEAD, i.e. the
+# behaviour from before. Degrading to the old, less precise stamp is correct for
+# a format change; fabricating a sha would not be.
+reviewer_pairing_dispatch_sha() {
+    local sid="${1:-}" aid="${2:-}" f out
+    [ -n "$aid" ] || return 1
+    case "$aid" in *[!A-Za-z0-9._-]*) return 1 ;; esac
+    f="$(_reviewer_pairing_file dispatch "$sid")" || return 1
+    [ -f "$f" ] || return 1
+    out="$(awk -v a="$aid" '$1==a {print $3; exit}' "$f" 2>/dev/null)" || return 1
     [ -n "$out" ] || return 1
     printf '%s' "$out"
 }

--- a/hooks/lib/reviewer-pairing.sh
+++ b/hooks/lib/reviewer-pairing.sh
@@ -56,14 +56,32 @@
 _reviewer_pairing_file() {
     local kind="${1:-}" sid="${2:-}"
     [ -n "$kind" ] && [ -n "$sid" ] || return 1
-    case "$kind" in dispatch|complete) ;; *) return 1 ;; esac
+    case "$kind" in dispatch|complete|saturated) ;; *) return 1 ;; esac
     case "$sid" in
         *[!A-Za-z0-9._-]*|.|..) return 1 ;;
     esac
     printf '%s' "${HOME}/.claude/.skill-reviewer-${kind}-session-${sid}"
 }
 
-# _reviewer_pairing_append <file> <line> — bounded, race-tolerant append.
+# _REVIEWER_PAIRING_MAX_BYTES — the per-file ceiling, overridable so tests can
+# exercise a REAL refusal cheaply instead of writing a megabyte of padding.
+# Precedent: IMPLEMENT_SHADOW_LOG overrides the shadow-corpus path the same way.
+# A test that hardcodes its padding silently stops testing anything the moment
+# this constant moves, which is the "mutation applied is not fault produced"
+# shape — so the cells derive their padding from this value.
+_REVIEWER_PAIRING_MAX_BYTES="${REVIEWER_PAIRING_MAX_BYTES:-1048576}"
+case "${_REVIEWER_PAIRING_MAX_BYTES}" in
+    ''|*[!0-9]*) _REVIEWER_PAIRING_MAX_BYTES=1048576 ;;
+esac
+
+# _reviewer_pairing_append <file> <line> <session_id> <kind> — bounded,
+# race-tolerant append. Returns 0 on write, 2 on CEILING refusal, 1 otherwise.
+#
+# The 2-vs-1 split is required, not cosmetic: the ceiling and a failed write are
+# different faults and only one of them can be recorded. An unwritable
+# ~/.claude cannot write a saturation marker either, so that cause is
+# STRUCTURALLY unable to announce; a marker that covered both would rebuild
+# exactly the collapse it exists to prevent.
 #
 # EXHAUSTING THE CEILING SILENCES THIS WHOLE FAMILY for the rest of the session,
 # including reviewer_pairing_note_mismatch — so the diagnostic that exists to keep
@@ -90,15 +108,44 @@ _reviewer_pairing_file() {
 # #137/#198). The `[ -f ]` only avoids a pointless fork on the common
 # first-write path; deleting it breaks nothing, so do not read it as the guard.
 _reviewer_pairing_append() {
-    local f="${1:-}" line="${2:-}" bytes=0
+    local f="${1:-}" line="${2:-}" sid="${3:-}" kind="${4:-}" bytes=0 marker
     [ -n "$f" ] && [ -n "$line" ] || return 1
     if [ -f "$f" ]; then
         bytes="$(wc -c < "$f" 2>/dev/null | tr -d ' ')" || bytes=0
         case "$bytes" in ''|*[!0-9]*) bytes=0 ;; esac
     fi
-    [ "$bytes" -lt 1048576 ] || return 1
+    if [ "$bytes" -ge "${_REVIEWER_PAIRING_MAX_BYTES}" ]; then
+        # SATURATION MARKER. The point is not to announce — a recorder must stay
+        # silent — but to make the state DISTINGUISHABLE on disk, so a reader can
+        # tell "the reviewer did not return" from "the recorder stopped
+        # recording". Those are `missing` and `cannot_check`, and CLAUDE.md is
+        # emphatic (IMPLEMENT shadow leg) that collapsing the second into the
+        # first biases every downstream reading in the unsafe direction.
+        #
+        # One whole-file overwrite of a fixed-size payload — the same shape as
+        # branch_ledger_record's per-milestone file, chosen there for the same
+        # reason: no read-modify-write, so concurrent hooks cannot race, and
+        # every writer writes the same fact. Bounded by construction, so the
+        # marker can never itself saturate and need a marker of its own.
+        marker="$(_reviewer_pairing_file saturated "$sid")" || marker=""
+        if [ -n "$marker" ]; then
+            printf '%s %s\n' "${kind:-unknown}" "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)" \
+                > "$marker" 2>/dev/null || true
+        fi
+        return 2
+    fi
     printf '%s\n' "$line" >> "$f" 2>/dev/null || return 1
     return 0
+}
+
+# reviewer_pairing_saturated <session_id> — 0 iff this session's pairing store
+# stopped accepting writes. A reader that finds no `reviewer-returned` MUST
+# consult this before concluding no reviewer returned: the honest answer in that
+# case is "could not check", not "did not happen".
+reviewer_pairing_saturated() {
+    local f
+    f="$(_reviewer_pairing_file saturated "${1:-}")" || return 1
+    [ -f "$f" ]
 }
 
 # reviewer_pairing_note_dispatch <session_id> <agent_id> <ledger_key>
@@ -114,7 +161,7 @@ reviewer_pairing_note_dispatch() {
     case "$aid" in *[!A-Za-z0-9._-]*) return 1 ;; esac
     case "$key" in *[!A-Za-z0-9._-]*) return 1 ;; esac
     f="$(_reviewer_pairing_file dispatch "$sid")" || return 1
-    _reviewer_pairing_append "$f" "${aid} ${key}"
+    _reviewer_pairing_append "$f" "${aid} ${key}" "$sid" dispatch
 }
 
 # reviewer_pairing_note_complete <session_id> <agent_id> <ledger_key>
@@ -134,7 +181,7 @@ reviewer_pairing_note_complete() {
     case "$aid" in *[!A-Za-z0-9._-]*) return 1 ;; esac
     case "$key" in *[!A-Za-z0-9._-]*) return 1 ;; esac
     f="$(_reviewer_pairing_file complete "$sid")" || return 1
-    _reviewer_pairing_append "$f" "${aid} ${key}"
+    _reviewer_pairing_append "$f" "${aid} ${key}" "$sid" complete
 }
 
 # reviewer_pairing_dispatch_key <session_id> <agent_id> — prints the ledger key
@@ -152,9 +199,10 @@ reviewer_pairing_note_complete() {
 # of a mismatch line is the word `branch-mismatch`. A lookup that matched such a
 # line would hand the caller "branch-mismatch" AS A LEDGER KEY. The charset
 # validation above closes it from the other end — a caller can never ask for `#`
-# — but do not remove either guard on the grounds that the other exists. Absent or unreadable file is a
-# miss, not an error: a recorder degrades to "no record", never to a fabricated
-# one.
+# — but do not remove either guard on the grounds that the other exists.
+#
+# An absent or unreadable file is a MISS, not an error: a recorder degrades to
+# "no record", never to a fabricated one.
 reviewer_pairing_dispatch_key() {
     local sid="${1:-}" aid="${2:-}" f out
     [ -n "$aid" ] || return 1
@@ -204,6 +252,12 @@ reviewer_pairing_complete_key() {
 # ran" and "a reviewer ran and the join failed" must not look identical.
 reviewer_pairing_note_mismatch() {
     local sid="${1:-}" aid="${2:-}" dkey="${3:-}" nkey="${4:-}" f
+    # The only writer here that interpolates the id into a line without checking
+    # it. Unreachable today — the completion hook only reaches the mismatch path
+    # after dispatch_key has already rejected a bad id — but a newline-bearing id
+    # would write a FORGED, readable dispatch record, and "unreachable" is a
+    # property of one caller, not of this function.
+    case "$aid" in *[!A-Za-z0-9._-]*) return 1 ;; esac
     f="$(_reviewer_pairing_file dispatch "$sid")" || return 1
-    _reviewer_pairing_append "$f" "# branch-mismatch ${aid} dispatched=${dkey} completed=${nkey}"
+    _reviewer_pairing_append "$f" "# branch-mismatch ${aid} dispatched=${dkey} completed=${nkey}" "$sid" dispatch
 }

--- a/hooks/lib/reviewer-pairing.sh
+++ b/hooks/lib/reviewer-pairing.sh
@@ -20,6 +20,12 @@
 # dispatches — that was the first cut, and it recorded `reviewer-ran` with no
 # `reviewer-returned` for a foreground reviewer.
 #
+# FORMAT CHANGE SAFETY: both halves store "<agent_id> <ledger_key>". A record
+# written in the earlier one-field format has an empty second field, so the key
+# readers return nothing and the join degrades to a MISS — never to a false
+# credit, since an empty key can never compare equal to a real one. That is the
+# correct direction for a format change inside a live-session state family.
+#
 # The file format and the key derivation live HERE and only here, so the writer
 # and the reader cannot drift — the recurring failure class behind
 # #51/#97/#122/#131/#133/#151/#156.
@@ -59,6 +65,16 @@ _reviewer_pairing_file() {
 
 # _reviewer_pairing_append <file> <line> — bounded, race-tolerant append.
 #
+# EXHAUSTING THE CEILING SILENCES THIS WHOLE FAMILY for the rest of the session,
+# including reviewer_pairing_note_mismatch — so the diagnostic that exists to keep
+# a refused credit visible is itself suppressed by the same condition, and the
+# failure is ORDER-ASYMMETRIC (the background order keeps working off the other
+# file). The completion file records EVERY subagent completion, not only
+# reviewers, so it is fan-out-driven in exactly the agent-team sessions this
+# evidence is for. Hence 1 MiB rather than a tighter bound: ~26k completions, not
+# ~1.6k. Raising it is the proportionate fix — pruning would need a
+# read-modify-write, which is the race this design avoids.
+#
 # A size CEILING, not a trim: parallel dispatches in one turn run their hooks
 # concurrently, so a read-modify-write rotation would be a genuine race, while a
 # short `printf >>` is a single write and interleaves safely at line
@@ -80,7 +96,7 @@ _reviewer_pairing_append() {
         bytes="$(wc -c < "$f" 2>/dev/null | tr -d ' ')" || bytes=0
         case "$bytes" in ''|*[!0-9]*) bytes=0 ;; esac
     fi
-    [ "$bytes" -lt 65536 ] || return 1
+    [ "$bytes" -lt 1048576 ] || return 1
     printf '%s\n' "$line" >> "$f" 2>/dev/null || return 1
     return 0
 }
@@ -101,15 +117,24 @@ reviewer_pairing_note_dispatch() {
     _reviewer_pairing_append "$f" "${aid} ${key}"
 }
 
-# reviewer_pairing_note_complete <session_id> <agent_id>
-# Records "this agent finished and emitted output". NOT a credit on its own —
-# the dispatch side still has to have classified it as a reviewer.
+# reviewer_pairing_note_complete <session_id> <agent_id> <ledger_key>
+# Records "this agent finished and emitted output, on this branch". NOT a credit
+# on its own — the dispatch side still has to have classified it as a reviewer.
+#
+# The key is stored for the SAME reason the dispatch half stores one, and its
+# absence was a measured false-credit path: the dispatch side credits on
+# membership alone, so an agent-id collision ALONE (no matching branch, no
+# ordering) was sufficient to record `reviewer-returned` at spawn time for a
+# reviewer that had produced nothing. Reproduced against the real hooks with a
+# positive control. Both halves now bind, so a collision must ALSO land on the
+# same branch to matter.
 reviewer_pairing_note_complete() {
-    local sid="${1:-}" aid="${2:-}" f
-    [ -n "$aid" ] || return 1
+    local sid="${1:-}" aid="${2:-}" key="${3:-}" f
+    [ -n "$aid" ] && [ -n "$key" ] || return 1
     case "$aid" in *[!A-Za-z0-9._-]*) return 1 ;; esac
+    case "$key" in *[!A-Za-z0-9._-]*) return 1 ;; esac
     f="$(_reviewer_pairing_file complete "$sid")" || return 1
-    _reviewer_pairing_append "$f" "${aid}"
+    _reviewer_pairing_append "$f" "${aid} ${key}"
 }
 
 # reviewer_pairing_dispatch_key <session_id> <agent_id> — prints the ledger key
@@ -117,13 +142,27 @@ reviewer_pairing_note_complete() {
 # not dispatched as a reviewer.
 #
 # `awk '$1==a'` is an exact FIELD comparison, so no stored value can be read as
-# a pattern or match as a prefix, and the `#`-prefixed diagnostic lines written
-# by note_mismatch can never match an agent id. Absent or unreadable file is a
+# a pattern or match as a prefix. The `#`-prefixed diagnostic lines note_mismatch
+# writes into THIS file do not collide with any REAL agent id (measured ids are
+# 17 hex characters) — but `$1` of such a line is the literal `#`, so the
+# exemption is a property of the id charset, not of the comparison. Do not
+# restate it as "a comment line can never match".
+#
+# The hazard is concrete and was observed: this function returns `$2`, and `$2`
+# of a mismatch line is the word `branch-mismatch`. A lookup that matched such a
+# line would hand the caller "branch-mismatch" AS A LEDGER KEY. The charset
+# validation above closes it from the other end — a caller can never ask for `#`
+# — but do not remove either guard on the grounds that the other exists. Absent or unreadable file is a
 # miss, not an error: a recorder degrades to "no record", never to a fabricated
 # one.
 reviewer_pairing_dispatch_key() {
     local sid="${1:-}" aid="${2:-}" f out
     [ -n "$aid" ] || return 1
+    # Readers charset-validate too, matching the writers. Nothing stored could
+    # today contain a character that changes `$1==a`, but awk -v processes POSIX
+    # escapes in the value, and writer/reader validation asymmetry is a class this
+    # repo has been bitten by before.
+    case "$aid" in *[!A-Za-z0-9._-]*) return 1 ;; esac
     f="$(_reviewer_pairing_file dispatch "$sid")" || return 1
     [ -f "$f" ] || return 1
     out="$(awk -v a="$aid" '$1==a {print $2; exit}' "$f" 2>/dev/null)" || return 1
@@ -131,26 +170,40 @@ reviewer_pairing_dispatch_key() {
     printf '%s' "$out"
 }
 
-# reviewer_pairing_has_complete <session_id> <agent_id> — 0 iff this agent has
-# already been observed completing with output.
-reviewer_pairing_has_complete() {
-    local sid="${1:-}" aid="${2:-}" f
+# reviewer_pairing_complete_key <session_id> <agent_id> — prints the ledger key
+# recorded when this agent was observed completing, or nothing (return 1).
+#
+# Returns the KEY rather than a boolean so the dispatch side can branch-bind the
+# way the completion side does. A membership test was the earlier shape and it
+# was a measured false-credit path — see note_complete.
+reviewer_pairing_complete_key() {
+    local sid="${1:-}" aid="${2:-}" f out
     [ -n "$aid" ] || return 1
+    case "$aid" in *[!A-Za-z0-9._-]*) return 1 ;; esac
     f="$(_reviewer_pairing_file complete "$sid")" || return 1
     [ -f "$f" ] || return 1
-    awk -v a="$aid" '$1==a {found=1; exit} END {exit !found}' "$f" 2>/dev/null
+    out="$(awk -v a="$aid" '$1==a {print $2; exit}' "$f" 2>/dev/null)" || return 1
+    [ -n "$out" ] || return 1
+    printf '%s' "$out"
 }
 
 # reviewer_pairing_note_mismatch <session_id> <agent_id> <dispatch_key> <now_key>
 # A reviewer completed on a branch other than the one it was dispatched on, so
-# nothing was credited. Recorded as a `#` comment line in the completion file —
-# no new state family, no new GC entry, and `$1==a` lookups can never match it.
+# nothing was credited. Recorded as a `#` comment line in the DISPATCH file — no
+# new state family, no new GC entry, and `$1==a` lookups skip it (its `$1` is the
+# literal `#`).
+#
+# The DISPATCH file, not the completion file, and that choice is the point: the
+# completion file grows with EVERY subagent completion, so it is the half that
+# approaches the size ceiling, and putting the diagnostic there meant it fell
+# silent under exactly the condition that starts breaking the join. The dispatch
+# file grows only with reviewer dispatches.
 #
 # This exists because a miss otherwise leaves NO trace anywhere, which is how
 # the foreground ordering defect nearly shipped as a silent no-op: "no reviewer
 # ran" and "a reviewer ran and the join failed" must not look identical.
 reviewer_pairing_note_mismatch() {
     local sid="${1:-}" aid="${2:-}" dkey="${3:-}" nkey="${4:-}" f
-    f="$(_reviewer_pairing_file complete "$sid")" || return 1
+    f="$(_reviewer_pairing_file dispatch "$sid")" || return 1
     _reviewer_pairing_append "$f" "# branch-mismatch ${aid} dispatched=${dkey} completed=${nkey}"
 }

--- a/hooks/reviewer-completion-hook.sh
+++ b/hooks/reviewer-completion-hook.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# reviewer-completion-hook.sh — SubagentStop
+#
+# Records a `reviewer-returned` milestone into the per-(repo+branch) branch
+# ledger when a REVIEWER subagent runs to COMPLETION. This is the signal
+# `reviewer-evidence-hook.sh` cannot give: that hook runs on `PostToolUse` for
+# `^(Task|Agent)$`, and for a backgrounded dispatch that payload is a launch
+# acknowledgement (measured on CLI 2.1.236: `status:"async_launched"`,
+# `content:null`), so a reviewer that spawns and then crashes, is stopped, goes
+# idle, or returns nothing is recorded identically to one that finished.
+#
+# What this milestone DOES mean: a reviewer-shaped subagent ran to completion
+# and emitted a final message. What it does NOT mean: that the output was a real
+# review, that it examined this diff, that any finding was correct, or that
+# anything was acted on. A model can still dispatch a reviewer prompted to
+# rubber-stamp. The honest label is "observed completion", never "reviewed" —
+# do not restate it as the latter anywhere it is read.
+#
+# Diagnostic/advisory recorder ONLY. It emits nothing on stdout, sets no
+# permissionDecision, and every failure path exits 0 silently — a recorder must
+# never alter a gate decision. Deliberately NOT in _GATE_ENFORCE_LIBS. No gate
+# reads `reviewer-returned` as of this change.
+#
+# Spec: openspec/changes/reviewer-completion-evidence/
+# Bash 3.2 compatible.
+
+trap 'exit 0' ERR
+set -uo pipefail
+
+# _pair_file <session_id> — path of the dispatch-time pairing file, or nothing.
+# The session id becomes a filename component, so it is validated as a single
+# path-safe segment rather than trusted: the payload is harness-supplied, but a
+# recorder must not be the thing that turns a surprising value into a write
+# outside ~/.claude. Naming mirrors _SESSION_TOKEN ("session-<id>") so the
+# session-start GC excludes the live session with a plain `! -name` match.
+_pair_file() {
+    local sid="${1:-}"
+    [ -n "$sid" ] || return 1
+    case "$sid" in
+        *[!A-Za-z0-9._-]*|.|..) return 1 ;;
+    esac
+    printf '%s' "${HOME}/.claude/.skill-reviewer-dispatch-session-${sid}"
+}
+
+_INPUT="$(cat 2>/dev/null)"
+[ -z "${_INPUT}" ] && exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+# One jq fork, \x1f-joined (the repo's field separator; never \n).
+#
+# `last_assistant_message` is read ONLY to test emptiness and is deliberately
+# the LAST field: it is free-form model output that can contain any byte,
+# including \x1f, so anything appended after it would be swallowed. Its VALUE is
+# never recorded — see the "what is not recorded" note at the ledger write.
+_FIELDS="$(printf '%s' "${_INPUT}" | jq -r '[
+    (.hook_event_name // "" | tostring),
+    (.session_id // "" | tostring),
+    (.agent_id // "" | tostring),
+    (.agent_type // "" | tostring),
+    (.last_assistant_message // "" | tostring)
+  ] | join("\u001f")' 2>/dev/null)" || exit 0
+[ -z "${_FIELDS}" ] && exit 0
+
+_EVENT="${_FIELDS%%$'\x1f'*}";  _R1="${_FIELDS#*$'\x1f'}"
+_SID="${_R1%%$'\x1f'*}";        _R2="${_R1#*$'\x1f'}"
+_AID="${_R2%%$'\x1f'*}";        _R3="${_R2#*$'\x1f'}"
+_ATYPE="${_R3%%$'\x1f'*}"
+_LAST="${_R3#*$'\x1f'}"
+
+# Registered on SubagentStop only, but a hooks.json edit that widens the
+# registration must not silently start crediting on another event.
+[ "${_EVENT}" = "SubagentStop" ] || exit 0
+
+# A subagent that emitted no final message did not return a review. Measured:
+# the CLI carries the subagent's final text inline in this payload, so this
+# costs no extra work. It under-credits an interrupted reviewer, which is the
+# safe direction for a fidelity signal.
+[ -n "${_LAST}" ] || exit 0
+
+[ -n "${_AID}" ] || exit 0
+
+# Reviewer identification, two arms, deliberately asymmetric.
+#
+# ARM 1 — allowlist. `agent_type` arrives verbatim and plugin-qualified
+# (measured: "pr-review-toolkit:code-reviewer", "general-purpose", "Explore"),
+# so the allowlist `reviewer-evidence-hook.sh` applies to `subagent_type`
+# transfers here unchanged and needs no pairing.
+#
+# ARM 2 — general-purpose. superpowers' own requesting-code-review dispatches
+# general-purpose from a reviewer template, so an allowlist alone would
+# false-negative on the ecosystem's documented pattern.
+#
+# The word-boundary DESCRIPTION predicate is deliberately NOT reused here, even
+# though the subagent's task prompt is reachable via `agent_transcript_path`.
+# That predicate (`*[Rr]eview|*[Rr]eview[!a-zA-Z]*`, measured 9/9 recall at 1/7
+# false positives) was fitted on the short dispatch `description` label. Its
+# second arm matches "review" ANYWHERE followed by a non-letter, so against
+# multi-paragraph prompt text it structurally degenerates into the substring
+# variant that measured 4/7 false positives — i.e. re-pointing it at the prompt
+# would silently ship the widening that variant was rejected for. Instead the
+# `agent_id` recorded at dispatch is looked up: an exact key, no heuristic, and
+# the predicate stays on the input it was measured against.
+#
+# The lookup cannot be replaced by reading the parent transcript. Measured
+# in-hook: at SubagentStop time the parent transcript contains ZERO lines
+# mentioning `agent_id` (the `tool_result` carrying it is written afterwards),
+# while the subagent's own transcript is already readable. The link exists only
+# post-hoc, so a dispatch-time writer is required.
+_IS_REVIEWER=false
+case "${_ATYPE}" in
+    pr-review-toolkit:code-reviewer|pr-review-toolkit:silent-failure-hunter|\
+    pr-review-toolkit:pr-test-analyzer|pr-review-toolkit:comment-analyzer|\
+    pr-review-toolkit:type-design-analyzer|feature-dev:code-reviewer)
+        _IS_REVIEWER=true ;;
+    general-purpose)
+        # A MISS records nothing. The alternative — a weaker milestone on a miss
+        # — would be indistinguishable from a genuine reviewer whose dispatch
+        # went unrecorded, and the missing population is dominated by ordinary
+        # implementation subagents, so a weaker record would be mostly noise
+        # wearing an evidence label.
+        #
+        # Absent / unreadable file is a MISS, not an error: this hook can be
+        # newer than the dispatch that produced the pairing (the dispatch may
+        # predate the plugin version that writes it), and a recorder must
+        # degrade to "no record", never to a fabricated one.
+        _PAIR="$(_pair_file "${_SID}")" || _PAIR=""
+        if [ -n "${_PAIR}" ] && [ -f "${_PAIR}" ]; then
+            # -x -F: the agent id is matched as a whole literal line, so no
+            # value in the file can be read as a pattern or a prefix.
+            grep -qxF -- "${_AID}" "${_PAIR}" 2>/dev/null && _IS_REVIEWER=true
+        fi ;;
+esac
+[ "${_IS_REVIEWER}" = "true" ] || exit 0
+
+# #137 source-guard form: source + command -v + flag. A bare `. lib` under
+# `trap 'exit 0' ERR` is a silent early exit, and `[ -f ]` proves existence, not
+# source success. Safe here because this hook is a recorder — a failed load
+# costs a record, never a deny.
+_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+_LEDGER_OK=false
+# Kept on ONE physical line: tests/test-hook-source-guards.sh classifies each
+# source line by grepping single lines, so a `\`-continued guard reads to the
+# lint as a bare `. lib` and is flagged.
+# shellcheck source=lib/branch-ledger.sh
+. "${_PLUGIN_ROOT}/hooks/lib/branch-ledger.sh" 2>/dev/null && command -v branch_ledger_record >/dev/null 2>&1 && _LEDGER_OK=true || true
+[ "${_LEDGER_OK}" = "true" ] || exit 0
+
+# branch_ledger_record stores "<sha> <utc-ts>", so the evidence is SHA-bound for
+# free. The key is sha1(origin remote URL, branch) — NOT the path — so two
+# worktrees of the same repo on the same branch share a key, while a review
+# recorded on a task branch and a push made from an integration branch do not,
+# and a detached HEAD re-keys on every commit. Those misses are safe (a reader
+# simply finds no record) but they are the normal shape of the repo's own
+# agent-team-execution pattern; do not read a missing record as "no review".
+#
+# What is NOT recorded, deliberately: the reviewer's output text. The payload
+# carries it inline and it would make the strongest-looking evidence, but it is
+# unbounded model output that can quote the diff, secrets, or private memory
+# content, and this repo already ships `hooks/publish-guard.sh` because exactly
+# that class of content leaking outbound is a known risk. The ledger stores a
+# sha and a timestamp; keep it that way.
+branch_ledger_record "reviewer-returned" 2>/dev/null || true
+
+exit 0

--- a/hooks/reviewer-completion-hook.sh
+++ b/hooks/reviewer-completion-hook.sh
@@ -86,12 +86,11 @@ _LAST="${_R2#*$'\x1f'}"
 # safe direction for a fidelity signal.
 [ -n "${_LAST}" ] || exit 0
 
-# #137 source-guard form: source + command -v + flag. The probed function is the
-# LAST one the lib defines, not the first one used: a file truncated at a function
-# boundary still sources cleanly, so probing an early definition would leave a
-# later one undefined and the command-not-found would trip the ERR trap.
-#
-# #137 source-guard form: source + command -v + flag. A bare `. lib` under
+# #137 source-guard form: source + command -v + flag. The probed symbol is the
+# LAST function the lib defines, not the first one used: a file truncated at a
+# function boundary still sources cleanly, so probing an early definition would
+# leave a later one undefined and the command-not-found would trip the ERR trap.
+# Pinned by a cell — if a function is appended to the lib, the probe must move. A bare `. lib` under
 # `trap 'exit 0' ERR` is a silent early exit, and `[ -f ]` proves existence, not
 # source success. Safe here because this hook is a recorder — a failed load
 # costs a record, never a deny.

--- a/hooks/reviewer-completion-hook.sh
+++ b/hooks/reviewer-completion-hook.sh
@@ -42,8 +42,16 @@
 trap 'exit 0' ERR
 set -uo pipefail
 
-# shellcheck source=lib/reviewer-pairing.sh
-_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+if [ -z "${_PLUGIN_ROOT}" ]; then
+    # NOT `X="${VAR:-$(cd .. && pwd)}"`. A top-level assignment whose value comes
+    # from a command substitution trips this file's blanket `trap 'exit 0' ERR`
+    # AT THAT LINE when the substitution fails, killing the hook before anything
+    # below it runs — the shape CLAUDE.md calls out in publish-guard.sh. Split so
+    # the failure is handled rather than fatal.
+    _PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)" || _PLUGIN_ROOT=""
+fi
+[ -n "${_PLUGIN_ROOT}" ] || exit 0
 
 _INPUT="$(cat 2>/dev/null)"
 [ -z "${_INPUT}" ] && exit 0
@@ -86,6 +94,11 @@ _PAIR_OK=false
 # Kept on ONE physical line: tests/test-hook-source-guards.sh classifies each
 # source line by grepping single lines, so a `\`-continued guard reads to the
 # lint as a bare `. lib` and is flagged.
+#
+# The `&&`-guard covers the SOURCE'S OWN exit status, not a command failing
+# inside the sourced file (#192). reviewer-pairing.sh only defines functions —
+# it executes nothing at load — so there is no such command to fail.
+# shellcheck source=lib/reviewer-pairing.sh
 . "${_PLUGIN_ROOT}/hooks/lib/reviewer-pairing.sh" 2>/dev/null && command -v reviewer_pairing_note_complete >/dev/null 2>&1 && _PAIR_OK=true || true
 [ "${_PAIR_OK}" = "true" ] || exit 0
 

--- a/hooks/reviewer-completion-hook.sh
+++ b/hooks/reviewer-completion-hook.sh
@@ -169,7 +169,9 @@ fi
 #
 # Residual, stated: if HEAD moved between dispatch and completion this artifact
 # has no way to SAY so; it records the reviewed commit, which is the honest
-# lower bound, not a straddle marker. The key is sha1(origin remote URL, branch) — NOT the path — so two
+# lower bound, not a straddle marker.
+#
+# The key is sha1(origin remote URL, branch) — NOT the path — so two
 # worktrees of the same repo on the same branch share a key, while a review
 # recorded on a task branch and a push made from an integration branch do not,
 # and a detached HEAD re-keys on every commit. Those misses are safe (a reader

--- a/hooks/reviewer-completion-hook.sh
+++ b/hooks/reviewer-completion-hook.sh
@@ -86,6 +86,11 @@ _LAST="${_R2#*$'\x1f'}"
 # safe direction for a fidelity signal.
 [ -n "${_LAST}" ] || exit 0
 
+# #137 source-guard form: source + command -v + flag. The probed function is the
+# LAST one the lib defines, not the first one used: a file truncated at a function
+# boundary still sources cleanly, so probing an early definition would leave a
+# later one undefined and the command-not-found would trip the ERR trap.
+#
 # #137 source-guard form: source + command -v + flag. A bare `. lib` under
 # `trap 'exit 0' ERR` is a silent early exit, and `[ -f ]` proves existence, not
 # source success. Safe here because this hook is a recorder — a failed load
@@ -99,7 +104,7 @@ _PAIR_OK=false
 # inside the sourced file (#192). reviewer-pairing.sh only defines functions —
 # it executes nothing at load — so there is no such command to fail.
 # shellcheck source=lib/reviewer-pairing.sh
-. "${_PLUGIN_ROOT}/hooks/lib/reviewer-pairing.sh" 2>/dev/null && command -v reviewer_pairing_note_complete >/dev/null 2>&1 && _PAIR_OK=true || true
+. "${_PLUGIN_ROOT}/hooks/lib/reviewer-pairing.sh" 2>/dev/null && command -v reviewer_pairing_note_mismatch >/dev/null 2>&1 && _PAIR_OK=true || true
 [ "${_PAIR_OK}" = "true" ] || exit 0
 
 _LEDGER_OK=false
@@ -125,7 +130,7 @@ _KEY="$(branch_ledger_key 2>/dev/null)" || _KEY=""
 # hook right here — silently skipping the join below and killing every credit
 # for the rest of the session, with no diagnostic. Found by a mutation that
 # was masked by exactly this early exit.
-reviewer_pairing_note_complete "${_SID}" "${_AID}" || true
+reviewer_pairing_note_complete "${_SID}" "${_AID}" "${_KEY}" || true
 
 # HALF TWO: was this agent dispatched as a reviewer, and on THIS branch?
 _DKEY="$(reviewer_pairing_dispatch_key "${_SID}" "${_AID}")" || _DKEY=""

--- a/hooks/reviewer-completion-hook.sh
+++ b/hooks/reviewer-completion-hook.sh
@@ -4,7 +4,7 @@
 # Records a `reviewer-returned` milestone into the per-(repo+branch) branch
 # ledger when a REVIEWER subagent runs to COMPLETION. This is the signal
 # `reviewer-evidence-hook.sh` cannot give: that hook runs on `PostToolUse` for
-# `^(Task|Agent)$`, and for a backgrounded dispatch that payload is a launch
+# `^(Task|Agent)$`, and for a BACKGROUNDED dispatch that payload is a launch
 # acknowledgement (measured on CLI 2.1.236: `status:"async_launched"`,
 # `content:null`), so a reviewer that spawns and then crashes, is stopped, goes
 # idle, or returns nothing is recorded identically to one that finished.
@@ -15,6 +15,21 @@
 # anything was acted on. A model can still dispatch a reviewer prompted to
 # rubber-stamp. The honest label is "observed completion", never "reviewed" —
 # do not restate it as the latter anywhere it is read.
+#
+# THE JOIN IS SYMMETRIC, AND THAT IS THE WHOLE DESIGN. Classification lives in
+# the dispatch hook (it owns the measured `description` predicate); this hook
+# owns the completion fact. Neither can credit alone, and NEITHER IS GUARANTEED
+# TO RUN FIRST — measured end-to-end against the real hooks on CLI 2.1.236:
+#
+#   background dispatch : DISPATCH fires 1.44s BEFORE completion
+#   foreground dispatch : COMPLETION fires ~30ms BEFORE dispatch (3 of 3)
+#
+# A dispatch-writes-then-completion-reads design is therefore a systematic
+# no-op for FOREGROUND dispatches — measured, not theorised: the first cut of
+# this hook recorded `reviewer-ran` and no `reviewer-returned` for a foreground
+# reviewer. So each hook writes its own half FIRST and then looks for the other;
+# whichever runs second completes the join. Do not "simplify" this back into a
+# one-directional lookup.
 #
 # Diagnostic/advisory recorder ONLY. It emits nothing on stdout, sets no
 # permissionDecision, and every failure path exits 0 silently — a recorder must
@@ -27,20 +42,8 @@
 trap 'exit 0' ERR
 set -uo pipefail
 
-# _pair_file <session_id> — path of the dispatch-time pairing file, or nothing.
-# The session id becomes a filename component, so it is validated as a single
-# path-safe segment rather than trusted: the payload is harness-supplied, but a
-# recorder must not be the thing that turns a surprising value into a write
-# outside ~/.claude. Naming mirrors _SESSION_TOKEN ("session-<id>") so the
-# session-start GC excludes the live session with a plain `! -name` match.
-_pair_file() {
-    local sid="${1:-}"
-    [ -n "$sid" ] || return 1
-    case "$sid" in
-        *[!A-Za-z0-9._-]*|.|..) return 1 ;;
-    esac
-    printf '%s' "${HOME}/.claude/.skill-reviewer-dispatch-session-${sid}"
-}
+# shellcheck source=lib/reviewer-pairing.sh
+_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 _INPUT="$(cat 2>/dev/null)"
 [ -z "${_INPUT}" ] && exit 0
@@ -51,21 +54,19 @@ command -v jq >/dev/null 2>&1 || exit 0
 # `last_assistant_message` is read ONLY to test emptiness and is deliberately
 # the LAST field: it is free-form model output that can contain any byte,
 # including \x1f, so anything appended after it would be swallowed. Its VALUE is
-# never recorded — see the "what is not recorded" note at the ledger write.
+# never stored — see the "what is not recorded" note at the ledger write.
 _FIELDS="$(printf '%s' "${_INPUT}" | jq -r '[
     (.hook_event_name // "" | tostring),
     (.session_id // "" | tostring),
     (.agent_id // "" | tostring),
-    (.agent_type // "" | tostring),
     (.last_assistant_message // "" | tostring)
   ] | join("\u001f")' 2>/dev/null)" || exit 0
 [ -z "${_FIELDS}" ] && exit 0
 
 _EVENT="${_FIELDS%%$'\x1f'*}";  _R1="${_FIELDS#*$'\x1f'}"
 _SID="${_R1%%$'\x1f'*}";        _R2="${_R1#*$'\x1f'}"
-_AID="${_R2%%$'\x1f'*}";        _R3="${_R2#*$'\x1f'}"
-_ATYPE="${_R3%%$'\x1f'*}"
-_LAST="${_R3#*$'\x1f'}"
+_AID="${_R2%%$'\x1f'*}"
+_LAST="${_R2#*$'\x1f'}"
 
 # Registered on SubagentStop only, but a hooks.json edit that widens the
 # registration must not silently start crediting on another event.
@@ -77,73 +78,65 @@ _LAST="${_R3#*$'\x1f'}"
 # safe direction for a fidelity signal.
 [ -n "${_LAST}" ] || exit 0
 
-[ -n "${_AID}" ] || exit 0
-
-# Reviewer identification, two arms, deliberately asymmetric.
-#
-# ARM 1 — allowlist. `agent_type` arrives verbatim and plugin-qualified
-# (measured: "pr-review-toolkit:code-reviewer", "general-purpose", "Explore"),
-# so the allowlist `reviewer-evidence-hook.sh` applies to `subagent_type`
-# transfers here unchanged and needs no pairing.
-#
-# ARM 2 — general-purpose. superpowers' own requesting-code-review dispatches
-# general-purpose from a reviewer template, so an allowlist alone would
-# false-negative on the ecosystem's documented pattern.
-#
-# The word-boundary DESCRIPTION predicate is deliberately NOT reused here, even
-# though the subagent's task prompt is reachable via `agent_transcript_path`.
-# That predicate (`*[Rr]eview|*[Rr]eview[!a-zA-Z]*`, measured 9/9 recall at 1/7
-# false positives) was fitted on the short dispatch `description` label. Its
-# second arm matches "review" ANYWHERE followed by a non-letter, so against
-# multi-paragraph prompt text it structurally degenerates into the substring
-# variant that measured 4/7 false positives — i.e. re-pointing it at the prompt
-# would silently ship the widening that variant was rejected for. Instead the
-# `agent_id` recorded at dispatch is looked up: an exact key, no heuristic, and
-# the predicate stays on the input it was measured against.
-#
-# The lookup cannot be replaced by reading the parent transcript. Measured
-# in-hook: at SubagentStop time the parent transcript contains ZERO lines
-# mentioning `agent_id` (the `tool_result` carrying it is written afterwards),
-# while the subagent's own transcript is already readable. The link exists only
-# post-hoc, so a dispatch-time writer is required.
-_IS_REVIEWER=false
-case "${_ATYPE}" in
-    pr-review-toolkit:code-reviewer|pr-review-toolkit:silent-failure-hunter|\
-    pr-review-toolkit:pr-test-analyzer|pr-review-toolkit:comment-analyzer|\
-    pr-review-toolkit:type-design-analyzer|feature-dev:code-reviewer)
-        _IS_REVIEWER=true ;;
-    general-purpose)
-        # A MISS records nothing. The alternative — a weaker milestone on a miss
-        # — would be indistinguishable from a genuine reviewer whose dispatch
-        # went unrecorded, and the missing population is dominated by ordinary
-        # implementation subagents, so a weaker record would be mostly noise
-        # wearing an evidence label.
-        #
-        # Absent / unreadable file is a MISS, not an error: this hook can be
-        # newer than the dispatch that produced the pairing (the dispatch may
-        # predate the plugin version that writes it), and a recorder must
-        # degrade to "no record", never to a fabricated one.
-        _PAIR="$(_pair_file "${_SID}")" || _PAIR=""
-        if [ -n "${_PAIR}" ] && [ -f "${_PAIR}" ]; then
-            # -x -F: the agent id is matched as a whole literal line, so no
-            # value in the file can be read as a pattern or a prefix.
-            grep -qxF -- "${_AID}" "${_PAIR}" 2>/dev/null && _IS_REVIEWER=true
-        fi ;;
-esac
-[ "${_IS_REVIEWER}" = "true" ] || exit 0
-
 # #137 source-guard form: source + command -v + flag. A bare `. lib` under
 # `trap 'exit 0' ERR` is a silent early exit, and `[ -f ]` proves existence, not
 # source success. Safe here because this hook is a recorder — a failed load
 # costs a record, never a deny.
-_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
-_LEDGER_OK=false
+_PAIR_OK=false
 # Kept on ONE physical line: tests/test-hook-source-guards.sh classifies each
 # source line by grepping single lines, so a `\`-continued guard reads to the
 # lint as a bare `. lib` and is flagged.
+. "${_PLUGIN_ROOT}/hooks/lib/reviewer-pairing.sh" 2>/dev/null && command -v reviewer_pairing_note_complete >/dev/null 2>&1 && _PAIR_OK=true || true
+[ "${_PAIR_OK}" = "true" ] || exit 0
+
+_LEDGER_OK=false
 # shellcheck source=lib/branch-ledger.sh
 . "${_PLUGIN_ROOT}/hooks/lib/branch-ledger.sh" 2>/dev/null && command -v branch_ledger_record >/dev/null 2>&1 && _LEDGER_OK=true || true
 [ "${_LEDGER_OK}" = "true" ] || exit 0
+
+# The ledger key binds the credit to a (repo, branch) pair. It is resolved HERE
+# so it can be compared against the key recorded at dispatch — see the branch
+# check below, which is the reason this hook computes a key at all rather than
+# letting branch_ledger_record derive one implicitly.
+_KEY="$(branch_ledger_key 2>/dev/null)" || _KEY=""
+[ -n "${_KEY}" ] || exit 0
+
+# HALF ONE: publish the completion fact, unconditionally on reaching here and
+# BEFORE reading the other half. A completion record is not a credit — the
+# dispatch hook still has to have classified this agent as a reviewer — so
+# recording every completed subagent here is not over-crediting, it is the join
+# key the other side needs when IT runs second.
+# `|| true` is load-bearing, not decoration: this returns non-zero whenever
+# the append does not happen (size ceiling reached, unwritable ~/.claude), and
+# a bare failing call under this file's `trap 'exit 0' ERR` would terminate the
+# hook right here — silently skipping the join below and killing every credit
+# for the rest of the session, with no diagnostic. Found by a mutation that
+# was masked by exactly this early exit.
+reviewer_pairing_note_complete "${_SID}" "${_AID}" || true
+
+# HALF TWO: was this agent dispatched as a reviewer, and on THIS branch?
+_DKEY="$(reviewer_pairing_dispatch_key "${_SID}" "${_AID}")" || _DKEY=""
+# DEFENCE IN DEPTH, and honestly so: the branch comparison below ALSO rejects an
+# absent record (an empty key can never equal a real one), so mutating this line
+# away breaks no test. It is kept because it states the actual precondition —
+# "this agent was dispatched as a reviewer" — rather than leaving correctness to
+# depend on the coincidence that "" never compares equal.
+[ -n "${_DKEY}" ] || exit 0
+
+# BRANCH BINDING. branch_ledger_record derives its key from the cwd/branch AT
+# CALL TIME, and a BACKGROUNDED reviewer completes on the parent session's
+# clock — the session is free to `git checkout` a different branch while it
+# runs. Crediting then would write `reviewer-returned` into the ledger of a
+# branch the reviewer never looked at: not a miss but a WRONG-TARGET HIT, and
+# the push gate treats ledger records as durable cross-session evidence. A
+# mismatch therefore records NOTHING and leaves a diagnostic line instead.
+# Under-crediting a legitimate review whose session moved on is the accepted
+# cost; writing into the dispatch-time ledger dir directly would credit a
+# branch this process cannot verify it is even on.
+if [ "${_DKEY}" != "${_KEY}" ]; then
+    reviewer_pairing_note_mismatch "${_SID}" "${_AID}" "${_DKEY}" "${_KEY}" || true
+    exit 0
+fi
 
 # branch_ledger_record stores "<sha> <utc-ts>", so the evidence is SHA-bound for
 # free. The key is sha1(origin remote URL, branch) — NOT the path — so two
@@ -156,9 +149,13 @@ _LEDGER_OK=false
 # What is NOT recorded, deliberately: the reviewer's output text. The payload
 # carries it inline and it would make the strongest-looking evidence, but it is
 # unbounded model output that can quote the diff, secrets, or private memory
-# content, and this repo already ships `hooks/publish-guard.sh` because exactly
-# that class of content leaking outbound is a known risk. The ledger stores a
-# sha and a timestamp; keep it that way.
+# content into a file that outlives the session. This repo already ships
+# `hooks/publish-guard.sh` and `scripts/memory-leak-check.sh` because that class
+# of content leaking outbound is a known risk, and that scanner watches only
+# `~/.claude/projects/*/memory/` — a ledger holding raw reviewer text would be a
+# second surface it does not know exists. The IMPLEMENT shadow corpus settled
+# the same trade the same way: "raw command text is never written;
+# transcript_path is the adjudication pointer."
 branch_ledger_record "reviewer-returned" 2>/dev/null || true
 
 exit 0

--- a/hooks/reviewer-completion-hook.sh
+++ b/hooks/reviewer-completion-hook.sh
@@ -155,8 +155,21 @@ if [ "${_DKEY}" != "${_KEY}" ]; then
     exit 0
 fi
 
-# branch_ledger_record stores "<sha> <utc-ts>", so the evidence is SHA-bound for
-# free. The key is sha1(origin remote URL, branch) — NOT the path — so two
+# The recorded sha is the DISPATCH-time commit, passed explicitly — NOT HEAD at
+# call time. This is the one place the "SHA-bound for free" wording inherited
+# from the dispatch hook would be wrong: a backgrounded reviewer finishes while
+# the session keeps committing, so HEAD here can name a tree the reviewer never
+# read, and ledger records are consumed with HEAD-or-ancestor acceptance — an
+# over-late sha silently covers commits nothing reviewed. That is the over-claim
+# #181 removed from verdicts, and it would make this milestone LESS sha-accurate
+# than the `reviewer-ran` it is meant to strengthen.
+#
+# An absent dispatch sha (a record written before the field existed) falls back
+# to HEAD, i.e. the older, less precise behaviour — never to a fabricated value.
+#
+# Residual, stated: if HEAD moved between dispatch and completion this artifact
+# has no way to SAY so; it records the reviewed commit, which is the honest
+# lower bound, not a straddle marker. The key is sha1(origin remote URL, branch) — NOT the path — so two
 # worktrees of the same repo on the same branch share a key, while a review
 # recorded on a task branch and a push made from an integration branch do not,
 # and a detached HEAD re-keys on every commit. Those misses are safe (a reader
@@ -173,6 +186,7 @@ fi
 # second surface it does not know exists. The IMPLEMENT shadow corpus settled
 # the same trade the same way: "raw command text is never written;
 # transcript_path is the adjudication pointer."
-branch_ledger_record "reviewer-returned" 2>/dev/null || true
+_DSHA="$(reviewer_pairing_dispatch_sha "${_SID}" "${_AID}")" || _DSHA=""
+branch_ledger_record "reviewer-returned" "" "${_DSHA}" 2>/dev/null || true
 
 exit 0

--- a/hooks/reviewer-evidence-hook.sh
+++ b/hooks/reviewer-evidence-hook.sh
@@ -218,7 +218,8 @@ if [ "${_PAIR_OK}" = "true" ] && [ -n "${_AGENT_ID}" ]; then
     _PAIR_KEY="$(branch_ledger_key 2>/dev/null)" || _PAIR_KEY=""
     if [ -n "${_PAIR_KEY}" ]; then
         # HALF ONE, written BEFORE reading the other half.
-        reviewer_pairing_note_dispatch "${_SID}" "${_AGENT_ID}" "${_PAIR_KEY}" || true
+        _PAIR_SHA="$(git rev-parse HEAD 2>/dev/null)" || _PAIR_SHA=""
+        reviewer_pairing_note_dispatch "${_SID}" "${_AGENT_ID}" "${_PAIR_KEY}" "${_PAIR_SHA}" || true
         # HALF TWO: did this agent already finish, on THIS branch? (foreground
         # ordering). The key comparison is not symmetry for its own sake — a
         # membership test here was a measured false-credit path: an agent-id
@@ -228,7 +229,10 @@ if [ "${_PAIR_OK}" = "true" ] && [ -n "${_AGENT_ID}" ]; then
         # control; pinned by a cell.
         _COMP_KEY="$(reviewer_pairing_complete_key "${_SID}" "${_AGENT_ID}")" || _COMP_KEY=""
         if [ -n "${_COMP_KEY}" ] && [ "${_COMP_KEY}" = "${_PAIR_KEY}" ]; then
-            branch_ledger_record "reviewer-returned" 2>/dev/null || true
+            # Stamp the commit that was REVIEWED. On this path they coincide (we
+            # are at dispatch time), but passing it explicitly keeps both credit
+            # paths writing the same fact rather than relying on that coincidence.
+            branch_ledger_record "reviewer-returned" "" "${_PAIR_SHA}" 2>/dev/null || true
         fi
     fi
 fi

--- a/hooks/reviewer-evidence-hook.sh
+++ b/hooks/reviewer-evidence-hook.sh
@@ -51,6 +51,8 @@ _FIELDS="$(printf '%s' "${_INPUT}" | jq -r '[
     .tool_name // "",
     ((.tool_response | objects | .is_error) // false | tostring),
     ((.tool_input | objects | .subagent_type) // "" | tostring),
+    (.session_id // "" | tostring),
+    ((.tool_response | objects | .agentId) // "" | tostring),
     ((.tool_input | objects | .description) // "" | tostring | gsub("[\\n\\r]"; " "))
   ] | join("\u001f")' 2>/dev/null)" || exit 0
 [ -z "${_FIELDS}" ] && exit 0
@@ -60,8 +62,10 @@ _FIELDS="$(printf '%s' "${_INPUT}" | jq -r '[
 # free-text description happened to contain.
 _TOOL="${_FIELDS%%$'\x1f'*}";      _R1="${_FIELDS#*$'\x1f'}"
 _IS_ERROR="${_R1%%$'\x1f'*}";      _R2="${_R1#*$'\x1f'}"
-_SUBAGENT="${_R2%%$'\x1f'*}"
-_DESC="${_R2#*$'\x1f'}"
+_SUBAGENT="${_R2%%$'\x1f'*}";      _R3="${_R2#*$'\x1f'}"
+_SID="${_R3%%$'\x1f'*}";           _R4="${_R3#*$'\x1f'}"
+_AGENT_ID="${_R4%%$'\x1f'*}"
+_DESC="${_R4#*$'\x1f'}"
 
 # Only the subagent-dispatch tool. `Agent` is the current Claude Code name;
 # `Task` is kept for older builds this plugin also ships to.
@@ -164,6 +168,62 @@ _LEDGER_OK=false
 # compare that SHA against HEAD to judge staleness without this hook doing
 # anything extra.
 branch_ledger_record "reviewer-ran" 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Dispatch-time pairing write (openspec/changes/reviewer-completion-evidence/).
+#
+# `reviewer-completion-hook.sh` runs on SubagentStop, whose payload carries
+# `agent_type` but NOT the dispatch `description` this hook's predicate was
+# measured on. It therefore needs the `agent_id` judged a reviewer HERE.
+#
+# It cannot recover the link itself: measured in-hook, at SubagentStop time the
+# parent transcript contains ZERO lines mentioning the agent id, because the
+# `tool_result` carrying `agentId` is written AFTER that event fires. A
+# dispatch-time writer is the only source.
+#
+# Symmetry is by construction, not by convention: both hooks read `session_id`
+# from their OWN payload, and the two events carry the identical value
+# (measured in one run). This is deliberately NOT the `resolve_own_session_token`
+# path — that resolver exists for model-Bash-turn writers which have no payload,
+# and its singleton fallback is the last-writer-wins scatter that would break a
+# pairing under concurrent sessions.
+#
+# ORDERING IS LOAD-BEARING: this runs AFTER the reviewer-ran record, never
+# before. Under this file's `trap 'exit 0' ERR`, a single failing command is a
+# silent early exit — and the first draft put this block above the record, where
+# `wc -c < <missing file>` (a REDIRECTION failure, which `2>/dev/null` does not
+# suppress) killed the hook before it wrote anything. That deleted the
+# pre-existing milestone with no error, and it is exactly the #137/#198 class.
+# New best-effort work goes below the thing that must not be lost.
+_pair_file() {
+    local sid="${1:-}"
+    [ -n "$sid" ] || return 1
+    case "$sid" in
+        *[!A-Za-z0-9._-]*|.|..) return 1 ;;
+    esac
+    printf '%s' "${HOME}/.claude/.skill-reviewer-dispatch-session-${sid}"
+}
+if [ -n "${_AGENT_ID}" ]; then
+    case "${_AGENT_ID}" in
+        *[!A-Za-z0-9._-]*) ;;                       # never write a surprising value
+        *)
+            _PAIR="$(_pair_file "${_SID}")" || _PAIR=""
+            if [ -n "${_PAIR}" ]; then
+                # Size ceiling instead of a trim: a read-modify-write rotation
+                # would race two parallel dispatches, and dropping new records
+                # is strictly safer than corrupting existing ones. ~18 bytes per
+                # line, so this bounds a pathological session, not a real one.
+                _PAIR_BYTES=0
+                if [ -f "${_PAIR}" ]; then
+                    _PAIR_BYTES="$(wc -c < "${_PAIR}" 2>/dev/null | tr -d ' ')" || _PAIR_BYTES=0
+                    case "${_PAIR_BYTES}" in ''|*[!0-9]*) _PAIR_BYTES=0 ;; esac
+                fi
+                if [ "${_PAIR_BYTES}" -lt 65536 ]; then
+                    printf '%s\n' "${_AGENT_ID}" >> "${_PAIR}" 2>/dev/null || true
+                fi
+            fi ;;
+    esac
+fi
 
 # D4 (design.md): this hook's write and scripts/record-review-verdict.sh's
 # read must resolve the branch-ledger key IDENTICALLY. branch_ledger_key

--- a/hooks/reviewer-evidence-hook.sh
+++ b/hooks/reviewer-evidence-hook.sh
@@ -154,7 +154,16 @@ esac
 # not source success. Safe to use the command -v form HERE because this hook
 # is a recorder — a failed load costs a record, never a deny. This change does
 # not touch openspec-guard.sh's own source sites.
-_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+if [ -z "${_PLUGIN_ROOT}" ]; then
+    # NOT `X="${VAR:-$(cd .. && pwd)}"`. A top-level assignment whose value comes
+    # from a command substitution trips this file's blanket `trap 'exit 0' ERR`
+    # AT THAT LINE when the substitution fails, killing the hook before anything
+    # below it runs — the shape CLAUDE.md calls out in publish-guard.sh. Split so
+    # the failure is handled rather than fatal.
+    _PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)" || _PLUGIN_ROOT=""
+fi
+[ -n "${_PLUGIN_ROOT}" ] || exit 0
 _LEDGER_OK=false
 # Kept on ONE physical line: tests/test-hook-source-guards.sh classifies each
 # source line by grepping single lines, so a `\`-continued guard reads to the

--- a/hooks/reviewer-evidence-hook.sh
+++ b/hooks/reviewer-evidence-hook.sh
@@ -202,6 +202,12 @@ _PAIR_OK=false
 # source line by grepping single lines, so a `\`-continued guard reads to the
 # lint as a bare `. lib` and is flagged.
 # shellcheck source=lib/reviewer-pairing.sh
+# The probed symbol is the LAST function the lib defines, NOT one this hook
+# calls: a file truncated at a function boundary still sources cleanly, so
+# probing a symbol used here would pass while a later one stayed undefined. The
+# cost is that deleting or renaming that function disables the join in BOTH
+# hooks rather than erroring — which is why a cell pins "the probed symbol is the
+# lib's last definition" instead of leaving it to memory.
 . "${_PLUGIN_ROOT}/hooks/lib/reviewer-pairing.sh" 2>/dev/null && command -v reviewer_pairing_note_mismatch >/dev/null 2>&1 && _PAIR_OK=true || true
 
 if [ "${_PAIR_OK}" = "true" ] && [ -n "${_AGENT_ID}" ]; then

--- a/hooks/reviewer-evidence-hook.sh
+++ b/hooks/reviewer-evidence-hook.sh
@@ -202,7 +202,7 @@ _PAIR_OK=false
 # source line by grepping single lines, so a `\`-continued guard reads to the
 # lint as a bare `. lib` and is flagged.
 # shellcheck source=lib/reviewer-pairing.sh
-. "${_PLUGIN_ROOT}/hooks/lib/reviewer-pairing.sh" 2>/dev/null && command -v reviewer_pairing_note_dispatch >/dev/null 2>&1 && _PAIR_OK=true || true
+. "${_PLUGIN_ROOT}/hooks/lib/reviewer-pairing.sh" 2>/dev/null && command -v reviewer_pairing_note_mismatch >/dev/null 2>&1 && _PAIR_OK=true || true
 
 if [ "${_PAIR_OK}" = "true" ] && [ -n "${_AGENT_ID}" ]; then
     # The key binds the credit to a (repo, branch) pair. Stored at dispatch so
@@ -213,8 +213,15 @@ if [ "${_PAIR_OK}" = "true" ] && [ -n "${_AGENT_ID}" ]; then
     if [ -n "${_PAIR_KEY}" ]; then
         # HALF ONE, written BEFORE reading the other half.
         reviewer_pairing_note_dispatch "${_SID}" "${_AGENT_ID}" "${_PAIR_KEY}" || true
-        # HALF TWO: did this agent already finish? (foreground ordering)
-        if reviewer_pairing_has_complete "${_SID}" "${_AGENT_ID}"; then
+        # HALF TWO: did this agent already finish, on THIS branch? (foreground
+        # ordering). The key comparison is not symmetry for its own sake — a
+        # membership test here was a measured false-credit path: an agent-id
+        # collision ALONE, with no matching branch and no ordering constraint, was
+        # enough to record `reviewer-returned` at SPAWN time for a reviewer that
+        # had produced nothing. Reproduced against the real hooks with a positive
+        # control; pinned by a cell.
+        _COMP_KEY="$(reviewer_pairing_complete_key "${_SID}" "${_AGENT_ID}")" || _COMP_KEY=""
+        if [ -n "${_COMP_KEY}" ] && [ "${_COMP_KEY}" = "${_PAIR_KEY}" ]; then
             branch_ledger_record "reviewer-returned" 2>/dev/null || true
         fi
     fi

--- a/hooks/reviewer-evidence-hook.sh
+++ b/hooks/reviewer-evidence-hook.sh
@@ -170,78 +170,45 @@ _LEDGER_OK=false
 branch_ledger_record "reviewer-ran" 2>/dev/null || true
 
 # ---------------------------------------------------------------------------
-# Dispatch-time pairing write (openspec/changes/reviewer-completion-evidence/).
+# Reviewer dispatch/completion JOIN (openspec/changes/reviewer-completion-
+# evidence/). `reviewer-completion-hook.sh` observes that a subagent finished;
+# this hook owns the classification. Neither can credit alone.
 #
-# `reviewer-completion-hook.sh` runs on SubagentStop, whose payload carries
-# `agent_type` but NOT the dispatch `description` this hook's predicate was
-# measured on. It therefore needs the `agent_id` judged a reviewer HERE.
+# NEITHER HOOK IS GUARANTEED TO RUN FIRST — measured end-to-end against both
+# real hooks on CLI 2.1.236: for a BACKGROUND dispatch this one fires 1.44s
+# BEFORE completion, but for a FOREGROUND dispatch it fires ~30ms AFTER it
+# (3 of 3). So each side writes its own half first and then looks for the
+# other; whichever runs second records the milestone. The first cut wrote here
+# and read there, which is a systematic no-op for every foreground reviewer.
 #
-# It cannot recover the link itself: measured in-hook, at SubagentStop time the
-# parent transcript contains ZERO lines mentioning the agent id, because the
-# `tool_result` carrying `agentId` is written AFTER that event fires. A
-# dispatch-time writer is the only source.
-#
-# Symmetry is by construction, not by convention: both hooks read `session_id`
-# from their OWN payload, and the two events carry the identical value
-# (measured in one run). This is deliberately NOT the `resolve_own_session_token`
-# path — that resolver exists for model-Bash-turn writers which have no payload,
-# and its singleton fallback is the last-writer-wins scatter that would break a
-# pairing under concurrent sessions.
-#
-# ORDERING IS LOAD-BEARING: this runs AFTER the reviewer-ran record, never
-# before. Under this file's `trap 'exit 0' ERR`, a single failing command is a
-# silent early exit — and the first draft put this block above the record, where
-# `wc -c < <missing file>` (a REDIRECTION failure, which `2>/dev/null` does not
-# suppress) killed the hook before it wrote anything. That deleted the
-# pre-existing milestone with no error, and it is exactly the #137/#198 class.
-# New best-effort work goes below the thing that must not be lost.
-_pair_file() {
-    local sid="${1:-}"
-    [ -n "$sid" ] || return 1
-    case "$sid" in
-        *[!A-Za-z0-9._-]*|.|..) return 1 ;;
-    esac
-    printf '%s' "${HOME}/.claude/.skill-reviewer-dispatch-session-${sid}"
-}
-if [ -n "${_AGENT_ID}" ]; then
-    case "${_AGENT_ID}" in
-        *[!A-Za-z0-9._-]*) ;;                       # never write a surprising value
-        *)
-            _PAIR="$(_pair_file "${_SID}")" || _PAIR=""
-            if [ -n "${_PAIR}" ]; then
-                # Size ceiling instead of a trim: a read-modify-write rotation
-                # would race two parallel dispatches, and dropping new records
-                # is strictly safer than corrupting existing ones. ~18 bytes per
-                # line, so this bounds a pathological session, not a real one.
-                _PAIR_BYTES=0
-                if [ -f "${_PAIR}" ]; then
-                    _PAIR_BYTES="$(wc -c < "${_PAIR}" 2>/dev/null | tr -d ' ')" || _PAIR_BYTES=0
-                    case "${_PAIR_BYTES}" in ''|*[!0-9]*) _PAIR_BYTES=0 ;; esac
-                fi
-                if [ "${_PAIR_BYTES}" -lt 65536 ]; then
-                    printf '%s\n' "${_AGENT_ID}" >> "${_PAIR}" 2>/dev/null || true
-                fi
-            fi ;;
-    esac
-fi
+# ORDERING WITHIN THIS FILE IS ALSO LOAD-BEARING: this runs AFTER the
+# reviewer-ran record, never before. Under this file's `trap 'exit 0' ERR` a
+# single failing command is a silent early exit — the first draft put this
+# above the record, where `wc -c < <missing file>` (a REDIRECTION failure,
+# which `2>/dev/null` does not suppress) killed the hook before it wrote
+# anything, silently deleting the pre-existing milestone. New best-effort work
+# goes below the thing that must not be lost. See CLAUDE.md #137/#198.
+_PAIR_OK=false
+# Kept on ONE physical line: tests/test-hook-source-guards.sh classifies each
+# source line by grepping single lines, so a `\`-continued guard reads to the
+# lint as a bare `. lib` and is flagged.
+# shellcheck source=lib/reviewer-pairing.sh
+. "${_PLUGIN_ROOT}/hooks/lib/reviewer-pairing.sh" 2>/dev/null && command -v reviewer_pairing_note_dispatch >/dev/null 2>&1 && _PAIR_OK=true || true
 
-# D4 (design.md): this hook's write and scripts/record-review-verdict.sh's
-# read must resolve the branch-ledger key IDENTICALLY. branch_ledger_key
-# hashes the raw path string AND branch name, so a non-canonical path on
-# either side (a trailing slash, a doubled separator, an unresolved symlink)
-# produces a different key and the read silently misses — this produced a
-# false negative during PR #212's development. Both currently derive the path
-# half from `git rev-parse --show-toplevel` (this hook via
-# branch_ledger_record's arg-less fallback); any future change giving one
-# side an explicit proj_root must give it to both.
-#
-# The branch half carries the SAME hazard from a different cause: each side
-# derives it from its own cwd. This hook runs in the dispatching session's
-# cwd/branch; the script may run from a different worktree entirely (the
-# repo's own using-git-worktrees / agent-team-execution pattern) and reads
-# ITS cwd/branch instead. That mismatch is silent and safe — the read simply
-# misses and the derivation falls through to "asserted" (D3) — but it means
-# this write is usually invisible to that read in exactly the workflow this
-# hook was built for. See design.md Trade-offs.
+if [ "${_PAIR_OK}" = "true" ] && [ -n "${_AGENT_ID}" ]; then
+    # The key binds the credit to a (repo, branch) pair. Stored at dispatch so
+    # the completion side can refuse to credit a branch the reviewer never saw:
+    # a backgrounded reviewer finishes on the parent session's clock, and that
+    # session is free to check out something else meanwhile.
+    _PAIR_KEY="$(branch_ledger_key 2>/dev/null)" || _PAIR_KEY=""
+    if [ -n "${_PAIR_KEY}" ]; then
+        # HALF ONE, written BEFORE reading the other half.
+        reviewer_pairing_note_dispatch "${_SID}" "${_AGENT_ID}" "${_PAIR_KEY}" || true
+        # HALF TWO: did this agent already finish? (foreground ordering)
+        if reviewer_pairing_has_complete "${_SID}" "${_AGENT_ID}"; then
+            branch_ledger_record "reviewer-returned" 2>/dev/null || true
+        fi
+    fi
+fi
 
 exit 0

--- a/hooks/session-start-hook.sh
+++ b/hooks/session-start-hook.sh
@@ -150,7 +150,7 @@ find "${HOME}/.claude" -maxdepth 1 \
     \( -name '.skill-composition-state-*' -o -name '.skill-openspec-state-*' \
        -o -name '.skill-compact-pending-*' \
        -o -name '.skill-invocation-evidence-*' -o -name '.skill-phase-attest-*' \
-       -o -name '.skill-reviewer-dispatch-*' \) \
+       -o -name '.skill-reviewer-dispatch-*' -o -name '.skill-reviewer-complete-*' \) \
     -mtime +"${_STATE_RETENTION_DAYS}" \
     ! -name "*-state-${_SESSION_TOKEN}" \
     ! -name ".skill-compact-pending-${_SESSION_TOKEN}" \
@@ -158,6 +158,7 @@ find "${HOME}/.claude" -maxdepth 1 \
     ! -name ".skill-invocation-evidence-sha-${_SESSION_TOKEN}" \
     ! -name ".skill-phase-attest-${_SESSION_TOKEN}" \
     ! -name ".skill-reviewer-dispatch-${_SESSION_TOKEN}" \
+    ! -name ".skill-reviewer-complete-${_SESSION_TOKEN}" \
     -exec rm -f {} + 2>/dev/null || true
 
 # Cap the phase-gate telemetry log (F6): every skill-gate.sh / openspec-guard.sh

--- a/hooks/session-start-hook.sh
+++ b/hooks/session-start-hook.sh
@@ -149,13 +149,15 @@ _STATE_RETENTION_DAYS=$(( _STATE_RETENTION_SECS / 86400 ))
 find "${HOME}/.claude" -maxdepth 1 \
     \( -name '.skill-composition-state-*' -o -name '.skill-openspec-state-*' \
        -o -name '.skill-compact-pending-*' \
-       -o -name '.skill-invocation-evidence-*' -o -name '.skill-phase-attest-*' \) \
+       -o -name '.skill-invocation-evidence-*' -o -name '.skill-phase-attest-*' \
+       -o -name '.skill-reviewer-dispatch-*' \) \
     -mtime +"${_STATE_RETENTION_DAYS}" \
     ! -name "*-state-${_SESSION_TOKEN}" \
     ! -name ".skill-compact-pending-${_SESSION_TOKEN}" \
     ! -name ".skill-invocation-evidence-${_SESSION_TOKEN}" \
     ! -name ".skill-invocation-evidence-sha-${_SESSION_TOKEN}" \
     ! -name ".skill-phase-attest-${_SESSION_TOKEN}" \
+    ! -name ".skill-reviewer-dispatch-${_SESSION_TOKEN}" \
     -exec rm -f {} + 2>/dev/null || true
 
 # Cap the phase-gate telemetry log (F6): every skill-gate.sh / openspec-guard.sh

--- a/hooks/session-start-hook.sh
+++ b/hooks/session-start-hook.sh
@@ -150,7 +150,8 @@ find "${HOME}/.claude" -maxdepth 1 \
     \( -name '.skill-composition-state-*' -o -name '.skill-openspec-state-*' \
        -o -name '.skill-compact-pending-*' \
        -o -name '.skill-invocation-evidence-*' -o -name '.skill-phase-attest-*' \
-       -o -name '.skill-reviewer-dispatch-*' -o -name '.skill-reviewer-complete-*' \) \
+       -o -name '.skill-reviewer-dispatch-*' -o -name '.skill-reviewer-complete-*' \
+       -o -name '.skill-reviewer-saturated-*' \) \
     -mtime +"${_STATE_RETENTION_DAYS}" \
     ! -name "*-state-${_SESSION_TOKEN}" \
     ! -name ".skill-compact-pending-${_SESSION_TOKEN}" \
@@ -159,6 +160,7 @@ find "${HOME}/.claude" -maxdepth 1 \
     ! -name ".skill-phase-attest-${_SESSION_TOKEN}" \
     ! -name ".skill-reviewer-dispatch-${_SESSION_TOKEN}" \
     ! -name ".skill-reviewer-complete-${_SESSION_TOKEN}" \
+    ! -name ".skill-reviewer-saturated-${_SESSION_TOKEN}" \
     -exec rm -f {} + 2>/dev/null || true
 
 # Cap the phase-gate telemetry log (F6): every skill-gate.sh / openspec-guard.sh

--- a/openspec/changes/reviewer-completion-evidence/design.md
+++ b/openspec/changes/reviewer-completion-evidence/design.md
@@ -2,148 +2,214 @@
 
 ## Architecture
 
-Two hooks, one exact key, no heuristic between them.
+Two hooks observe two halves of one fact. Neither can credit alone, and
+**neither is guaranteed to run first**.
 
 ```
-Agent dispatch                              Subagent finishes
-      |                                            |
-PostToolUse ^(Task|Agent)$                    SubagentStop
-reviewer-evidence-hook.sh                reviewer-completion-hook.sh
-      |                                            |
-  predicate on tool_input.description        agent_type in allowlist? -> credit
-  (unchanged, 9/9 @ 1/7)                     agent_type == general-purpose?
-      |                                            |
-  reviewer? -> record `reviewer-ran`           look up agent_id  <----+
-            -> append agent_id to             in the pairing file     |
-               ~/.claude/.skill-reviewer-dispatch-session-<sid>  -----+
-                                                   |
-                                             credit `reviewer-returned`
+   PostToolUse ^(Task|Agent)$                    SubagentStop
+   reviewer-evidence-hook.sh              reviewer-completion-hook.sh
+            |                                          |
+   classify (description predicate                observe completion
+   + subagent_type allowlist)                     (non-empty final message)
+            |                                          |
+   record `reviewer-ran`                               |
+            |                                          |
+   [HALF 1] write  <agent_id> <ledger_key>      [HALF 1] write <agent_id>
+            |                                          |
+   [HALF 2] is agent_id in the                 [HALF 2] is agent_id in the
+            completion file?  ---------------.          dispatch file, with a
+            |                                 \         MATCHING ledger key?
+            +--> yes: record `reviewer-returned` <------+
+                        (whichever hook ran second)
 ```
 
 Both hooks read `session_id` from **their own payload**, and the two events
-carry the identical value (measured in one run; it also equals the transcript
-basename, so the filename is `_SESSION_TOKEN`-shaped and the session-start GC
-excludes the live session with a plain `! -name` match).
+carry the identical value (measured; it also equals the transcript basename, so
+the filenames are `_SESSION_TOKEN`-shaped and session-start's GC excludes the
+live session with a plain `! -name` match). This is deliberately **not**
+`resolve_own_session_token` — that resolver exists for model-Bash-turn writers,
+which have no payload, and its singleton fallback is the last-writer-wins
+scatter behind #51/#97/#122/#131/#133/#151/#156. Here both sides are
+payload-driven within one session, so symmetry holds by construction.
 
-This is deliberately **not** `resolve_own_session_token`. That resolver exists
-for model-Bash-turn writers, which have no payload; its singleton fallback is
-the last-writer-wins scatter behind #51/#97/#122/#131/#133/#151/#156. Here both
-sides are payload-driven within one session, so symmetry holds by construction
-rather than by convention — and cell (i) drives the real writer to prove it,
-instead of asserting it against a hand-written fixture.
+`hooks/lib/reviewer-pairing.sh` owns the file format and key derivation so the
+writer and reader cannot drift — the same reason CLAUDE.md insists a third
+caller of `_advisory_text_for_action` must call it rather than re-derive it.
+
+## Why the join is symmetric — the measurement that killed the first design
+
+The first cut was one-directional: dispatch writes, completion reads. It is a
+systematic no-op for foreground dispatches. Measured end-to-end with both real
+hooks registered and timestamped, on CLI 2.1.236:
+
+| dispatch mode | firing order |
+|---|---|
+| `run_in_background: true` | dispatch **1.44s before** completion |
+| `run_in_background: false` | completion **~30ms before** dispatch (3 of 3) |
+
+The live probe on the one-directional build recorded `reviewer-ran` and **no**
+`reviewer-returned` for a foreground reviewer. After the symmetric rewrite, the
+identical probe — same firing order, completion still 462ms first — records
+both. This is why every credit path in the test matrix is asserted in **both**
+orders: a one-directional design passes the background order cleanly.
+
+The general lesson, and the reason the probe existed at all: two hooks on two
+events are a distributed system, and "the dispatch obviously happens before the
+completion" is a statement about the world, not about hook delivery.
 
 ## Why a dispatch-time writer at all
 
-`SubagentStop` carries `agent_type` but not the dispatch `description`. Three
-ways to recover reviewer-ness were considered.
+Three ways to identify a `general-purpose` reviewer at completion were
+considered.
 
-1. **Apply the existing predicate to the subagent's task prompt.** Rejected.
-   The prompt is reachable (`agent_transcript_path` exists at hook time and its
-   first `user` record is the prompt verbatim), but the predicate
+1. **Apply the existing predicate to the subagent's task prompt.** Rejected. The
+   prompt is reachable (`agent_transcript_path` exists at hook time and its first
+   `user` record is the prompt verbatim), but the predicate
    `*[Rr]eview|*[Rr]eview[!a-zA-Z]*` was **fitted on a short `description`
-   label**. Its second arm matches "review" anywhere followed by a non-letter,
-   so against multi-paragraph prompt text it structurally degenerates into the
-   substring variant that measured 4/7 false positives. Lifting it "verbatim"
-   onto a different population would ship exactly the widening that variant was
-   rejected for, silently — the predicate would look unchanged in the diff.
-
-2. **Read the parent transcript to find the dispatch record.** Rejected, and
-   this one is closed by measurement rather than judgement. Instrumented from
-   inside the hook: at `SubagentStop` time the parent transcript contained
-   **zero** lines mentioning `agent_id` (18-line parent, 4-line subagent
-   transcript readable). The `tool_result` carrying `agentId` is written after
-   the event fires, so the link exists only post-hoc.
-
-3. **Write the pairing at dispatch.** Chosen, by elimination — (2) proves no
-   reader-side reconstruction exists.
+   label**. Its second arm matches "review" anywhere followed by a non-letter, so
+   against multi-paragraph prompt text it structurally degenerates into the
+   substring variant that measured 4/7 false positives — the widening that
+   variant was rejected for, shipped silently, with the predicate looking
+   unchanged in the diff.
+2. **Read the parent transcript to find the dispatch record.** Rejected by
+   measurement, not judgement: instrumented from inside the hook, at
+   `SubagentStop` time the parent transcript contained **zero** lines mentioning
+   `agent_id` (18-line parent; the 4-line subagent transcript was readable). The
+   `tool_result` carrying `agentId` is written after the event fires.
+3. **Pair against what the dispatch hook already classified.** Chosen — (2)
+   proves no reader-side reconstruction exists.
 
 ## Trade-offs
 
 **A lookup MISS records nothing.** The alternative — a weaker milestone on a
-miss — was rejected on two grounds. A miss is indistinguishable from a genuine
-reviewer whose dispatch went unrecorded (older plugin, hook disabled, GC'd
-pairing), so the weaker record could not be interpreted; and the missing
-population is dominated by ordinary implementation subagents, so it would be
-mostly noise wearing an evidence label. Under-recording is the safe direction
-for a signal whose whole purpose is fidelity.
+miss — is indistinguishable from a genuine reviewer whose dispatch went
+unrecorded, and the missing population is dominated by ordinary implementation
+subagents, so it would be mostly noise wearing an evidence label. Under-
+recording is the safe direction for a signal whose purpose is fidelity.
+
+**But a miss must not be invisible.** A refused credit leaves a
+`# branch-mismatch` line in the completion file. This is not decoration: the
+foreground ordering defect produced no trace anywhere, which is precisely why it
+nearly shipped. "No reviewer ran" and "a reviewer ran and the join was refused"
+must not look identical from the outside — the same reason the IMPLEMENT leg
+splits `missing` from `cannot_check`.
 
 **An empty `last_assistant_message` is not a return.** A reviewer that emitted
-nothing — interrupted, crashed — did not produce a review. This under-credits an
-interrupted reviewer, again the safe direction.
+nothing — interrupted, crashed — did not produce a review, and its completion
+half is not published, so a later dispatch cannot join against a crash. This
+under-credits an interrupted reviewer: the safe direction.
 
 **The reviewer's output text is deliberately NOT recorded.** The payload carries
 it inline and it would make the strongest-looking evidence, but it is unbounded
 model output that can quote the diff, secrets, or private memory content into a
-file that outlives the session. This repo already ships `hooks/publish-guard.sh`
-because that class of content leaking outbound is a known risk; the ledger keeps
-storing a sha and a timestamp.
+file that outlives the session. `hooks/publish-guard.sh` and
+`scripts/memory-leak-check.sh` exist because that class of leak is a known risk
+here, and that scanner watches only `~/.claude/projects/*/memory/` — a ledger
+holding raw reviewer text would be a second surface it does not know exists. The
+IMPLEMENT shadow corpus settled the same trade the same way: "raw command text is
+never written; `transcript_path` is the adjudication pointer."
 
-**A size ceiling, not a trim.** Parallel dispatches in one turn run their hooks
-concurrently, so a read-modify-write rotation would race. Appending short lines
-and refusing to append past 64KB drops new records under pathological load
-rather than corrupting existing ones.
+**A size ceiling, not a trim.** Parallel dispatches run their hooks
+concurrently, so a read-modify-write rotation would be a real race, while a short
+`printf >>` interleaves safely at line granularity. Dropping new records past the
+ceiling is safer than corrupting existing ones. The TOCTOU between the size check
+and the append can overshoot slightly; that is inherent to bounding a
+pathological case, not a correctness bug.
 
-**Ordering is load-bearing, and the first draft got it wrong.** The pairing
-write initially sat above `branch_ledger_record "reviewer-ran"`. Under that
-file's `trap 'exit 0' ERR`, `wc -c < <missing file>` is a redirection failure
-that `2>/dev/null` does not suppress, so the hook exited 0 in silence and
-stopped recording the **pre-existing** milestone. Caught by cell (i3), which
-existed only because the end-to-end cell drives the real writer. New
-best-effort work goes below the thing that must not be lost — this is the
-#137/#198 class arriving from a new direction.
+**Ordering inside `reviewer-evidence-hook.sh` is load-bearing.** The pairing work
+runs AFTER `branch_ledger_record "reviewer-ran"`, never before. Under that file's
+`trap 'exit 0' ERR`, `wc -c < <missing file>` is a redirection failure that
+`2>/dev/null` does not suppress; the first draft put the pairing block above the
+record, and the hook exited 0 in silence having deleted the pre-existing
+milestone. New best-effort work goes below the thing that must not be lost.
+
+**Every call into the pairing lib is `|| true`-guarded on a path that must
+continue.** `reviewer_pairing_note_complete` returns non-zero whenever the append
+does not happen (ceiling reached, unwritable `~/.claude`), and unguarded under
+`trap 'exit 0' ERR` that terminates the hook *before* the join — silently ending
+every credit for the rest of the session. Found by a mutation whose real fault
+was masked by that very early exit.
 
 **Known misses, inherited and unfixed.** `branch_ledger_key` is
 `sha1(origin remote URL, branch)`, so a review recorded on a task branch and a
-push made from an integration branch do not share a key — which is the normal
-shape of this repo's own `agent-team-execution` pattern — and a detached HEAD
-re-keys on every commit. Misses are safe (a reader finds no record) but a
-missing record must never be read as "no review happened".
+push made from an integration branch do not share a key — the normal shape of
+this repo's own `agent-team-execution` pattern — and a detached HEAD re-keys on
+every commit. Misses are safe, but a missing record must never be read as "no
+review happened".
+
+**Unmeasured, and stated as such.** `agent_id` uniqueness within a session is
+not proven; 8 ids observed across the probes were 17 random hex characters and
+all distinct, including 3 dispatched in one session, so reuse is implausible but
+not excluded. Reuse would require a collision *and* a matching branch key to
+produce a false credit. `isolation: "worktree"` and `isolation: "remote"`
+dispatches were not probed — `session-token.sh` flags the same gap for the
+adjacent mechanism — so `session_id` symmetry is established for local
+dispatches only. A pairing record written in the pre-join format degrades to a
+miss rather than a false credit (the key field is empty, and an empty key never
+compares equal), which is the correct direction for a format change.
 
 ## Dissenting views
 
 **"This is a better-looking attestation, not better evidence."** Partly true and
 stated in the proposal: observed completion does not establish that the output
 was a review, that it examined this diff, or that anything was acted on. The
-defence is narrow and specific — it is strictly more than the status quo (a
-`Skill()` return at instruction-load time, which witnesses nothing) and strictly
-more than observed dispatch (which credits a reviewer that crashed on spawn).
-It is not a quality gate and the code says so in the header.
+defence is narrow: it is strictly more than a `Skill()` return at
+instruction-load time (which witnesses nothing) and strictly more than observed
+dispatch (which credits a reviewer that crashed on spawn). It is not a quality
+gate and the code says so in its header.
 
-**"Remedy cost, not predicate strictness, is the binding constraint."** The
-competing thesis is that the gate is already accurate, its escape (a human
-typing `!`) is free and unrecordable, and tightening a gate whose escape is free
-mostly buys more escaping. This change is deliberately the one candidate that
-does not fight that thesis: it raises fidelity while **lowering** remedy cost,
+**"Remedy cost, not predicate strictness, is the binding constraint."** Endorsed,
+including by the sparring review, and this change is deliberately consistent with
+it rather than in tension: it raises fidelity while **lowering** remedy cost,
 because the dispatch already happens in compliant sessions and credit becomes
-automatic with no extra CLI call. If the thesis is right, this change is still
-the right shape; what it forecloses is any follow-up that raises the cost of
-compliance.
+automatic with no extra CLI call. Sharpened form, which is the more accurate
+framing: this is not tightening a screw past where it buys anything — the current
+gate is satisfied by an event carrying *less* information than "the reviewer
+started running", so this closes a gap in the free ride rather than raising a bar
+anyone must clear.
 
 **"Is any predicate over review findings non-theatre when one agent wrote both
-the code and the review?"** Held open, deliberately, and it must be answered
-before any deny-flip — not before this increment, which wires no gate. The
-honest position today: a predicate over *findings* (count, severity, resolution)
-is gameable by the same model that authored the code, so it measures compliance
-theatre rather than review quality. What is not gameable by prose alone is that
-a **second context** had to be spun up and had to produce output — that is a
-real resource cost, not a claim. This change buys exactly that and nothing more,
-which is why the label is "observed completion".
+the code and the review?"** No — and this was the sparring review's answer too,
+without hedging. Any classifier over what the reviewer *said* (keyword density,
+a `Findings:` header, file:line citations, absence of "LGTM") is satisfiable by
+boilerplate cheaper than a real review the moment the dispatching model has an
+incentive to unblock; citations are especially weak, since the model wrote the
+diff and can cite plausible lines without having reasoned about them. This repo
+has already paid for that lesson once, and #205's adjudication rule needed an
+actual *reproduction* step precisely because content review was untrustworthy
+even for human-originated findings.
+
+The narrow exception worth recording so "no content predicate works" is not
+overstated into "no further signal is possible": a **behavioural** check on the
+reviewer's own transcript — did its tool-call trace touch the files under review
+before it emitted a final message — is not grading findings. It is still gameable
+by an instructed rubber-stamp, but it is harder to fabricate than zero-effort
+text and does not inherit the self-grading problem. Possible next increment, in
+the same procedural spirit. Not built here.
 
 ## Decisions
 
 - **D1.** Record `reviewer-returned` as a new milestone rather than
-  strengthening `reviewer-ran`. Dispatch and completion are different facts, and
-  collapsing them would make existing `reviewer-ran` records silently mean
-  something they never measured.
-- **D2.** No gate reads the new milestone in this change. Pinned by a test cell
-  asserting `openspec-guard.sh` does not mention it. The deny-flip decision
-  belongs to a shadow corpus, as with the IMPLEMENT leg.
-- **D3.** Not in `_GATE_ENFORCE_LIBS`. That list drives both the session-start
+  strengthening `reviewer-ran`. Dispatch and completion are different facts;
+  collapsing them would make existing records silently mean something they never
+  measured.
+- **D2.** No gate reads the new milestone in this change. Pinned by a cell
+  asserting `openspec-guard.sh` does not mention it. Any future deny-flip must be
+  framed as narrowly as the IMPLEMENT leg's — "closes a measured completion gap",
+  never "review quality is now assured".
+- **D3.** Not in `_GATE_ENFORCE_LIBS`. That list drives the session-start
   precondition canary and the drift manifest; a diagnostic recorder joining it
   would make a missing recorder announce as a degraded gate. Pinned by a cell.
-- **D4.** The allowlist arm needs no pairing, so it keeps working when the
-  dispatch hook did not run (older plugin, hook disabled). Pinned by cell (a),
-  which runs with no pairing file present at all.
-- **D5.** `session_id` is validated as a single path-safe segment on both sides.
-  The value is harness-supplied, but a recorder must not be the component that
+- **D4.** Classification for BOTH arms lives in the dispatch hook. The earlier
+  design let the allowlist arm credit at completion with no dispatch record,
+  which was simpler but left the branch-binding hole open for exactly the
+  backgrounded case where it bites.
+- **D5.** `session_id` and `agent_id` are validated as single path-safe segments.
+  The values are harness-supplied, but a recorder must not be the component that
   turns a surprising value into a read or write outside `~/.claude`.
+- **D6.** Three guards are knowingly redundant and kept: the `[ -n "${_DKEY}" ]`
+  check (the branch comparison also rejects an empty key), the `[ -f ]` before
+  `wc -c` (the `|| bytes=0` is what makes it safe), and `|| true` on
+  `note_mismatch` (the hook exits immediately after either way). No test can
+  catch their removal, and each says so in a comment rather than being presented
+  as covered.

--- a/openspec/changes/reviewer-completion-evidence/design.md
+++ b/openspec/changes/reviewer-completion-evidence/design.md
@@ -134,6 +134,18 @@ holding raw reviewer text would be a second surface it does not know exists. The
 IMPLEMENT shadow corpus settled the same trade the same way: "raw command text is
 never written; `transcript_path` is the adjudication pointer."
 
+**The size ceiling is a real limit, and exhausting it is silent.** Once the
+completion file is full, `note_mismatch` is suppressed by the same condition —
+so the diagnostic that exists to keep a refused credit visible disappears exactly
+when the join starts failing, restoring the indistinguishability this design says
+must not exist. The failure is also ORDER-ASYMMETRIC: the background order keeps
+working off the separate dispatch file, so it degrades rather than stopping
+cleanly. The completion file records EVERY subagent completion (correct — it is
+the join key), which makes it fan-out-driven in exactly the agent-team sessions
+this evidence is for. Mitigated by raising the ceiling to 1 MiB (~26k
+completions), not by pruning, which would need the read-modify-write this design
+avoids. Pinned as a documented miss by cell (j3) rather than left implicit.
+
 **A size ceiling, not a trim.** Parallel dispatches run their hooks
 concurrently, so a read-modify-write rotation would be a real race, while a short
 `printf >>` interleaves safely at line granularity. Dropping new records past the
@@ -165,8 +177,13 @@ review happened".
 **Unmeasured, and stated as such.** `agent_id` uniqueness within a session is
 not proven; 8 ids observed across the probes were 17 random hex characters and
 all distinct, including 3 dispatched in one session, so reuse is implausible but
-not excluded. Reuse would require a collision *and* a matching branch key to
-produce a false credit. `isolation: "worktree"` WAS probed after
+not excluded. Reuse now requires a collision *and* a matching branch key on
+either half. That was NOT true when first written: the dispatch-side join
+credited on membership alone, so a collision ALONE recorded `reviewer-returned`
+at spawn time for a reviewer that had produced nothing. Caught in review,
+reproduced against the real hooks with a positive control, and closed by storing
+the ledger key in the completion half too. A doc asserting double protection over
+a single-guarded path is worse than no claim — it stops the next reader looking. `isolation: "worktree"` WAS probed after
 `session-token.sh` flagged the same gap for the adjacent mechanism: both halves
 land under the same `session_id`, the ledger key matches (both hooks run in the
 parent session's cwd, not the worktree), and the credit is recorded.
@@ -233,9 +250,17 @@ the same procedural spirit. Not built here.
 - **D5.** `session_id` and `agent_id` are validated as single path-safe segments.
   The values are harness-supplied, but a recorder must not be the component that
   turns a surprising value into a read or write outside `~/.claude`.
-- **D6.** Three guards are knowingly redundant and kept: the `[ -n "${_DKEY}" ]`
-  check (the branch comparison also rejects an empty key), the `[ -f ]` before
-  `wc -c` (the `|| bytes=0` is what makes it safe), and `|| true` on
-  `note_mismatch` (the hook exits immediately after either way). No test can
-  catch their removal, and each says so in a comment rather than being presented
-  as covered.
+- **D6.** TWO guards are knowingly redundant and kept: the `[ -f ]` before
+  `wc -c` (the `|| bytes=0` is the live handler) and `|| true` on
+  `note_mismatch` (the hook exits immediately after either way, so the two paths
+  are observably identical). No test can catch their removal, and each says so in
+  a comment rather than being presented as covered.
+
+  A THIRD was claimed redundant here and was not. `[ -n "${_DKEY}" ] || exit 0`
+  is redundant *for crediting* — the branch comparison also rejects an empty key
+  — but removing it is observable and harmful: the hook then fabricates a
+  `# branch-mismatch` line for every ordinary subagent completion. That is a
+  FALSE diagnostic ("never dispatched as a reviewer" is not "branch mismatch")
+  and it multiplies the completion file's growth rate, bringing the ceiling below
+  closer. Caught in review; the gap was that only the PRESENCE of a mismatch line
+  was ever asserted, never its absence. Cell (j4) closes it.

--- a/openspec/changes/reviewer-completion-evidence/design.md
+++ b/openspec/changes/reviewer-completion-evidence/design.md
@@ -1,0 +1,149 @@
+# Design: observed reviewer completion
+
+## Architecture
+
+Two hooks, one exact key, no heuristic between them.
+
+```
+Agent dispatch                              Subagent finishes
+      |                                            |
+PostToolUse ^(Task|Agent)$                    SubagentStop
+reviewer-evidence-hook.sh                reviewer-completion-hook.sh
+      |                                            |
+  predicate on tool_input.description        agent_type in allowlist? -> credit
+  (unchanged, 9/9 @ 1/7)                     agent_type == general-purpose?
+      |                                            |
+  reviewer? -> record `reviewer-ran`           look up agent_id  <----+
+            -> append agent_id to             in the pairing file     |
+               ~/.claude/.skill-reviewer-dispatch-session-<sid>  -----+
+                                                   |
+                                             credit `reviewer-returned`
+```
+
+Both hooks read `session_id` from **their own payload**, and the two events
+carry the identical value (measured in one run; it also equals the transcript
+basename, so the filename is `_SESSION_TOKEN`-shaped and the session-start GC
+excludes the live session with a plain `! -name` match).
+
+This is deliberately **not** `resolve_own_session_token`. That resolver exists
+for model-Bash-turn writers, which have no payload; its singleton fallback is
+the last-writer-wins scatter behind #51/#97/#122/#131/#133/#151/#156. Here both
+sides are payload-driven within one session, so symmetry holds by construction
+rather than by convention — and cell (i) drives the real writer to prove it,
+instead of asserting it against a hand-written fixture.
+
+## Why a dispatch-time writer at all
+
+`SubagentStop` carries `agent_type` but not the dispatch `description`. Three
+ways to recover reviewer-ness were considered.
+
+1. **Apply the existing predicate to the subagent's task prompt.** Rejected.
+   The prompt is reachable (`agent_transcript_path` exists at hook time and its
+   first `user` record is the prompt verbatim), but the predicate
+   `*[Rr]eview|*[Rr]eview[!a-zA-Z]*` was **fitted on a short `description`
+   label**. Its second arm matches "review" anywhere followed by a non-letter,
+   so against multi-paragraph prompt text it structurally degenerates into the
+   substring variant that measured 4/7 false positives. Lifting it "verbatim"
+   onto a different population would ship exactly the widening that variant was
+   rejected for, silently — the predicate would look unchanged in the diff.
+
+2. **Read the parent transcript to find the dispatch record.** Rejected, and
+   this one is closed by measurement rather than judgement. Instrumented from
+   inside the hook: at `SubagentStop` time the parent transcript contained
+   **zero** lines mentioning `agent_id` (18-line parent, 4-line subagent
+   transcript readable). The `tool_result` carrying `agentId` is written after
+   the event fires, so the link exists only post-hoc.
+
+3. **Write the pairing at dispatch.** Chosen, by elimination — (2) proves no
+   reader-side reconstruction exists.
+
+## Trade-offs
+
+**A lookup MISS records nothing.** The alternative — a weaker milestone on a
+miss — was rejected on two grounds. A miss is indistinguishable from a genuine
+reviewer whose dispatch went unrecorded (older plugin, hook disabled, GC'd
+pairing), so the weaker record could not be interpreted; and the missing
+population is dominated by ordinary implementation subagents, so it would be
+mostly noise wearing an evidence label. Under-recording is the safe direction
+for a signal whose whole purpose is fidelity.
+
+**An empty `last_assistant_message` is not a return.** A reviewer that emitted
+nothing — interrupted, crashed — did not produce a review. This under-credits an
+interrupted reviewer, again the safe direction.
+
+**The reviewer's output text is deliberately NOT recorded.** The payload carries
+it inline and it would make the strongest-looking evidence, but it is unbounded
+model output that can quote the diff, secrets, or private memory content into a
+file that outlives the session. This repo already ships `hooks/publish-guard.sh`
+because that class of content leaking outbound is a known risk; the ledger keeps
+storing a sha and a timestamp.
+
+**A size ceiling, not a trim.** Parallel dispatches in one turn run their hooks
+concurrently, so a read-modify-write rotation would race. Appending short lines
+and refusing to append past 64KB drops new records under pathological load
+rather than corrupting existing ones.
+
+**Ordering is load-bearing, and the first draft got it wrong.** The pairing
+write initially sat above `branch_ledger_record "reviewer-ran"`. Under that
+file's `trap 'exit 0' ERR`, `wc -c < <missing file>` is a redirection failure
+that `2>/dev/null` does not suppress, so the hook exited 0 in silence and
+stopped recording the **pre-existing** milestone. Caught by cell (i3), which
+existed only because the end-to-end cell drives the real writer. New
+best-effort work goes below the thing that must not be lost — this is the
+#137/#198 class arriving from a new direction.
+
+**Known misses, inherited and unfixed.** `branch_ledger_key` is
+`sha1(origin remote URL, branch)`, so a review recorded on a task branch and a
+push made from an integration branch do not share a key — which is the normal
+shape of this repo's own `agent-team-execution` pattern — and a detached HEAD
+re-keys on every commit. Misses are safe (a reader finds no record) but a
+missing record must never be read as "no review happened".
+
+## Dissenting views
+
+**"This is a better-looking attestation, not better evidence."** Partly true and
+stated in the proposal: observed completion does not establish that the output
+was a review, that it examined this diff, or that anything was acted on. The
+defence is narrow and specific — it is strictly more than the status quo (a
+`Skill()` return at instruction-load time, which witnesses nothing) and strictly
+more than observed dispatch (which credits a reviewer that crashed on spawn).
+It is not a quality gate and the code says so in the header.
+
+**"Remedy cost, not predicate strictness, is the binding constraint."** The
+competing thesis is that the gate is already accurate, its escape (a human
+typing `!`) is free and unrecordable, and tightening a gate whose escape is free
+mostly buys more escaping. This change is deliberately the one candidate that
+does not fight that thesis: it raises fidelity while **lowering** remedy cost,
+because the dispatch already happens in compliant sessions and credit becomes
+automatic with no extra CLI call. If the thesis is right, this change is still
+the right shape; what it forecloses is any follow-up that raises the cost of
+compliance.
+
+**"Is any predicate over review findings non-theatre when one agent wrote both
+the code and the review?"** Held open, deliberately, and it must be answered
+before any deny-flip — not before this increment, which wires no gate. The
+honest position today: a predicate over *findings* (count, severity, resolution)
+is gameable by the same model that authored the code, so it measures compliance
+theatre rather than review quality. What is not gameable by prose alone is that
+a **second context** had to be spun up and had to produce output — that is a
+real resource cost, not a claim. This change buys exactly that and nothing more,
+which is why the label is "observed completion".
+
+## Decisions
+
+- **D1.** Record `reviewer-returned` as a new milestone rather than
+  strengthening `reviewer-ran`. Dispatch and completion are different facts, and
+  collapsing them would make existing `reviewer-ran` records silently mean
+  something they never measured.
+- **D2.** No gate reads the new milestone in this change. Pinned by a test cell
+  asserting `openspec-guard.sh` does not mention it. The deny-flip decision
+  belongs to a shadow corpus, as with the IMPLEMENT leg.
+- **D3.** Not in `_GATE_ENFORCE_LIBS`. That list drives both the session-start
+  precondition canary and the drift manifest; a diagnostic recorder joining it
+  would make a missing recorder announce as a degraded gate. Pinned by a cell.
+- **D4.** The allowlist arm needs no pairing, so it keeps working when the
+  dispatch hook did not run (older plugin, hook disabled). Pinned by cell (a),
+  which runs with no pairing file present at all.
+- **D5.** `session_id` is validated as a single path-safe segment on both sides.
+  The value is harness-supplied, but a recorder must not be the component that
+  turns a surprising value into a read or write outside `~/.claude`.

--- a/openspec/changes/reviewer-completion-evidence/design.md
+++ b/openspec/changes/reviewer-completion-evidence/design.md
@@ -142,9 +142,36 @@ must not exist. The failure is also ORDER-ASYMMETRIC: the background order keeps
 working off the separate dispatch file, so it degrades rather than stopping
 cleanly. The completion file records EVERY subagent completion (correct — it is
 the join key), which makes it fan-out-driven in exactly the agent-team sessions
-this evidence is for. Mitigated by raising the ceiling to 1 MiB (~26k
-completions), not by pruning, which would need the read-modify-write this design
-avoids. Pinned as a documented miss by cell (j3) rather than left implicit.
+this evidence is for. Mitigated two ways. Raising the ceiling to 1 MiB (~26k
+completions) makes the state rarer — but rarer is not visible, and a rarer silent
+failure is harder to diagnose when it finally happens. So the refusal also writes
+a SATURATION MARKER.
+
+The marker exists because the requirement is not really "announce" — a recorder
+must stay silent — it is that **a reader can tell the two states apart**.
+Saturation is `cannot_check`, not `missing`, and CLAUDE.md is explicit for the
+IMPLEMENT shadow leg that collapsing the second into the first "makes a
+false_block look like a true_catch" and biases the reading toward clearing. This
+is the identical error in the identical direction: an absent `reviewer-returned`
+would read as "the reviewer did not return" when the truth is "the recorder
+stopped recording".
+
+Shape: one whole-file overwrite of a fixed-size payload — `branch_ledger_record`'s
+per-milestone design, chosen there for the same reason. No read-modify-write, so
+concurrent hooks cannot race; bounded by construction, so the marker cannot
+itself saturate and need a marker of its own. Written ONLY for the ceiling
+refusal, never for a failed write: an unwritable `~/.claude` cannot record a
+marker either, so that cause is structurally unable to announce and must not
+pretend to — which is why `_reviewer_pairing_append` returns 2 for the ceiling
+and 1 for everything else.
+
+Deliberately NOT routed through `openspec-guard.sh`'s `_DEGRADED_MSG`. That
+channel means "a gate-enforcement leg fell open", and a saturated recorder
+stopped RECORDING, not ENFORCING. Putting it there would be the mirror of the
+mistake #198 warns about: replacing an under-report with a confident over-report
+that tells the user to distrust a gate which is still holding.
+
+Cell (j3) still pins the residual foreground miss as a documented miss.
 
 **A size ceiling, not a trim.** Parallel dispatches run their hooks
 concurrently, so a read-modify-write rotation would be a real race, while a short
@@ -178,7 +205,14 @@ review happened".
 not proven; 8 ids observed across the probes were 17 random hex characters and
 all distinct, including 3 dispatched in one session, so reuse is implausible but
 not excluded. Reuse now requires a collision *and* a matching branch key on
-either half. That was NOT true when first written: the dispatch-side join
+either half — but those two conjuncts are NOT independent, and pricing them as
+if they were would overstate the protection. A session normally stays on one
+branch, so a SAME-BRANCH id collision still credits `reviewer-returned` at spawn
+time for a reviewer that has produced nothing. That variant is open and is the
+ordinary case; what the binding actually closes is the cross-branch and
+cross-repo one. No clean ordering constraint exists to close the rest, and the
+residual risk rests entirely on ids being 17 random hex characters — which is
+measured only as "8 observed, all distinct", not proven. That was NOT true when first written: the dispatch-side join
 credited on membership alone, so a collision ALONE recorded `reviewer-returned`
 at spawn time for a reviewer that had produced nothing. Caught in review,
 reproduced against the real hooks with a positive control, and closed by storing
@@ -250,6 +284,17 @@ the same procedural spirit. Not built here.
 - **D5.** `session_id` and `agent_id` are validated as single path-safe segments.
   The values are harness-supplied, but a recorder must not be the component that
   turns a surprising value into a read or write outside `~/.claude`.
+- **D7.** The pairing store is two append-only files with a size ceiling, not a
+  directory of one file per agent id. The directory form would remove the ceiling
+  entirely, remove the TOCTOU, remove `awk` from a hot path, and close the
+  reader-side charset question by construction — it is the better design and is
+  recorded here as the recommended next shape. It is declined now for one
+  specific reason worth writing down: `session-start-hook.sh` prunes this family
+  with `find … -exec rm -f {} +`, which does NOT remove directories, so a
+  directory-shaped family would leak every dead session's pairing dir forever,
+  silently. Cells (p) and C6 would NOT catch that — (p) asserts glob and
+  exclusion TEXT, and C6 plants FILES. Whoever takes this must change the GC and
+  make C6 plant a directory.
 - **D6.** TWO guards are knowingly redundant and kept: the `[ -f ]` before
   `wc -c` (the `|| bytes=0` is the live handler) and `|| true` on
   `note_mismatch` (the hook exits immediately after either way, so the two paths

--- a/openspec/changes/reviewer-completion-evidence/design.md
+++ b/openspec/changes/reviewer-completion-evidence/design.md
@@ -225,6 +225,26 @@ parent session's cwd, not the worktree), and the credit is recorded.
 miss rather than a false credit (the key field is empty, and an empty key never
 compares equal), which is the correct direction for a format change.
 
+**The credit names the REVIEWED commit, not HEAD at completion.** Found in
+review, and it mattered more than its severity suggested: `branch_ledger_record`
+stamps HEAD at call time, so a backgrounded reviewer — which finishes while the
+session keeps committing, the normal shape of "kick off a reviewer, keep
+working" — recorded a tree it never read. Ledger records are consumed with
+HEAD-or-ancestor acceptance, so that sha silently covered commits nothing
+reviewed: the over-claim #181 removed from verdicts, reintroduced in a new
+artifact. It also made the new milestone LESS sha-accurate than the
+`reviewer-ran` it exists to strengthen, and it bit exactly in the background case
+that motivated the change.
+
+The dispatch half now carries the dispatch-time sha and both credit paths pass it
+to an OPTIONAL trailing argument on `branch_ledger_record` — omitting it resolves
+HEAD, so every other caller is byte-identical (the shape #219 used for
+`verdict.sh`). A record predating the field falls back to HEAD: the older, less
+precise stamp, never a fabricated one. Residual, stated rather than implied: if
+HEAD moved between dispatch and completion this artifact cannot SAY so; it
+records the reviewed commit, which is the honest lower bound, not a straddle
+marker. Regression (t), red-green verified.
+
 ## Dissenting views
 
 **"This is a better-looking attestation, not better evidence."** Partly true and

--- a/openspec/changes/reviewer-completion-evidence/design.md
+++ b/openspec/changes/reviewer-completion-evidence/design.md
@@ -57,6 +57,31 @@ The general lesson, and the reason the probe existed at all: two hooks on two
 events are a distributed system, and "the dispatch obviously happens before the
 completion" is a statement about the world, not about hook delivery.
 
+## The join cannot double-miss
+
+Write-own-half-then-read-the-other is not merely "a small window". The
+both-miss interleaving is impossible, and the argument is short enough to check.
+
+Let `Wd`/`Rd` be the dispatch hook's write and read, `Wc`/`Rc` the completion
+hook's. Each hook writes before it reads, so `Wd < Rd` and `Wc < Rc`.
+
+Suppose both miss. The dispatch hook missing means it read before the completion
+half existed: `Rd < Wc`. The completion hook missing means `Rc < Wd`. Chaining:
+
+    Wd < Rd < Wc < Rc < Wd
+
+which requires `Wd < Wd`. Contradiction — so at least one side always observes
+the other, and exactly one or both record the milestone (the ledger write is an
+idempotent overwrite, so a double credit is harmless).
+
+This holds because each half is a single `printf >>` whose fd is closed when the
+command ends, and each read `awk`s a freshly opened file — there is no buffered
+writer holding data back across the two processes.
+
+The one way a half legitimately never appears is an append that did not happen
+(size ceiling, unwritable `~/.claude`). That is the `|| true` path, and it fails
+toward UNDER-crediting.
+
 ## Why a dispatch-time writer at all
 
 Three ways to identify a `general-purpose` reviewer at completion were
@@ -141,10 +166,11 @@ review happened".
 not proven; 8 ids observed across the probes were 17 random hex characters and
 all distinct, including 3 dispatched in one session, so reuse is implausible but
 not excluded. Reuse would require a collision *and* a matching branch key to
-produce a false credit. `isolation: "worktree"` and `isolation: "remote"`
-dispatches were not probed — `session-token.sh` flags the same gap for the
-adjacent mechanism — so `session_id` symmetry is established for local
-dispatches only. A pairing record written in the pre-join format degrades to a
+produce a false credit. `isolation: "worktree"` WAS probed after
+`session-token.sh` flagged the same gap for the adjacent mechanism: both halves
+land under the same `session_id`, the ledger key matches (both hooks run in the
+parent session's cwd, not the worktree), and the credit is recorded.
+`isolation: "remote"` remains unprobed. A pairing record written in the pre-join format degrades to a
 miss rather than a false credit (the key field is empty, and an empty key never
 compares equal), which is the correct direction for a format change.
 

--- a/openspec/changes/reviewer-completion-evidence/proposal.md
+++ b/openspec/changes/reviewer-completion-evidence/proposal.md
@@ -1,0 +1,110 @@
+# Proposal: credit REVIEW on an observed subagent COMPLETION, not on a spawn
+
+## Why
+
+The push gate's REVIEW milestone is credited by `hooks/skill-completion-hook.sh`
+the instant `Skill(superpowers:requesting-code-review)` returns. That
+`PostToolUse` `^Skill$` event fires at instruction-**load** time, so **the
+crediting event cannot witness what it attests**. Measured: 7 of 8 sampled
+denied-then-merged PRs merged with zero reviews, and those sessions were
+*satisfying* the gate, not evading it.
+
+`hooks/reviewer-evidence-hook.sh` (#220) improved on that by recording a
+`reviewer-ran` milestone when a reviewer subagent is **dispatched** — but it
+runs on `PostToolUse` for `^(Task|Agent)$`, and for a backgrounded dispatch that
+payload is a launch acknowledgement (`status: "async_launched"`,
+`content: null`). A reviewer that spawns and then crashes, is stopped, goes
+idle, or returns nothing is recorded identically to one that finished.
+
+A completion event exists and this plugin does not subscribe to it.
+
+## What was measured
+
+Live, against Claude Code CLI 2.1.236, in an isolated `claude -p --settings`
+session with `PostToolUse` and `Stop` registered in the same run as positive
+controls (all three fired, so a non-firing `SubagentStop` would have been
+distinguishable from a dead harness):
+
+1. **`SubagentStop` fires**, once per subagent, at completion, including for two
+   subagents dispatched in parallel in one message.
+2. Its `transcript_path` names the **parent** session, but the payload carries
+   `agent_transcript_path` for the subagent's own JSONL (present at hook time),
+   plus `agent_id`, `agent_type`, and `last_assistant_message`.
+3. `agent_type` is **verbatim and plugin-qualified** — measured
+   `pr-review-toolkit:*`-shaped, `general-purpose`, and `Explore`.
+4. `PostToolUse` for `Agent` returns `status: "completed"` with full content for
+   a **foreground** dispatch, and `status: "async_launched"` with
+   `content: null` for `run_in_background: true`. The "spawn acknowledgement"
+   documented in `reviewer-evidence-hook.sh` is the background case only.
+5. **The parent transcript does NOT link `agent_id` at hook time** — measured
+   in-hook, `0` matching lines in an 18-line parent transcript while the
+   subagent's own 4-line transcript was readable. The `tool_result` carrying
+   `agentId` is written *after* `SubagentStop` fires. Any `agent_id` pairing
+   must therefore be written by a **dispatch-time** writer; it cannot be
+   recovered afterwards from the parent transcript.
+6. `session_id` is identical across the dispatch and completion events and
+   equals the transcript basename, so both sides key state off their own
+   payload with no token resolver and no singleton fallback.
+
+## What Changes
+
+1. **`hooks/reviewer-completion-hook.sh`** (new) — a `SubagentStop` hook that
+   records a `reviewer-returned` milestone into the per-(repo+branch) branch
+   ledger when a **reviewer** subagent runs to completion. Same posture as the
+   existing recorder: emits nothing on stdout, sets no `permissionDecision`,
+   exits 0 on every failure path, and is deliberately NOT in
+   `_GATE_ENFORCE_LIBS`.
+
+2. **`hooks/reviewer-evidence-hook.sh`** — additionally appends the dispatched
+   `agent_id` to a session-scoped pairing file when, and only when, it has
+   already judged the dispatch to be a reviewer. No change to its predicate, its
+   ledger write, or its exit behaviour.
+
+3. **`hooks/hooks.json`** — one new `SubagentStop` registration.
+
+4. **`hooks/session-start-hook.sh`** — the pairing file joins the existing
+   7-day state GC, with the current session excluded.
+
+5. **Nothing in `hooks/openspec-guard.sh`.** The new milestone is recorded and
+   not read by any gate in this change.
+
+## Reviewer identification
+
+Two arms, and they are not symmetric:
+
+- **Allowlist arm** — `agent_type` matched against the same reviewer allowlist
+  `reviewer-evidence-hook.sh` uses. Transfers with zero change, because
+  `SubagentStop` carries the qualified type verbatim. No pairing needed.
+- **`general-purpose` arm** — `SubagentStop` does not carry the dispatch
+  `description`, and the existing word-boundary predicate
+  (`*[Rr]eview|*[Rr]eview[!a-zA-Z]*`, measured 9/9 recall at 1/7 false
+  positives) was **fitted on that short label**. Against a full multi-paragraph
+  task prompt its second arm matches "review" anywhere followed by a non-letter,
+  i.e. it structurally degenerates into the substring variant that measured 4/7
+  false positives. The predicate is therefore NOT re-pointed at prompt text.
+  Instead the `agent_id` written at dispatch is looked up — an exact key, no
+  heuristic, and the predicate stays on the input it was measured against.
+
+## What this does NOT establish
+
+The honest label is **"observed completion"**, never "reviewed". This shows that
+a reviewer-shaped subagent ran to completion and produced output. It does not
+show that the output was a real review, that it examined this diff, that any
+finding was correct, or that anything was acted on. A model can still dispatch a
+reviewer prompted to rubber-stamp, and the human `!`/terminal bypass writes no
+record at all and cannot be instrumented.
+
+## Capabilities
+
+### Modified Capabilities
+- `pdlc-safety`: reviewer evidence gains an observed-completion signal distinct
+  from observed dispatch, recorded but not yet gate-wired.
+
+## Impact
+
+- `hooks/reviewer-completion-hook.sh` — new, diagnostic-only recorder.
+- `hooks/reviewer-evidence-hook.sh` — pairing write only.
+- `hooks/hooks.json` — one `SubagentStop` registration.
+- `hooks/session-start-hook.sh` — one GC name + one exclusion.
+- `tests/test-reviewer-completion-hook.sh` — new.
+- No change to any deny decision in this change.

--- a/openspec/changes/reviewer-completion-evidence/proposal.md
+++ b/openspec/changes/reviewer-completion-evidence/proposal.md
@@ -45,6 +45,18 @@ distinguishable from a dead harness):
 6. `session_id` is identical across the dispatch and completion events and
    equals the transcript basename, so both sides key state off their own
    payload with no token resolver and no singleton fallback.
+7. **Neither hook is guaranteed to run first**, and this killed the first
+   design. Measured end-to-end with both REAL hooks registered and timestamped:
+
+   | dispatch mode | order |
+   |---|---|
+   | `run_in_background: true` | dispatch fires **1.44s before** completion |
+   | `run_in_background: false` | completion fires **~30ms before** dispatch (3 of 3) |
+
+   A "dispatch writes the pairing, completion reads it" design is therefore a
+   systematic no-op for every FOREGROUND dispatch. Not theorised — the first
+   cut was built, and the live probe recorded `reviewer-ran` with **no**
+   `reviewer-returned` for a foreground reviewer.
 
 ## What Changes
 
@@ -55,35 +67,58 @@ distinguishable from a dead harness):
    exits 0 on every failure path, and is deliberately NOT in
    `_GATE_ENFORCE_LIBS`.
 
-2. **`hooks/reviewer-evidence-hook.sh`** — additionally appends the dispatched
-   `agent_id` to a session-scoped pairing file when, and only when, it has
-   already judged the dispatch to be a reviewer. No change to its predicate, its
-   ledger write, or its exit behaviour.
+2. **`hooks/lib/reviewer-pairing.sh`** (new) — owns the pairing file format and
+   key derivation in ONE place, so the two hooks cannot drift.
 
-3. **`hooks/hooks.json`** — one new `SubagentStop` registration.
+3. **`hooks/reviewer-evidence-hook.sh`** — additionally records the dispatched
+   `agent_id` and the branch ledger key when, and only when, it has already
+   judged the dispatch to be a reviewer, and completes the join if the subagent
+   has already finished. No change to its predicate, its ledger write, or its
+   exit behaviour.
 
-4. **`hooks/session-start-hook.sh`** — the pairing file joins the existing
-   7-day state GC, with the current session excluded.
+4. **`hooks/hooks.json`** — one new `SubagentStop` registration.
 
-5. **Nothing in `hooks/openspec-guard.sh`.** The new milestone is recorded and
+5. **`hooks/session-start-hook.sh`** — both pairing halves join the existing
+   7-day state GC, each with the current session excluded.
+
+6. **Nothing in `hooks/openspec-guard.sh`.** The new milestone is recorded and
    not read by any gate in this change.
 
-## Reviewer identification
+## The join
 
-Two arms, and they are not symmetric:
+Classification lives in the **dispatch** hook for both arms, because that is
+where the measured `description` predicate and the `subagent_type` allowlist
+already are. The completion hook owns the completion fact. Neither credits
+alone, and because neither is guaranteed to run first (measured fact 7), the
+join is **symmetric**: each hook writes its own half, then looks for the other,
+and whichever runs second records the milestone.
 
-- **Allowlist arm** — `agent_type` matched against the same reviewer allowlist
-  `reviewer-evidence-hook.sh` uses. Transfers with zero change, because
-  `SubagentStop` carries the qualified type verbatim. No pairing needed.
-- **`general-purpose` arm** — `SubagentStop` does not carry the dispatch
-  `description`, and the existing word-boundary predicate
-  (`*[Rr]eview|*[Rr]eview[!a-zA-Z]*`, measured 9/9 recall at 1/7 false
-  positives) was **fitted on that short label**. Against a full multi-paragraph
-  task prompt its second arm matches "review" anywhere followed by a non-letter,
-  i.e. it structurally degenerates into the substring variant that measured 4/7
-  false positives. The predicate is therefore NOT re-pointed at prompt text.
-  Instead the `agent_id` written at dispatch is looked up — an exact key, no
-  heuristic, and the predicate stays on the input it was measured against.
+The existing word-boundary predicate is therefore never re-pointed at new input.
+It stays on `tool_input.description`, the short label it was fitted on
+(9/9 recall at 1/7 false positives). Applying it to the subagent's full
+multi-paragraph task prompt would have been a different population — its
+`*[Rr]eview[!a-zA-Z]*` arm matches the word anywhere followed by a non-letter,
+so against long prose it structurally degenerates into the substring variant
+that measured 4/7 false positives, while looking unchanged in the diff.
+
+A reader-side reconstruction is not available as an alternative: measured
+in-hook, at `SubagentStop` time the parent transcript contains **zero** lines
+mentioning `agent_id`, because the `tool_result` carrying it is written
+afterwards.
+
+## Branch binding
+
+`branch_ledger_record` derives its key from the cwd at CALL time. A backgrounded
+reviewer completes on the parent session's clock, and that session is free to
+`git checkout` something else meanwhile — so an unbound credit would write
+`reviewer-returned` into the ledger of a branch the reviewer never looked at.
+That is not a miss but a **wrong-target hit**, into evidence the push gate
+treats as durable cross-session proof.
+
+The key is therefore recorded at dispatch and compared at completion. A mismatch
+records nothing and leaves a `# branch-mismatch` diagnostic line, so a refused
+credit is distinguishable from "no reviewer ran" — a silent miss is exactly how
+the foreground ordering defect nearly shipped.
 
 ## What this does NOT establish
 
@@ -103,8 +138,11 @@ record at all and cannot be instrumented.
 ## Impact
 
 - `hooks/reviewer-completion-hook.sh` — new, diagnostic-only recorder.
-- `hooks/reviewer-evidence-hook.sh` — pairing write only.
+- `hooks/lib/reviewer-pairing.sh` — new, owns the pairing format/keys.
+- `hooks/reviewer-evidence-hook.sh` — pairing write + backward join only.
 - `hooks/hooks.json` — one `SubagentStop` registration.
-- `hooks/session-start-hook.sh` — one GC name + one exclusion.
-- `tests/test-reviewer-completion-hook.sh` — new.
+- `hooks/session-start-hook.sh` — two GC names + two exclusions.
+- `tests/test-reviewer-completion-hook.sh` — new, 27 cells, every credit path
+  asserted in BOTH firing orders.
+- `tests/test-state-file-cleanup.sh` — C6a/C6b for both pairing halves.
 - No change to any deny decision in this change.

--- a/openspec/changes/reviewer-completion-evidence/specs/pdlc-safety/spec.md
+++ b/openspec/changes/reviewer-completion-evidence/specs/pdlc-safety/spec.md
@@ -1,0 +1,59 @@
+# Spec delta: pdlc-safety — observed reviewer completion
+
+## ADDED Requirements
+
+### Requirement: A reviewer subagent's COMPLETION MUST be recorded distinctly from its dispatch
+
+The plugin MUST record a `reviewer-returned` milestone into the per-(repo+branch)
+branch ledger when a reviewer subagent runs to completion, and this milestone
+MUST be distinct from the existing `reviewer-ran` dispatch milestone. A dispatch
+that never completes MUST NOT produce `reviewer-returned`.
+
+The recorder MUST be diagnostic-only: it MUST emit nothing on stdout, MUST NOT
+set a `permissionDecision`, and MUST exit 0 on every failure path. It MUST NOT
+be added to `_GATE_ENFORCE_LIBS`.
+
+No gate decision in this change MAY read `reviewer-returned`.
+
+#### Scenario: a reviewer subagent completes
+
+- **GIVEN** a subagent whose `agent_type` is in the reviewer allowlist
+- **WHEN** the `SubagentStop` hook receives its completion payload
+- **THEN** `reviewer-returned` is recorded in the branch ledger
+- **AND** the hook writes nothing to stdout and exits 0
+
+#### Scenario: a non-reviewer subagent completes
+
+- **GIVEN** a subagent whose `agent_type` is `general-purpose` and whose
+  `agent_id` was never recorded as a reviewer dispatch
+- **WHEN** the `SubagentStop` hook receives its completion payload
+- **THEN** no milestone is recorded
+- **AND** the hook writes nothing to stdout and exits 0
+
+### Requirement: Reviewer identification for `general-purpose` MUST use the dispatch-time pairing key, not the task prompt
+
+For a subagent whose `agent_type` is `general-purpose`, reviewer-ness MUST be
+resolved by looking up the `agent_id` recorded at dispatch time.
+
+The word-boundary description predicate MUST NOT be applied to the subagent's
+task prompt. That predicate was fitted on the short dispatch `description`; its
+`*[Rr]eview[!a-zA-Z]*` arm matches any occurrence of the word followed by a
+non-letter, so against multi-paragraph prompt text it degenerates into the
+substring variant that measured 4/7 false positives.
+
+A lookup MISS MUST record nothing. A missing, unreadable, or unparseable pairing
+file MUST be treated as a miss and MUST NOT be treated as an error.
+
+#### Scenario: a general-purpose reviewer paired at dispatch completes
+
+- **GIVEN** `reviewer-evidence-hook.sh` judged a `general-purpose` dispatch to be
+  a reviewer and recorded its `agent_id`
+- **WHEN** that subagent's `SubagentStop` payload arrives with the same `agent_id`
+- **THEN** `reviewer-returned` is recorded
+
+#### Scenario: the pairing file is absent
+
+- **GIVEN** no pairing file exists for this session
+- **WHEN** a `general-purpose` subagent completes
+- **THEN** no milestone is recorded
+- **AND** the hook exits 0

--- a/openspec/changes/reviewer-completion-evidence/specs/pdlc-safety/spec.md
+++ b/openspec/changes/reviewer-completion-evidence/specs/pdlc-safety/spec.md
@@ -7,7 +7,8 @@
 The plugin MUST record a `reviewer-returned` milestone into the per-(repo+branch)
 branch ledger when a reviewer subagent runs to completion, and this milestone
 MUST be distinct from the existing `reviewer-ran` dispatch milestone. A dispatch
-that never completes MUST NOT produce `reviewer-returned`.
+that never completes MUST NOT produce `reviewer-returned`. A subagent that
+emitted no final message MUST be treated as not having returned.
 
 The recorder MUST be diagnostic-only: it MUST emit nothing on stdout, MUST NOT
 set a `permissionDecision`, and MUST exit 0 on every failure path. It MUST NOT
@@ -17,43 +18,62 @@ No gate decision in this change MAY read `reviewer-returned`.
 
 #### Scenario: a reviewer subagent completes
 
-- **GIVEN** a subagent whose `agent_type` is in the reviewer allowlist
-- **WHEN** the `SubagentStop` hook receives its completion payload
+- **GIVEN** a subagent classified as a reviewer at dispatch on this branch
+- **WHEN** its completion is observed with a non-empty final message
 - **THEN** `reviewer-returned` is recorded in the branch ledger
 - **AND** the hook writes nothing to stdout and exits 0
 
-#### Scenario: a non-reviewer subagent completes
+#### Scenario: an ordinary subagent completes
 
-- **GIVEN** a subagent whose `agent_type` is `general-purpose` and whose
-  `agent_id` was never recorded as a reviewer dispatch
-- **WHEN** the `SubagentStop` hook receives its completion payload
+- **GIVEN** a subagent that was not classified as a reviewer at dispatch
+- **WHEN** its completion is observed
 - **THEN** no milestone is recorded
 - **AND** the hook writes nothing to stdout and exits 0
 
-### Requirement: Reviewer identification for `general-purpose` MUST use the dispatch-time pairing key, not the task prompt
+### Requirement: The dispatch/completion join MUST NOT depend on hook firing order
 
-For a subagent whose `agent_type` is `general-purpose`, reviewer-ness MUST be
-resolved by looking up the `agent_id` recorded at dispatch time.
+Reviewer classification MUST be performed at dispatch, against the short
+dispatch `description` and `subagent_type`. The word-boundary description
+predicate MUST NOT be applied to the subagent's task prompt: it was fitted on
+the short label, and its `*[Rr]eview[!a-zA-Z]*` arm matches the word anywhere
+followed by a non-letter, so against multi-paragraph prompt text it degenerates
+into the substring variant measured at 4/7 false positives.
 
-The word-boundary description predicate MUST NOT be applied to the subagent's
-task prompt. That predicate was fitted on the short dispatch `description`; its
-`*[Rr]eview[!a-zA-Z]*` arm matches any occurrence of the word followed by a
-non-letter, so against multi-paragraph prompt text it degenerates into the
-substring variant that measured 4/7 false positives.
+Because neither hook is guaranteed to run first — measured, the dispatch hook
+fires before completion for a backgrounded subagent and AFTER it for a
+foreground one — each side MUST publish its own half before reading the other,
+and EITHER side MUST be able to record the milestone. A design in which only one
+side can record MUST NOT be used.
 
 A lookup MISS MUST record nothing. A missing, unreadable, or unparseable pairing
 file MUST be treated as a miss and MUST NOT be treated as an error.
 
-#### Scenario: a general-purpose reviewer paired at dispatch completes
+#### Scenario: the completion is observed before the dispatch is recorded
 
-- **GIVEN** `reviewer-evidence-hook.sh` judged a `general-purpose` dispatch to be
-  a reviewer and recorded its `agent_id`
-- **WHEN** that subagent's `SubagentStop` payload arrives with the same `agent_id`
+- **GIVEN** a reviewer subagent whose completion event fires first
+- **WHEN** the dispatch event is subsequently observed for the same agent
 - **THEN** `reviewer-returned` is recorded
 
-#### Scenario: the pairing file is absent
+#### Scenario: the dispatch is recorded before the completion is observed
 
-- **GIVEN** no pairing file exists for this session
-- **WHEN** a `general-purpose` subagent completes
-- **THEN** no milestone is recorded
-- **AND** the hook exits 0
+- **GIVEN** a reviewer subagent whose dispatch event fires first
+- **WHEN** its completion is subsequently observed
+- **THEN** `reviewer-returned` is recorded
+
+### Requirement: A completion credit MUST be bound to the branch it was dispatched on
+
+The branch ledger key MUST be recorded at dispatch and compared at completion. A
+credit MUST NOT be recorded when the two differ, because the ledger key is
+derived from the working directory at call time and a backgrounded reviewer can
+complete after the session has moved to another branch — writing a credit into
+the ledger of a branch the reviewer never examined.
+
+A refused credit MUST leave a diagnostic trace, so that "no reviewer ran" and "a
+reviewer ran and the join was refused" are distinguishable.
+
+#### Scenario: a reviewer completes after the session changed branches
+
+- **GIVEN** a reviewer subagent dispatched while one branch was checked out
+- **WHEN** its completion is observed with a different branch ledger key
+- **THEN** no milestone is recorded on either branch
+- **AND** a diagnostic record of the refusal is written

--- a/tests/test-reviewer-completion-hook.sh
+++ b/tests/test-reviewer-completion-hook.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# test-reviewer-completion-hook.sh — the SubagentStop recorder.
+#
+# Spec: openspec/changes/reviewer-completion-evidence/
+#
+# The payload SHAPE asserted here is not invented. It was captured live from
+# Claude Code CLI 2.1.236 by registering a throwaway SubagentStop hook via
+# `claude -p --settings` and dumping the raw stdin, with PostToolUse and Stop
+# registered in the same run as positive controls. Any test that hand-writes a
+# producer's output only ever proves the consumer agrees with the test author's
+# idea of the format (see CLAUDE.md, and .claude/knowledge/
+# classifier-fixtures-from-real-producer.md). Cell (i) closes the remaining gap
+# by driving the REAL dispatch hook to produce the pairing file this hook reads.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+. "${SCRIPT_DIR}/test-helpers.sh"
+echo "=== test-reviewer-completion-hook.sh ==="
+
+HOOK="${PROJECT_ROOT}/hooks/reviewer-completion-hook.sh"
+DISPATCH_HOOK="${PROJECT_ROOT}/hooks/reviewer-evidence-hook.sh"
+_OLDHOME="$HOME"
+export HOME="$(mktemp -d /tmp/rch-home-XXXXXX)"
+mkdir -p "$HOME/.claude"
+
+# A real git repo so branch_ledger_key resolves. PHYSICAL path (`pwd -P`): on
+# macOS /tmp is a symlink to /private/tmp and the hook records with no explicit
+# proj_root, so the key is derived from `git rev-parse --show-toplevel`, which
+# resolves symlinks. Hashing the unresolved path in the reader yields a
+# DIFFERENT key and every assertion fails against a correct hook.
+_REPO="$(mktemp -d /tmp/rch-repo-XXXXXX)"
+_REPO="$(cd "$_REPO" && pwd -P)"
+( cd "$_REPO" && git init -q && git config user.email t@t && git config user.name t \
+  && git commit -q --allow-empty -m init )
+
+_SID="0f5b1a2c-1111-4222-8333-444455556666"
+
+# $1=agent_type $2=agent_id $3=last_assistant_message $4=session_id
+# $5=hook_event_name (defaults to SubagentStop)
+_payload() {
+    jq -n --arg at "$1" --arg ai "$2" --arg lm "$3" --arg sid "$4" \
+          --arg ev "${5:-SubagentStop}" \
+      '{hook_event_name:$ev, session_id:$sid, agent_id:$ai, agent_type:$at,
+        agent_transcript_path:"/nonexistent/agent.jsonl",
+        transcript_path:"/nonexistent/parent.jsonl",
+        last_assistant_message:$lm, stop_hook_active:false}'
+}
+_run() {  # prints stdout; exit status in _STATUS
+    local out
+    out="$(_payload "$@" | ( cd "$_REPO" && CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${HOOK}" ) 2>/dev/null)"
+    _STATUS=$?
+    printf '%s' "$out"
+}
+_pairfile() { printf '%s' "${HOME}/.claude/.skill-reviewer-dispatch-session-${_SID}"; }
+_reset() { rm -rf "$HOME"/.claude/.skill-branch-ledger-*; rm -f "$(_pairfile)"; }
+
+# shellcheck disable=SC1090
+. "${PROJECT_ROOT}/hooks/lib/branch-ledger.sh"
+_has() { branch_ledger_has "reviewer-returned" "$_REPO"; }
+_has_ran() { branch_ledger_has "reviewer-ran" "$_REPO"; }
+
+# --- (a) allowlisted agent_type records, with no pairing file at all --------
+# The allowlist arm must not depend on the dispatch hook having run: agent_type
+# arrives verbatim and plugin-qualified, which is the whole reason that arm
+# needs no pairing.
+_reset; _run "pr-review-toolkit:code-reviewer" "a1" "Findings: 2 blocking" "$_SID" >/dev/null
+if _has; then _record_pass "(a) allowlisted agent_type records reviewer-returned"
+else _record_fail "(a) allowlisted agent_type records reviewer-returned" "no ledger entry"; fi
+
+# --- (b) general-purpose WITH a pairing entry records -----------------------
+_reset; printf '%s\n' "a2" > "$(_pairfile)"
+_run "general-purpose" "a2" "Findings: none" "$_SID" >/dev/null
+if _has; then _record_pass "(b) paired general-purpose records reviewer-returned"
+else _record_fail "(b) paired general-purpose records reviewer-returned" "no ledger entry"; fi
+
+# --- (c) general-purpose WITHOUT a pairing entry records nothing ------------
+# This is the false positive the whole pairing design exists to avoid: an
+# ordinary implementation subagent completing is not a review.
+_reset; printf '%s\n' "someone-else" > "$(_pairfile)"
+_run "general-purpose" "a3" "Implemented the parser" "$_SID" >/dev/null
+if _has; then _record_fail "(c) unpaired general-purpose is not credited" "ledger entry written"
+else _record_pass "(c) unpaired general-purpose is not credited"; fi
+
+# --- (d) no pairing file at all is a MISS, not an error ---------------------
+# The dispatch may predate the plugin version that writes the pairing, so a
+# recorder must degrade to "no record", never to a fabricated one.
+_reset
+_run "general-purpose" "a4" "Implemented the parser" "$_SID" >/dev/null
+if _has; then _record_fail "(d) absent pairing file is a miss" "ledger entry written"
+elif [ "${_STATUS}" -ne 0 ]; then _record_fail "(d) absent pairing file is a miss" "non-zero exit ${_STATUS}"
+else _record_pass "(d) absent pairing file is a miss, exit 0"; fi
+
+# --- (e) an empty last_assistant_message is not a return -------------------
+# A reviewer that emitted nothing (interrupted, crashed) returned no review.
+# Under-crediting is the safe direction for a fidelity signal.
+_reset; _run "pr-review-toolkit:code-reviewer" "a5" "" "$_SID" >/dev/null
+if _has; then _record_fail "(e) empty final message is not credited" "ledger entry written"
+else _record_pass "(e) empty final message is not credited"; fi
+
+# --- (f) a non-SubagentStop event is never credited ------------------------
+# The hook is registered on SubagentStop only; this pins that a hooks.json edit
+# widening the registration cannot silently start crediting on another event.
+_reset; _run "pr-review-toolkit:code-reviewer" "a6" "Findings: 0" "$_SID" "Stop" >/dev/null
+if _has; then _record_fail "(f) non-SubagentStop event is not credited" "ledger entry written"
+else _record_pass "(f) non-SubagentStop event is not credited"; fi
+
+# --- (g) the recorder contract: nothing on stdout, exit 0 ------------------
+# A recorder that emitted JSON on a PreToolUse-adjacent path could alter a gate
+# decision. Asserted on the CREDITING path, which is the one that does work.
+_reset
+_OUT="$(_run "pr-review-toolkit:code-reviewer" "a7" "Findings: 1" "$_SID")"
+if [ -n "${_OUT}" ]; then _record_fail "(g) recorder writes nothing to stdout" "stdout: ${_OUT}"
+elif [ "${_STATUS}" -ne 0 ]; then _record_fail "(g) recorder exits 0" "exit ${_STATUS}"
+else _record_pass "(g) recorder writes nothing to stdout and exits 0"; fi
+
+# --- (h) the pairing lookup is a WHOLE-LINE LITERAL match ------------------
+# A prefix or a regex must not credit: `grep -qxF` is load-bearing, and a
+# `grep -q` regression would credit "a8" from a stored "." or from "a8x".
+_reset; printf '%s\n' "a8xyz" > "$(_pairfile)"
+_run "general-purpose" "a8" "output" "$_SID" >/dev/null
+if _has; then _record_fail "(h1) a prefix does not credit" "ledger entry written"
+else _record_pass "(h1) a prefix does not credit"; fi
+
+# The metachar risk lives in the PATTERN (the agent id), not in the file — an
+# earlier version of this cell had it backwards and passed with `-F` deleted.
+# `.` is inside the id charset the writer accepts, so `a.9` is a reachable id;
+# without `-F` it is a regex that matches the unrelated stored line `a29`.
+_reset; printf '%s\n' "a29" > "$(_pairfile)"
+_run "general-purpose" "a.9" "output" "$_SID" >/dev/null
+if _has; then _record_fail "(h2) a regex metachar in the agent id does not credit" "ledger entry written"
+else _record_pass "(h2) a regex metachar in the agent id does not credit"; fi
+
+# --- (i) END-TO-END: the REAL dispatch hook produces the pairing this reads --
+# The one cell that is not hostage to this file's idea of the format. A
+# hand-written pairing file proves only that the reader agrees with the test;
+# this drives the actual writer, so writer/reader symmetry — the recurring bug
+# class in this repo (#51/#97/#122/#131/#133/#151/#156) — is measured, not
+# assumed. It also pins that the two hooks agree on the session_id-derived
+# filename without either side re-deriving a token.
+_reset
+_DISPATCH_ID="e2e-agent-0001"
+jq -n --arg sid "$_SID" --arg ai "$_DISPATCH_ID" \
+  '{tool_name:"Agent", session_id:$sid,
+    tool_response:{is_error:false, agentId:$ai, status:"async_launched"},
+    tool_input:{subagent_type:"general-purpose", description:"Task 1 review: spec + quality"}}' \
+  | ( cd "$_REPO" && CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${DISPATCH_HOOK}" ) >/dev/null 2>&1
+
+if [ -f "$(_pairfile)" ]; then
+    _record_pass "(i1) dispatch hook writes the pairing file the reader expects"
+else
+    _record_fail "(i1) dispatch hook writes the pairing file the reader expects" "no file at $(_pairfile)"
+fi
+
+_run "general-purpose" "$_DISPATCH_ID" "Findings: 1 blocking" "$_SID" >/dev/null
+if _has; then _record_pass "(i2) end-to-end: real dispatch pairing credits the completion"
+else _record_fail "(i2) end-to-end: real dispatch pairing credits the completion" "no ledger entry"; fi
+
+# The dispatch hook must keep recording its OWN milestone unchanged — the
+# pairing write is additive, not a replacement.
+if _has_ran; then _record_pass "(i3) dispatch hook still records reviewer-ran"
+else _record_fail "(i3) dispatch hook still records reviewer-ran" "no reviewer-ran entry"; fi
+
+# --- (i4) a NON-reviewer dispatch writes NO pairing entry ------------------
+# The pairing file must carry only agent ids the dispatch predicate accepted;
+# if it recorded every dispatch, the completion hook's general-purpose arm
+# would credit every subagent that ever finished.
+_reset
+jq -n --arg sid "$_SID" \
+  '{tool_name:"Agent", session_id:$sid,
+    tool_response:{is_error:false, agentId:"impl-agent-0001"},
+    tool_input:{subagent_type:"general-purpose", description:"Task 3: reviewer-evidence writer hook"}}' \
+  | ( cd "$_REPO" && CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${DISPATCH_HOOK}" ) >/dev/null 2>&1
+_run "general-purpose" "impl-agent-0001" "Implemented it" "$_SID" >/dev/null
+if _has; then _record_fail "(i4) implementation dispatch writes no pairing" "ledger entry written"
+else _record_pass "(i4) implementation dispatch writes no pairing"; fi
+
+# --- (j) a session_id that is not a single path-safe segment is refused ----
+# The value is harness-supplied, but a recorder must not be the component that
+# turns a surprising value into a read or a write outside ~/.claude.
+#
+# The traversal is made REACHABLE rather than asserted in the abstract: an
+# earlier version of this cell used a bare "../../escape", which resolves
+# through a non-existent directory and so is refused whether the guard is there
+# or not — it passed with the guard deleted. Here the first path component is
+# made to exist, so without the guard the lookup genuinely escapes to the
+# planted file and credits.
+_reset
+_ESC_DIR="${HOME}/.claude/.skill-reviewer-dispatch-session-x"
+mkdir -p "${_ESC_DIR}"
+_ESC_TARGET="${HOME}/planted-pairing"
+printf '%s\n' "aj" > "${_ESC_TARGET}"
+_run "general-purpose" "aj" "output" "x/../../planted-pairing" >/dev/null
+if [ "${_STATUS}" -ne 0 ]; then
+    _record_fail "(j) unsafe session_id is refused" "non-zero exit ${_STATUS}"
+elif _has; then
+    _record_fail "(j) unsafe session_id is refused" "escaped to the planted file and credited"
+else
+    _record_pass "(j) unsafe session_id is refused, exit 0"
+fi
+rm -rf "${_ESC_DIR}" "${_ESC_TARGET}"
+
+# --- (j2) an unsafe session_id must not break the DISPATCH hook -------------
+# The generalisation of the bug (i3) caught: new best-effort code must never be
+# able to suppress the pre-existing milestone, on any input.
+_reset
+jq -n '{tool_name:"Agent", session_id:"../../nope",
+    tool_response:{is_error:false, agentId:"safe-id-1"},
+    tool_input:{subagent_type:"general-purpose", description:"Review the diff"}}' \
+  | ( cd "$_REPO" && CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${DISPATCH_HOOK}" ) >/dev/null 2>&1
+if _has_ran; then _record_pass "(j2) unsafe session_id does not suppress reviewer-ran"
+else _record_fail "(j2) unsafe session_id does not suppress reviewer-ran" "no reviewer-ran entry"; fi
+
+# --- (k) malformed / empty input never fails --------------------------------
+_reset
+printf 'not json at all' | ( cd "$_REPO" && CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${HOOK}" ) >/dev/null 2>&1
+_S1=$?
+printf '' | ( cd "$_REPO" && CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${HOOK}" ) >/dev/null 2>&1
+_S2=$?
+if [ "${_S1}" -eq 0 ] && [ "${_S2}" -eq 0 ] && ! _has; then
+    _record_pass "(k) malformed and empty input exit 0 with no record"
+else
+    _record_fail "(k) malformed and empty input exit 0 with no record" "exits ${_S1}/${_S2}"
+fi
+
+# --- (l) registration ------------------------------------------------------
+if jq -e '[.hooks.SubagentStop[]?.hooks[]?.command]
+          | any(test("reviewer-completion-hook\\.sh"))' \
+     "${PROJECT_ROOT}/hooks/hooks.json" >/dev/null 2>&1; then
+    _record_pass "(l1) registered on SubagentStop in hooks.json"
+else
+    _record_fail "(l1) registered on SubagentStop in hooks.json" "not found"
+fi
+
+# The event name is exact. A typo registers a hook that never fires, and the
+# failure mode is silence, which every other cell here would pass through.
+if jq -e '.hooks | keys | any(. == "SubagentStop")' \
+     "${PROJECT_ROOT}/hooks/hooks.json" >/dev/null 2>&1; then
+    _record_pass "(l2) the event key is spelled SubagentStop"
+else
+    _record_fail "(l2) the event key is spelled SubagentStop" "no such key"
+fi
+
+# --- (m) diagnostic-only: never a gate-enforcement component ---------------
+# _GATE_ENFORCE_LIBS drives both the session-start precondition canary and the
+# installed-plugin drift manifest. A diagnostic recorder joining it would make
+# a missing recorder announce as a degraded GATE.
+if grep -q 'reviewer-completion-hook' "${PROJECT_ROOT}/hooks/session-start-hook.sh" 2>/dev/null; then
+    _record_fail "(m) not a gate-enforcement component" "referenced by session-start canary/manifest"
+else
+    _record_pass "(m) not a gate-enforcement component"
+fi
+
+# It must also never appear in the guard: this change wires no gate.
+if grep -q 'reviewer-returned' "${PROJECT_ROOT}/hooks/openspec-guard.sh" 2>/dev/null; then
+    _record_fail "(m2) no gate reads reviewer-returned in this change" "openspec-guard.sh references it"
+else
+    _record_pass "(m2) no gate reads reviewer-returned in this change"
+fi
+
+# --- (n) the pairing file is covered by the state GC ----------------------
+# Behavioural pruning is asserted in tests/test-state-file-cleanup.sh; here we
+# only pin that the name and its current-session exclusion are both present, so
+# adding one without the other cannot pass.
+_SS="${PROJECT_ROOT}/hooks/session-start-hook.sh"
+if grep -q "name '\.skill-reviewer-dispatch-\*'" "$_SS" 2>/dev/null \
+   && grep -q '! -name "\.skill-reviewer-dispatch-\${_SESSION_TOKEN}"' "$_SS" 2>/dev/null; then
+    _record_pass "(n) pairing file is GC'd with a current-session exclusion"
+else
+    _record_fail "(n) pairing file is GC'd with a current-session exclusion" "name or exclusion missing"
+fi
+
+rm -rf "$_REPO"
+export HOME="$_OLDHOME"
+print_summary
+exit $?

--- a/tests/test-reviewer-completion-hook.sh
+++ b/tests/test-reviewer-completion-hook.sh
@@ -335,6 +335,36 @@ else
     _record_fail "(r4) the shipped ceiling is the documented 1 MiB" "got ${_R4}"
 fi
 
+# --- (t) the credit is stamped with the REVIEWED commit, not with HEAD -------
+# A backgrounded reviewer finishes while the session keeps committing — the
+# normal shape of "kick off a reviewer, keep working". branch_ledger_record
+# stamps HEAD at CALL time, so before this was fixed the milestone named a tree
+# the reviewer never read. Ledger records are consumed with HEAD-or-ancestor
+# acceptance, so an over-late sha silently covers commits nothing reviewed: the
+# over-claim #181 removed from verdicts, reintroduced in a new artifact — and it
+# made this milestone LESS sha-accurate than the `reviewer-ran` it strengthens.
+#
+# `reviewer-ran` is the BUILT-IN POSITIVE CONTROL: same harness, same run, same
+# ledger, correct sha. It rules out "this harness cannot record the dispatch sha"
+# and isolates the milestone as the single variable.
+_reset
+_T_DISPATCH_SHA="$(cd "$_REPO" && git rev-parse HEAD)"
+_run_dispatch "bgsha-1" "Review the diff for correctness"
+( cd "$_REPO" && git commit -q --allow-empty -m "landed while the reviewer ran" )
+_T_LATER_SHA="$(cd "$_REPO" && git rev-parse HEAD)"
+_run_completion "bgsha-1" "Findings: 1" >/dev/null
+_T_RAN="$(branch_ledger_sha "reviewer-ran" "$_REPO")"
+_T_RET="$(branch_ledger_sha "reviewer-returned" "$_REPO")"
+if [ "$_T_DISPATCH_SHA" = "$_T_LATER_SHA" ]; then
+    _record_fail "(t) the credit names the reviewed commit" "harness did not move HEAD — cell proves nothing"
+elif [ "$_T_RAN" != "$_T_DISPATCH_SHA" ]; then
+    _record_fail "(t) the credit names the reviewed commit" "control broken: reviewer-ran sha=${_T_RAN} != dispatch ${_T_DISPATCH_SHA}"
+elif [ "$_T_RET" = "$_T_DISPATCH_SHA" ]; then
+    _record_pass "(t) the credit names the reviewed commit, not the later HEAD"
+else
+    _record_fail "(t) the credit names the reviewed commit" "reviewer-returned sha=${_T_RET} names a commit the reviewer never saw (dispatch was ${_T_DISPATCH_SHA})"
+fi
+
 # ===========================================================================
 # Lookup exactness
 # ===========================================================================

--- a/tests/test-reviewer-completion-hook.sh
+++ b/tests/test-reviewer-completion-hook.sh
@@ -203,18 +203,64 @@ fi
 # The miss must leave a TRACE. A silent miss is how the foreground ordering
 # defect nearly shipped: "no reviewer ran" and "a reviewer ran, join refused"
 # must not look identical from the outside.
-if grep -q '^# branch-mismatch mv-1 ' "$(_complete_file)" 2>/dev/null; then
+# In the DISPATCH file, deliberately: the completion file is the half that grows
+# with every subagent and approaches the ceiling, so a diagnostic stored there
+# would fall silent under the very condition that starts breaking the join.
+if grep -q '^# branch-mismatch mv-1 ' "$(_dispatch_file)" 2>/dev/null; then
     _record_pass "(h2) the refused credit leaves a diagnostic line"
 else
     _record_fail "(h2) the refused credit leaves a diagnostic line" "no mismatch line recorded"
 fi
 
-# A diagnostic comment line must never be readable as an agent id.
+# A diagnostic comment line must never be readable as a pairing record.
+#
+# An earlier version of this cell was VACUOUS AND MISLEADING: it planted the
+# comment in the DISPATCH file (where note_mismatch never writes) and completed
+# agent id "#", which `awk '$1==a'` genuinely MATCHES — so the credit was refused
+# by the branch comparison, not by the property named. It also implied the lib's
+# `#` exemption is a property of the comparison; it is a property of the id
+# charset (a real id is 17 hex characters and can never be "#").
+#
+# The honest test: plant a mismatch line in the COMPLETION file whose TEXT
+# contains a real-shaped agent id, then dispatch that id. `$1` of that line is
+# "#", so an exact field lookup must not join — while a substring or
+# line-content lookup would.
 _reset
-printf '# branch-mismatch cm-1 dispatched=x completed=y\n' > "$(_dispatch_file)"
-_run_completion "#" "Findings: 1" >/dev/null
-if _has; then _record_fail "(h3) a comment line is not a pairing record" "ledger entry written"
+_KEYNOW2="$(cd "$_REPO" && branch_ledger_key)"
+printf '# branch-mismatch cm00000000000001 dispatched=%s completed=%s\n' "$_KEYNOW2" "$_KEYNOW2" > "$(_dispatch_file)"
+_run_dispatch "cm00000000000001" "Review the diff for correctness"
+if _has; then _record_fail "(h3) a comment line is not a pairing record" "joined against a diagnostic line"
 else _record_pass "(h3) a comment line is not a pairing record"; fi
+
+# --- (h4) the DISPATCH side must branch-bind too ----------------------------
+# Measured false credit before this: the dispatch-side join credited on agent-id
+# MEMBERSHIP alone, so an id collision with no matching branch and no ordering
+# constraint recorded `reviewer-returned` at SPAWN time for a reviewer that had
+# produced nothing. Reproduced against the real hooks; the negative control below
+# isolates it to the single variable (the prior completion record).
+_reset
+_CWD="$_REPO2"
+_run_completion "xrepo-1" "Implemented something" >/dev/null   # non-reviewer completes in repo 2
+_CWD="$_REPO"
+_run_dispatch "xrepo-1" "Review the diff for correctness"      # same id dispatched in repo 1
+if _has "$_REPO"; then
+    _record_fail "(h4) a foreign completion does not credit the dispatch side" "credited from another branch's completion"
+else
+    _record_pass "(h4) a foreign completion does not credit the dispatch side"
+fi
+
+# (h5) NEGATIVE CONTROL for (h4): the same dispatch with no completion anywhere
+# must also not credit — otherwise (h4) proves only that this harness cannot
+# credit at all.
+_reset
+_run_dispatch "xrepo-2" "Review the diff for correctness"
+if _has "$_REPO"; then
+    _record_fail "(h5) control: a dispatch alone does not credit" "credited with no completion"
+else
+    _record_pass "(h5) control: a dispatch alone does not credit"
+fi
+# ...and (a)/(b) above are the positive controls: the same harness DOES credit a
+# genuine same-branch join in both orders.
 
 # ===========================================================================
 # Lookup exactness
@@ -253,11 +299,19 @@ else _record_fail "(i3) positive control: an exact planted record DOES join" "no
 # ===========================================================================
 
 # --- (j) recorder contract: nothing on stdout, exit 0, on the CREDIT path ---
+# `_run_completion` sets _STATUS, but capturing its stdout with `$( )` runs it in
+# a SUBSHELL and the assignment is discarded — an earlier version of this cell
+# read a stale _STATUS belonging to a previous cell, so the "exits 0" half
+# asserted nothing about this invocation. Capture to a file instead, so the
+# helper runs in THIS shell.
 _reset
 _run_dispatch "out-1" "Review the diff for correctness"
-_OUT="$(_run_completion "out-1" "Findings: 1")"
+_OUTFILE="${HOME}/out.txt"
+_run_completion "out-1" "Findings: 1" > "${_OUTFILE}"
+_JSTATUS="${_STATUS}"
+_OUT="$(cat "${_OUTFILE}" 2>/dev/null)"
 if [ -n "${_OUT}" ]; then _record_fail "(j) recorder writes nothing to stdout" "stdout: ${_OUT}"
-elif [ "${_STATUS}" -ne 0 ]; then _record_fail "(j) recorder exits 0" "exit ${_STATUS}"
+elif [ "${_JSTATUS}" -ne 0 ]; then _record_fail "(j) recorder exits 0" "exit ${_JSTATUS}"
 else _record_pass "(j) recorder writes nothing to stdout and exits 0"; fi
 
 # --- (j2) an exhausted completion file must not kill the join --------------
@@ -268,14 +322,55 @@ else _record_pass "(j) recorder writes nothing to stdout and exits 0"; fi
 _reset
 _run_dispatch "full-1" "Review the diff for correctness"
 # push the completion half past the 64KiB ceiling
-_i=0; : > "$(_complete_file)"
-while [ "$_i" -lt 2000 ]; do
-    printf 'padpadpadpadpadpadpadpadpadpadpadpadpadpad%s\n' "$_i" >> "$(_complete_file)"
-    _i=$(( _i + 1 ))
-done
+{ head -c 1100000 /dev/zero 2>/dev/null | tr '\0' 'x'; printf '\n'; } >> "$(_complete_file)"
 _run_completion "full-1" "Findings: 1" >/dev/null
-if _has; then _record_pass "(j2) a full completion file does not stop the join"
-else _record_fail "(j2) a full completion file does not stop the join" "no ledger entry"; fi
+if _has; then _record_pass "(j2) a full completion file does not stop the join (bg order)"
+else _record_fail "(j2) a full completion file does not stop the join (bg order)" "no ledger entry"; fi
+
+# (j3) The SAME state in the FOREGROUND order. This is the order where the
+# ceiling actually bites — the completion half cannot be published, so there is
+# nothing for the later dispatch to join against. Asserted as the DOCUMENTED
+# behaviour (no credit) rather than as a passing credit: the cell pins the limit
+# so it stays visible, it does not claim it is fixed.
+#
+# THIS IS NOT UNFIXABLE, and an earlier comment here wrongly called it
+# structural. The signal exists: `reviewer_pairing_note_complete` returns
+# non-zero at reviewer-completion-hook.sh's HALF ONE and the `|| true` discards
+# it. What is missing is somewhere to put it — the fact is SESSION-scoped ("this
+# session's completion half stopped accepting writes"), not agent-scoped, so
+# recording it needs a new state family (one more GC glob plus the paired
+# `! -name` exclusion that cell (p) already forces). Declined for this increment
+# because the ceiling is 1 MiB (~26k completions), not because it cannot be done.
+# A prerequisite if it is ever taken: `_reviewer_pairing_append` must
+# DISTINGUISH ceiling-refusal from failed-write, since an unwritable ~/.claude
+# cannot record the marker either, and conflating them rebuilds the exact
+# collapse the marker would exist to prevent.
+_reset
+# One command, not a 30k-iteration shell loop: the cell needs the file to EXCEED
+# the ceiling, and nothing here reads its contents (no `$1` can match a real id).
+# The loop form cost seconds on every run of this file and every mutation pass.
+{ head -c 1100000 /dev/zero 2>/dev/null | tr '\0' 'x'; printf '\n'; } > "$(_complete_file)"
+_run_completion "full-2" "Findings: 1" >/dev/null
+_run_dispatch "full-2" "Review the diff for correctness"
+if _has; then
+    _record_fail "(j3) foreground order at the ceiling is a documented miss" "credited unexpectedly — the ceiling may have moved; revisit the limit note"
+else
+    _record_pass "(j3) foreground order at the ceiling is a documented miss"
+fi
+
+# (j4) A non-reviewer completion must leave NO mismatch line. Without the
+# `[ -n "${_DKEY}" ]` guard the hook fabricates `# branch-mismatch` lines for
+# every ordinary subagent — a FALSE diagnostic ("never dispatched as a reviewer"
+# is not "branch mismatch") that also accelerates the ceiling above. Before this
+# cell, only the PRESENCE of a mismatch line was asserted, never its absence,
+# which is the asymmetry that let that mutation through.
+_reset
+_run_completion "plain-1" "Implemented the parser" >/dev/null
+if grep -q '^# branch-mismatch' "$(_dispatch_file)" 2>/dev/null; then
+    _record_fail "(j4) a non-reviewer completion leaves no mismatch line" "fabricated a branch-mismatch diagnostic"
+else
+    _record_pass "(j4) a non-reviewer completion leaves no mismatch line"
+fi
 
 # --- (k) malformed / empty input never fails --------------------------------
 _reset
@@ -379,6 +474,48 @@ if [ "$_GCOK" -eq 1 ]; then
     _record_pass "(p) both pairing families are GC'd with current-session exclusions"
 else
     _record_fail "(p) both pairing families are GC'd with current-session exclusions" "a glob or exclusion is missing"
+fi
+
+# --- (q) writer and reader must accept and reject the SAME ids -------------
+# Asserted as AGREEMENT, not as two separate lists. If the writer's charset and
+# a reader's ever diverge, an id becomes writable but not readable — a silent
+# miss, and precisely the writer/reader split this lib exists to prevent. Two
+# independent assertions of "the writer rejects X" and "the reader rejects X"
+# would both keep passing while the two lists drifted apart.
+#
+# Loop is heredoc-fed, NOT piped: a piped loop runs in a subshell and its
+# _record_pass/_record_fail calls vanish from the summary (CLAUDE.md).
+# shellcheck disable=SC1090
+. "${PROJECT_ROOT}/hooks/lib/reviewer-pairing.sh"
+_QHOME="$(mktemp -d /tmp/rch-q-XXXXXX)"; _QOLD="$HOME"; export HOME="$_QHOME"; mkdir -p "$HOME/.claude"
+_QSID="qqqqqqqq-1111-2222-3333-444444444444"
+_QKEY="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+_QAGREE=1; _QDETAIL=""
+while IFS= read -r _qid; do
+    [ -n "$_qid" ] || continue
+    _qid="${_qid%\'}"; _qid="${_qid#\'}"          # strip the quoting used below
+    if reviewer_pairing_note_dispatch "$_QSID" "$_qid" "$_QKEY" 2>/dev/null; then _qw=accept; else _qw=reject; fi
+    if reviewer_pairing_dispatch_key "$_QSID" "$_qid" >/dev/null 2>&1; then _qr=accept; else _qr=reject; fi
+    if [ "$_qw" != "$_qr" ]; then
+        _QAGREE=0; _QDETAIL="${_QDETAIL} [${_qid}: writer=${_qw} reader=${_qr}]"
+    fi
+done <<'QIDS'
+'abc-1'
+'a.b_c'
+'A1'
+'0123456789abcdef0'
+'a b'
+'a/b'
+'a;b'
+'a$b'
+'a*b'
+'#'
+QIDS
+export HOME="$_QOLD"; rm -rf "$_QHOME"
+if [ "$_QAGREE" -eq 1 ]; then
+    _record_pass "(q) writer and reader agree on the agent-id charset"
+else
+    _record_fail "(q) writer and reader agree on the agent-id charset" "disagreements:${_QDETAIL}"
 fi
 
 rm -rf "$_REPO" "$_REPO2"

--- a/tests/test-reviewer-completion-hook.sh
+++ b/tests/test-reviewer-completion-hook.sh
@@ -81,7 +81,7 @@ _dispatch_file() { printf '%s' "${HOME}/.claude/.skill-reviewer-dispatch-session
 _complete_file() { printf '%s' "${HOME}/.claude/.skill-reviewer-complete-session-${_SID}"; }
 _reset() {
     rm -rf "$HOME"/.claude/.skill-branch-ledger-*
-    rm -f "$HOME"/.claude/.skill-reviewer-dispatch-* "$HOME"/.claude/.skill-reviewer-complete-*
+    rm -f "$HOME"/.claude/.skill-reviewer-dispatch-* "$HOME"/.claude/.skill-reviewer-complete-* "$HOME"/.claude/.skill-reviewer-saturated-*
     _CWD="$_REPO"
 }
 
@@ -212,25 +212,35 @@ else
     _record_fail "(h2) the refused credit leaves a diagnostic line" "no mismatch line recorded"
 fi
 
-# A diagnostic comment line must never be readable as a pairing record.
+# (h3) A diagnostic comment line must never be readable as a pairing RECORD.
 #
-# An earlier version of this cell was VACUOUS AND MISLEADING: it planted the
-# comment in the DISPATCH file (where note_mismatch never writes) and completed
-# agent id "#", which `awk '$1==a'` genuinely MATCHES — so the credit was refused
-# by the branch comparison, not by the property named. It also implied the lib's
-# `#` exemption is a property of the comparison; it is a property of the id
-# charset (a real id is 17 hex characters and can never be "#").
-#
-# The honest test: plant a mismatch line in the COMPLETION file whose TEXT
-# contains a real-shaped agent id, then dispatch that id. `$1` of that line is
-# "#", so an exact field lookup must not join — while a substring or
-# line-content lookup would.
+# Asserted at the LIB level, and the two previous end-to-end versions of this
+# cell were BOTH vacuous — the second one passed with its own fixture deleted.
+# The end-to-end path cannot isolate this: `$2` of a mismatch line is the word
+# `branch-mismatch`, so even if the lookup DID match, the branch comparison
+# refuses the credit and the cell goes green for the wrong reason. The only
+# honest form is to ask the reader directly.
 _reset
-_KEYNOW2="$(cd "$_REPO" && branch_ledger_key)"
-printf '# branch-mismatch cm00000000000001 dispatched=%s completed=%s\n' "$_KEYNOW2" "$_KEYNOW2" > "$(_dispatch_file)"
-_run_dispatch "cm00000000000001" "Review the diff for correctness"
-if _has; then _record_fail "(h3) a comment line is not a pairing record" "joined against a diagnostic line"
-else _record_pass "(h3) a comment line is not a pairing record"; fi
+_KEYNOW3="$(cd "$_REPO" && branch_ledger_key)"
+printf '# branch-mismatch h300000000000001 dispatched=%s completed=%s\n' "$_KEYNOW3" "$_KEYNOW3" > "$(_dispatch_file)"
+if ( . "${PROJECT_ROOT}/hooks/lib/reviewer-pairing.sh"
+     reviewer_pairing_dispatch_key "$_SID" "h300000000000001" ) >/dev/null 2>&1; then
+    _record_fail "(h3) a diagnostic line is not readable as a record" "dispatch_key matched a # line"
+else
+    _record_pass "(h3) a diagnostic line is not readable as a record"
+fi
+
+# (h3b) POSITIVE CONTROL for (h3): the same reader, same file, same id, but a
+# REAL record — must be found. Without it, (h3) passes just as well against a
+# reader that never matches anything, which is what "passes with the fixture
+# deleted" means.
+printf '%s %s\n' "h300000000000001" "$_KEYNOW3" > "$(_dispatch_file)"
+if ( . "${PROJECT_ROOT}/hooks/lib/reviewer-pairing.sh"
+     reviewer_pairing_dispatch_key "$_SID" "h300000000000001" ) >/dev/null 2>&1; then
+    _record_pass "(h3b) control: the same reader DOES find a real record"
+else
+    _record_fail "(h3b) control: the same reader DOES find a real record" "reader found nothing"
+fi
 
 # --- (h4) the DISPATCH side must branch-bind too ----------------------------
 # Measured false credit before this: the dispatch-side join credited on agent-id
@@ -249,9 +259,11 @@ else
     _record_pass "(h4) a foreign completion does not credit the dispatch side"
 fi
 
-# (h5) NEGATIVE CONTROL for (h4): the same dispatch with no completion anywhere
-# must also not credit — otherwise (h4) proves only that this harness cannot
-# credit at all.
+# (h5) SPECIFICITY control for (h4): the same dispatch with no completion
+# anywhere must also not credit. This isolates the prior completion record as the
+# single variable that differs between the two cells. It is NOT the control that
+# rules out "this harness cannot credit at all" — a second negative cannot do
+# that; (a)/(b) are the positive controls that do.
 _reset
 _run_dispatch "xrepo-2" "Review the diff for correctness"
 if _has "$_REPO"; then
@@ -261,6 +273,67 @@ else
 fi
 # ...and (a)/(b) above are the positive controls: the same harness DOES credit a
 # genuine same-branch join in both orders.
+
+# --- (r) saturation is DISTINGUISHABLE, not merely rarer --------------------
+# An absent `reviewer-returned` means "the reviewer did not return" OR "the
+# recorder stopped recording". Those are `missing` and `cannot_check`, and
+# CLAUDE.md is emphatic (IMPLEMENT shadow leg) that collapsing the second into
+# the first biases every downstream reading in the unsafe direction. Raising the
+# ceiling makes the state rarer; only the marker makes it legible.
+
+# The override is set HERE, not inherited from another cell. These cells
+# originally sat above the one that exported it and therefore ran against the
+# shipped 1 MiB ceiling: (r1) failed loudly, but (r2) PASSED VACUOUSLY — it
+# asserts an absence, so a cell that never triggers the condition looks correct.
+export REVIEWER_PAIRING_MAX_BYTES=200
+
+# (r1) a ceiling refusal leaves a marker
+_reset
+printf '%0400d\n' 0 > "$(_complete_file)"
+_run_completion "sat-1" "Findings: 1" >/dev/null
+if [ -f "${HOME}/.claude/.skill-reviewer-saturated-session-${_SID}" ]; then
+    _record_pass "(r1) a ceiling refusal leaves a saturation marker"
+else
+    _record_fail "(r1) a ceiling refusal leaves a saturation marker" "no marker written"
+fi
+
+# (r2) ordinary operation leaves NO marker. Without this, (r1) passes just as
+# well for a hook that marks unconditionally, which would make the marker
+# meaningless — the same present-but-never-absent asymmetry that let the
+# fabricated-mismatch mutation through until (j4).
+_reset
+_run_dispatch "sat-2" "Review the diff for correctness"
+_run_completion "sat-2" "Findings: 1" >/dev/null
+if [ -f "${HOME}/.claude/.skill-reviewer-saturated-session-${_SID}" ]; then
+    _record_fail "(r2) ordinary operation leaves no marker" "marker written with no refusal"
+else
+    _record_pass "(r2) ordinary operation leaves no marker"
+fi
+unset REVIEWER_PAIRING_MAX_BYTES
+
+# (r3) the reader agrees with the file, via the lib's own accessor rather than a
+# path this test re-derives.
+_reset
+( . "${PROJECT_ROOT}/hooks/lib/reviewer-pairing.sh"
+  reviewer_pairing_saturated "$_SID" ) && _R3PRE=0 || _R3PRE=1
+printf 'complete now\n' > "${HOME}/.claude/.skill-reviewer-saturated-session-${_SID}"
+( . "${PROJECT_ROOT}/hooks/lib/reviewer-pairing.sh"
+  reviewer_pairing_saturated "$_SID" ) && _R3POST=0 || _R3POST=1
+rm -f "${HOME}/.claude/.skill-reviewer-saturated-session-${_SID}"
+if [ "$_R3PRE" -eq 1 ] && [ "$_R3POST" -eq 0 ]; then
+    _record_pass "(r3) reviewer_pairing_saturated tracks the marker"
+else
+    _record_fail "(r3) reviewer_pairing_saturated tracks the marker" "pre=${_R3PRE} post=${_R3POST}"
+fi
+
+# (r4) the SHIPPED default is the documented one. The cells above drive an
+# override, so without this nothing would notice the real constant changing.
+_R4="$( . "${PROJECT_ROOT}/hooks/lib/reviewer-pairing.sh"; printf '%s' "${_REVIEWER_PAIRING_MAX_BYTES}" )"
+if [ "${_R4}" = "1048576" ]; then
+    _record_pass "(r4) the shipped ceiling is the documented 1 MiB"
+else
+    _record_fail "(r4) the shipped ceiling is the documented 1 MiB" "got ${_R4}"
+fi
 
 # ===========================================================================
 # Lookup exactness
@@ -319,10 +392,15 @@ else _record_pass "(j) recorder writes nothing to stdout and exits 0"; fi
 # happen (size ceiling, unwritable HOME). Unguarded under `trap 'exit 0' ERR`
 # that terminates the hook before the join, silently ending every credit for the
 # session. Found by a mutation whose real fault was masked by this early exit.
+# The ceiling is OVERRIDDEN rather than out-padded. Hardcoded padding silently
+# stops testing anything the moment the constant moves — and it already did once
+# here: raising the ceiling to 1 MiB left this cell padding to ~90 KB, which made
+# it vacuous, and only a mutation showed it. Driving the constant instead keeps
+# the cell tied to the mechanism and takes milliseconds.
+export REVIEWER_PAIRING_MAX_BYTES=200
 _reset
 _run_dispatch "full-1" "Review the diff for correctness"
-# push the completion half past the 64KiB ceiling
-{ head -c 1100000 /dev/zero 2>/dev/null | tr '\0' 'x'; printf '\n'; } >> "$(_complete_file)"
+printf '%0400d\n' 0 >> "$(_complete_file)"        # now over the 200-byte ceiling
 _run_completion "full-1" "Findings: 1" >/dev/null
 if _has; then _record_pass "(j2) a full completion file does not stop the join (bg order)"
 else _record_fail "(j2) a full completion file does not stop the join (bg order)" "no ledger entry"; fi
@@ -346,10 +424,7 @@ else _record_fail "(j2) a full completion file does not stop the join (bg order)
 # cannot record the marker either, and conflating them rebuilds the exact
 # collapse the marker would exist to prevent.
 _reset
-# One command, not a 30k-iteration shell loop: the cell needs the file to EXCEED
-# the ceiling, and nothing here reads its contents (no `$1` can match a real id).
-# The loop form cost seconds on every run of this file and every mutation pass.
-{ head -c 1100000 /dev/zero 2>/dev/null | tr '\0' 'x'; printf '\n'; } > "$(_complete_file)"
+printf '%0400d\n' 0 > "$(_complete_file)"          # over the overridden ceiling
 _run_completion "full-2" "Findings: 1" >/dev/null
 _run_dispatch "full-2" "Review the diff for correctness"
 if _has; then
@@ -371,6 +446,11 @@ if grep -q '^# branch-mismatch' "$(_dispatch_file)" 2>/dev/null; then
 else
     _record_pass "(j4) a non-reviewer completion leaves no mismatch line"
 fi
+
+# The overridden ceiling is scoped to the cells that need it. Leaving it set
+# would silently apply a 200-byte limit to every later cell, which is the same
+# class of cross-cell coupling that made (r2) vacuous.
+unset REVIEWER_PAIRING_MAX_BYTES
 
 # --- (k) malformed / empty input never fails --------------------------------
 _reset
@@ -460,62 +540,98 @@ else
 fi
 
 # --- (p) both pairing families are GC'd, each with its own exclusion --------
-# Behavioural pruning is asserted in tests/test-state-file-cleanup.sh. Here both
-# halves are pinned together, so adding a family's glob without its
-# current-session exclusion (which would prune the LIVE session's pairing and
-# silently break every later join) cannot pass.
+# Behavioural pruning is asserted in tests/test-state-file-cleanup.sh. Here every
+# family is pinned together, so adding a glob without its current-session
+# exclusion — which would prune the LIVE session's state and silently break every
+# later join — cannot pass. Adding a family means adding it in BOTH places, and
+# this loop is what forces that.
 _SS="${PROJECT_ROOT}/hooks/session-start-hook.sh"
 _GCOK=1
-for _k in dispatch complete; do
+for _k in dispatch complete saturated; do
     grep -q "name '\.skill-reviewer-${_k}-\*'" "$_SS" 2>/dev/null || _GCOK=0
     grep -q "! -name \"\.skill-reviewer-${_k}-\${_SESSION_TOKEN}\"" "$_SS" 2>/dev/null || _GCOK=0
 done
 if [ "$_GCOK" -eq 1 ]; then
-    _record_pass "(p) both pairing families are GC'd with current-session exclusions"
+    _record_pass "(p) all pairing families are GC'd with current-session exclusions"
 else
-    _record_fail "(p) both pairing families are GC'd with current-session exclusions" "a glob or exclusion is missing"
+    _record_fail "(p) all pairing families are GC'd with current-session exclusions" "a glob or exclusion is missing"
 fi
 
-# --- (q) writer and reader must accept and reject the SAME ids -------------
-# Asserted as AGREEMENT, not as two separate lists. If the writer's charset and
-# a reader's ever diverge, an id becomes writable but not readable — a silent
-# miss, and precisely the writer/reader split this lib exists to prevent. Two
-# independent assertions of "the writer rejects X" and "the reader rejects X"
-# would both keep passing while the two lists drifted apart.
+# --- (q) writer and reader must agree on the id charset, BOTH pairs -----------
+# Asserted as AGREEMENT rather than as two separate rejection lists: independent
+# assertions of "the writer rejects X" and "the reader rejects X" both keep
+# passing while the two lists drift apart, which is a silent miss and exactly the
+# writer/reader split this lib exists to prevent.
+#
+# BOTH pairs, deliberately. An earlier version covered only dispatch/dispatch_key
+# — and complete_key, which the branch-binding fix depends on, had zero test
+# callers, so deleting its guard produced no observable failure anywhere.
+#
+# The record is PLANTED DIRECTLY rather than written through the writer, so a
+# reader's "accept" is not confounded with "the writer happened to store it".
+#
+# LIMIT, stated rather than papered over: for an id the writer rejects, the
+# reader also fails to find a planted line (its `$1` cannot equal an id
+# containing a space), so the two agree for two different reasons. This cell
+# therefore reliably detects READER-STRICTER-THAN-WRITER drift — the direction
+# that silently loses real records — and not the converse.
 #
 # Loop is heredoc-fed, NOT piped: a piped loop runs in a subshell and its
 # _record_pass/_record_fail calls vanish from the summary (CLAUDE.md).
-# shellcheck disable=SC1090
-. "${PROJECT_ROOT}/hooks/lib/reviewer-pairing.sh"
 _QHOME="$(mktemp -d /tmp/rch-q-XXXXXX)"; _QOLD="$HOME"; export HOME="$_QHOME"; mkdir -p "$HOME/.claude"
 _QSID="qqqqqqqq-1111-2222-3333-444444444444"
 _QKEY="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+_QD="${HOME}/.claude/.skill-reviewer-dispatch-session-${_QSID}"
+_QC="${HOME}/.claude/.skill-reviewer-complete-session-${_QSID}"
 _QAGREE=1; _QDETAIL=""
 while IFS= read -r _qid; do
     [ -n "$_qid" ] || continue
-    _qid="${_qid%\'}"; _qid="${_qid#\'}"          # strip the quoting used below
-    if reviewer_pairing_note_dispatch "$_QSID" "$_qid" "$_QKEY" 2>/dev/null; then _qw=accept; else _qw=reject; fi
-    if reviewer_pairing_dispatch_key "$_QSID" "$_qid" >/dev/null 2>&1; then _qr=accept; else _qr=reject; fi
-    if [ "$_qw" != "$_qr" ]; then
-        _QAGREE=0; _QDETAIL="${_QDETAIL} [${_qid}: writer=${_qw} reader=${_qr}]"
-    fi
+    ( . "${PROJECT_ROOT}/hooks/lib/reviewer-pairing.sh"
+      rm -f "$_QD" "$_QC"
+      reviewer_pairing_note_dispatch "$_QSID" "$_qid" "$_QKEY" >/dev/null 2>&1 && _wd=accept || _wd=reject
+      reviewer_pairing_note_complete "$_QSID" "$_qid" "$_QKEY" >/dev/null 2>&1 && _wc=accept || _wc=reject
+      printf '%s %s\n' "$_qid" "$_QKEY" > "$_QD"
+      printf '%s %s\n' "$_qid" "$_QKEY" > "$_QC"
+      reviewer_pairing_dispatch_key "$_QSID" "$_qid" >/dev/null 2>&1 && _rd=accept || _rd=reject
+      reviewer_pairing_complete_key "$_QSID" "$_qid" >/dev/null 2>&1 && _rc=accept || _rc=reject
+      [ "$_wd" = "$_rd" ] || printf 'dispatch[%s: w=%s r=%s] ' "$_qid" "$_wd" "$_rd"
+      [ "$_wc" = "$_rc" ] || printf 'complete[%s: w=%s r=%s] ' "$_qid" "$_wc" "$_rc" ) > "${_QHOME}/out" 2>/dev/null
+    _qout="$(cat "${_QHOME}/out" 2>/dev/null)"
+    if [ -n "$_qout" ]; then _QAGREE=0; _QDETAIL="${_QDETAIL} ${_qout}"; fi
 done <<'QIDS'
-'abc-1'
-'a.b_c'
-'A1'
-'0123456789abcdef0'
-'a b'
-'a/b'
-'a;b'
-'a$b'
-'a*b'
-'#'
+abc-1
+a.b_c
+A1
+0123456789abcdef0
+a b
+a/b
+a;b
+a*b
+#
 QIDS
 export HOME="$_QOLD"; rm -rf "$_QHOME"
 if [ "$_QAGREE" -eq 1 ]; then
-    _record_pass "(q) writer and reader agree on the agent-id charset"
+    _record_pass "(q) writer and reader agree on the id charset, both pairs"
 else
-    _record_fail "(q) writer and reader agree on the agent-id charset" "disagreements:${_QDETAIL}"
+    _record_fail "(q) writer and reader agree on the id charset, both pairs" "disagreements:${_QDETAIL}"
+fi
+
+# --- (s) the probed source-guard symbol IS the lib's last definition ---------
+# Both hooks deliberately probe a symbol neither of them may call, because a lib
+# truncated at a function boundary sources cleanly and would leave later
+# definitions undefined. That only works while the probed symbol really is last —
+# append a function to the lib and the guarantee silently reverts. The cost of
+# the choice is that deleting or renaming that symbol disables the join in BOTH
+# hooks without erroring, so it is pinned here rather than left to memory.
+_LASTFN="$(grep -o '^[a-z_][a-z_]*() {' "${PROJECT_ROOT}/hooks/lib/reviewer-pairing.sh" | tail -1 | sed 's/() {//')"
+_SOK=1
+for _h in reviewer-completion-hook reviewer-evidence-hook; do
+    grep -q "command -v ${_LASTFN} >/dev/null 2>&1" "${PROJECT_ROOT}/hooks/${_h}.sh" 2>/dev/null || _SOK=0
+done
+if [ -n "${_LASTFN}" ] && [ "$_SOK" -eq 1 ]; then
+    _record_pass "(s) both hooks probe the lib's last-defined function (${_LASTFN})"
+else
+    _record_fail "(s) both hooks probe the lib's last-defined function" "last='${_LASTFN}' — a hook probes something else"
 fi
 
 rm -rf "$_REPO" "$_REPO2"

--- a/tests/test-reviewer-completion-hook.sh
+++ b/tests/test-reviewer-completion-hook.sh
@@ -1,16 +1,24 @@
 #!/usr/bin/env bash
-# test-reviewer-completion-hook.sh — the SubagentStop recorder.
+# test-reviewer-completion-hook.sh — the reviewer dispatch/completion JOIN.
 #
 # Spec: openspec/changes/reviewer-completion-evidence/
 #
-# The payload SHAPE asserted here is not invented. It was captured live from
-# Claude Code CLI 2.1.236 by registering a throwaway SubagentStop hook via
-# `claude -p --settings` and dumping the raw stdin, with PostToolUse and Stop
-# registered in the same run as positive controls. Any test that hand-writes a
-# producer's output only ever proves the consumer agrees with the test author's
-# idea of the format (see CLAUDE.md, and .claude/knowledge/
-# classifier-fixtures-from-real-producer.md). Cell (i) closes the remaining gap
-# by driving the REAL dispatch hook to produce the pairing file this hook reads.
+# The payload SHAPES here are not invented. They were captured live from Claude
+# Code CLI 2.1.236 by registering throwaway hooks via `claude -p --settings` and
+# dumping raw stdin, with unrelated events registered in the same run as
+# positive controls. Any test that hand-writes a producer's output only proves
+# the consumer agrees with the test author (CLAUDE.md; .claude/knowledge/
+# classifier-fixtures-from-real-producer.md).
+#
+# THE CENTRAL FACT THIS FILE EXISTS TO PIN: neither hook is guaranteed to run
+# first. Measured end-to-end against both real hooks:
+#
+#   background dispatch : DISPATCH fires 1.44s BEFORE completion
+#   foreground dispatch : COMPLETION fires ~30ms BEFORE dispatch (3 of 3)
+#
+# Every credit path is therefore asserted in BOTH orders. A one-directional
+# design passes the background order and is a systematic no-op for foreground —
+# that was the first cut of this change, and only the live probe caught it.
 set -u
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
@@ -23,192 +31,251 @@ _OLDHOME="$HOME"
 export HOME="$(mktemp -d /tmp/rch-home-XXXXXX)"
 mkdir -p "$HOME/.claude"
 
-# A real git repo so branch_ledger_key resolves. PHYSICAL path (`pwd -P`): on
-# macOS /tmp is a symlink to /private/tmp and the hook records with no explicit
-# proj_root, so the key is derived from `git rev-parse --show-toplevel`, which
-# resolves symlinks. Hashing the unresolved path in the reader yields a
-# DIFFERENT key and every assertion fails against a correct hook.
-_REPO="$(mktemp -d /tmp/rch-repo-XXXXXX)"
-_REPO="$(cd "$_REPO" && pwd -P)"
-( cd "$_REPO" && git init -q && git config user.email t@t && git config user.name t \
-  && git commit -q --allow-empty -m init )
+# Two real git repos, PHYSICAL paths (`pwd -P`): on macOS /tmp is a symlink to
+# /private/tmp and the hooks derive the ledger key from
+# `git rev-parse --show-toplevel`, which resolves symlinks — hashing the
+# unresolved path in the reader yields a DIFFERENT key and every assertion fails
+# against correct hooks. The SECOND repo exists only to produce a genuinely
+# different ledger key for the branch-binding cell.
+_mkrepo() {
+    local d; d="$(mktemp -d "/tmp/rch-repo-XXXXXX")"; d="$(cd "$d" && pwd -P)"
+    ( cd "$d" && git init -q && git config user.email t@t && git config user.name t \
+      && git commit -q --allow-empty -m init )
+    printf '%s' "$d"
+}
+_REPO="$(_mkrepo)"
+_REPO2="$(_mkrepo)"
 
 _SID="0f5b1a2c-1111-4222-8333-444455556666"
 
-# $1=agent_type $2=agent_id $3=last_assistant_message $4=session_id
-# $5=hook_event_name (defaults to SubagentStop)
-_payload() {
-    jq -n --arg at "$1" --arg ai "$2" --arg lm "$3" --arg sid "$4" \
-          --arg ev "${5:-SubagentStop}" \
-      '{hook_event_name:$ev, session_id:$sid, agent_id:$ai, agent_type:$at,
+# --- payload builders (shapes captured from the live probe) -----------------
+# completion: $1=agent_id $2=last_assistant_message $3=session_id $4=event
+_completion_payload() {
+    jq -n --arg ai "$1" --arg lm "$2" --arg sid "$3" --arg ev "${4:-SubagentStop}" \
+      '{hook_event_name:$ev, session_id:$sid, agent_id:$ai, agent_type:"general-purpose",
         agent_transcript_path:"/nonexistent/agent.jsonl",
         transcript_path:"/nonexistent/parent.jsonl",
         last_assistant_message:$lm, stop_hook_active:false}'
 }
-_run() {  # prints stdout; exit status in _STATUS
+# dispatch: $1=agent_id $2=description $3=session_id $4=subagent_type
+_dispatch_payload() {
+    jq -n --arg ai "$1" --arg d "$2" --arg sid "$3" --arg st "${4:-general-purpose}" \
+      '{tool_name:"Agent", session_id:$sid,
+        tool_response:{is_error:false, agentId:$ai, status:"completed"},
+        tool_input:{subagent_type:$st, description:$d}}'
+}
+# Both hooks are always driven as the REAL scripts, in the given repo.
+_run_completion() {  # agent_id msg [session_id] [event] ; repo in _CWD
     local out
-    out="$(_payload "$@" | ( cd "$_REPO" && CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${HOOK}" ) 2>/dev/null)"
+    out="$(_completion_payload "$1" "$2" "${3:-$_SID}" "${4:-SubagentStop}" \
+        | ( cd "${_CWD:-$_REPO}" && CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${HOOK}" ) 2>/dev/null)"
     _STATUS=$?
     printf '%s' "$out"
 }
-_pairfile() { printf '%s' "${HOME}/.claude/.skill-reviewer-dispatch-session-${_SID}"; }
-_reset() { rm -rf "$HOME"/.claude/.skill-branch-ledger-*; rm -f "$(_pairfile)"; }
+_run_dispatch() {    # agent_id description [session_id] [subagent_type]
+    _dispatch_payload "$1" "$2" "${3:-$_SID}" "${4:-general-purpose}" \
+        | ( cd "${_CWD:-$_REPO}" && CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${DISPATCH_HOOK}" ) >/dev/null 2>&1
+}
+
+_dispatch_file() { printf '%s' "${HOME}/.claude/.skill-reviewer-dispatch-session-${_SID}"; }
+_complete_file() { printf '%s' "${HOME}/.claude/.skill-reviewer-complete-session-${_SID}"; }
+_reset() {
+    rm -rf "$HOME"/.claude/.skill-branch-ledger-*
+    rm -f "$HOME"/.claude/.skill-reviewer-dispatch-* "$HOME"/.claude/.skill-reviewer-complete-*
+    _CWD="$_REPO"
+}
 
 # shellcheck disable=SC1090
 . "${PROJECT_ROOT}/hooks/lib/branch-ledger.sh"
-_has() { branch_ledger_has "reviewer-returned" "$_REPO"; }
-_has_ran() { branch_ledger_has "reviewer-ran" "$_REPO"; }
+_has()      { branch_ledger_has "reviewer-returned" "${1:-$_REPO}"; }
+_has_ran()  { branch_ledger_has "reviewer-ran" "${1:-$_REPO}"; }
 
-# --- (a) allowlisted agent_type records, with no pairing file at all --------
-# The allowlist arm must not depend on the dispatch hook having run: agent_type
-# arrives verbatim and plugin-qualified, which is the whole reason that arm
-# needs no pairing.
-_reset; _run "pr-review-toolkit:code-reviewer" "a1" "Findings: 2 blocking" "$_SID" >/dev/null
-if _has; then _record_pass "(a) allowlisted agent_type records reviewer-returned"
-else _record_fail "(a) allowlisted agent_type records reviewer-returned" "no ledger entry"; fi
+# ===========================================================================
+# The join, in BOTH firing orders. These two cells are the point of the file.
+# ===========================================================================
 
-# --- (b) general-purpose WITH a pairing entry records -----------------------
-_reset; printf '%s\n' "a2" > "$(_pairfile)"
-_run "general-purpose" "a2" "Findings: none" "$_SID" >/dev/null
-if _has; then _record_pass "(b) paired general-purpose records reviewer-returned"
-else _record_fail "(b) paired general-purpose records reviewer-returned" "no ledger entry"; fi
-
-# --- (c) general-purpose WITHOUT a pairing entry records nothing ------------
-# This is the false positive the whole pairing design exists to avoid: an
-# ordinary implementation subagent completing is not a review.
-_reset; printf '%s\n' "someone-else" > "$(_pairfile)"
-_run "general-purpose" "a3" "Implemented the parser" "$_SID" >/dev/null
-if _has; then _record_fail "(c) unpaired general-purpose is not credited" "ledger entry written"
-else _record_pass "(c) unpaired general-purpose is not credited"; fi
-
-# --- (d) no pairing file at all is a MISS, not an error ---------------------
-# The dispatch may predate the plugin version that writes the pairing, so a
-# recorder must degrade to "no record", never to a fabricated one.
+# --- (a) BACKGROUND order: dispatch first, then completion ------------------
 _reset
-_run "general-purpose" "a4" "Implemented the parser" "$_SID" >/dev/null
-if _has; then _record_fail "(d) absent pairing file is a miss" "ledger entry written"
-elif [ "${_STATUS}" -ne 0 ]; then _record_fail "(d) absent pairing file is a miss" "non-zero exit ${_STATUS}"
-else _record_pass "(d) absent pairing file is a miss, exit 0"; fi
+_run_dispatch "bg-1" "Review the diff for correctness"
+_run_completion "bg-1" "Findings: 1 blocking" >/dev/null
+if _has; then _record_pass "(a) background order (dispatch->completion) credits"
+else _record_fail "(a) background order (dispatch->completion) credits" "no ledger entry"; fi
 
-# --- (e) an empty last_assistant_message is not a return -------------------
-# A reviewer that emitted nothing (interrupted, crashed) returned no review.
-# Under-crediting is the safe direction for a fidelity signal.
-_reset; _run "pr-review-toolkit:code-reviewer" "a5" "" "$_SID" >/dev/null
-if _has; then _record_fail "(e) empty final message is not credited" "ledger entry written"
-else _record_pass "(e) empty final message is not credited"; fi
-
-# --- (f) a non-SubagentStop event is never credited ------------------------
-# The hook is registered on SubagentStop only; this pins that a hooks.json edit
-# widening the registration cannot silently start crediting on another event.
-_reset; _run "pr-review-toolkit:code-reviewer" "a6" "Findings: 0" "$_SID" "Stop" >/dev/null
-if _has; then _record_fail "(f) non-SubagentStop event is not credited" "ledger entry written"
-else _record_pass "(f) non-SubagentStop event is not credited"; fi
-
-# --- (g) the recorder contract: nothing on stdout, exit 0 ------------------
-# A recorder that emitted JSON on a PreToolUse-adjacent path could alter a gate
-# decision. Asserted on the CREDITING path, which is the one that does work.
+# --- (b) FOREGROUND order: completion first, then dispatch ------------------
+# The order that a one-directional design silently fails. Measured as the real
+# order for foreground dispatches, 3 of 3.
 _reset
-_OUT="$(_run "pr-review-toolkit:code-reviewer" "a7" "Findings: 1" "$_SID")"
-if [ -n "${_OUT}" ]; then _record_fail "(g) recorder writes nothing to stdout" "stdout: ${_OUT}"
-elif [ "${_STATUS}" -ne 0 ]; then _record_fail "(g) recorder exits 0" "exit ${_STATUS}"
-else _record_pass "(g) recorder writes nothing to stdout and exits 0"; fi
+_run_completion "fg-1" "Findings: 1 blocking" >/dev/null
+_run_dispatch "fg-1" "Review the diff for correctness"
+if _has; then _record_pass "(b) foreground order (completion->dispatch) credits"
+else _record_fail "(b) foreground order (completion->dispatch) credits" "no ledger entry"; fi
 
-# --- (h) the pairing lookup is a WHOLE-LINE LITERAL match ------------------
-# A prefix or a regex must not credit: `grep -qxF` is load-bearing, and a
-# `grep -q` regression would credit "a8" from a stored "." or from "a8x".
-_reset; printf '%s\n' "a8xyz" > "$(_pairfile)"
-_run "general-purpose" "a8" "output" "$_SID" >/dev/null
-if _has; then _record_fail "(h1) a prefix does not credit" "ledger entry written"
-else _record_pass "(h1) a prefix does not credit"; fi
-
-# The metachar risk lives in the PATTERN (the agent id), not in the file — an
-# earlier version of this cell had it backwards and passed with `-F` deleted.
-# `.` is inside the id charset the writer accepts, so `a.9` is a reachable id;
-# without `-F` it is a regex that matches the unrelated stored line `a29`.
-_reset; printf '%s\n' "a29" > "$(_pairfile)"
-_run "general-purpose" "a.9" "output" "$_SID" >/dev/null
-if _has; then _record_fail "(h2) a regex metachar in the agent id does not credit" "ledger entry written"
-else _record_pass "(h2) a regex metachar in the agent id does not credit"; fi
-
-# --- (i) END-TO-END: the REAL dispatch hook produces the pairing this reads --
-# The one cell that is not hostage to this file's idea of the format. A
-# hand-written pairing file proves only that the reader agrees with the test;
-# this drives the actual writer, so writer/reader symmetry — the recurring bug
-# class in this repo (#51/#97/#122/#131/#133/#151/#156) — is measured, not
-# assumed. It also pins that the two hooks agree on the session_id-derived
-# filename without either side re-deriving a token.
+# --- (c) allowlisted agent_type, both orders --------------------------------
+# Classification lives in the dispatch hook for BOTH arms, so the allowlist arm
+# goes through the identical join. Its description is deliberately NOT
+# review-shaped, so only the subagent_type allowlist can be crediting it.
 _reset
-_DISPATCH_ID="e2e-agent-0001"
-jq -n --arg sid "$_SID" --arg ai "$_DISPATCH_ID" \
-  '{tool_name:"Agent", session_id:$sid,
-    tool_response:{is_error:false, agentId:$ai, status:"async_launched"},
-    tool_input:{subagent_type:"general-purpose", description:"Task 1 review: spec + quality"}}' \
-  | ( cd "$_REPO" && CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${DISPATCH_HOOK}" ) >/dev/null 2>&1
+_run_dispatch "al-1" "Task 4: add the parser" "$_SID" "pr-review-toolkit:code-reviewer"
+_run_completion "al-1" "Findings: 0" >/dev/null
+if _has; then _record_pass "(c1) allowlisted type credits (background order)"
+else _record_fail "(c1) allowlisted type credits (background order)" "no ledger entry"; fi
 
-if [ -f "$(_pairfile)" ]; then
-    _record_pass "(i1) dispatch hook writes the pairing file the reader expects"
+_reset
+_run_completion "al-2" "Findings: 0" >/dev/null
+_run_dispatch "al-2" "Task 4: add the parser" "$_SID" "pr-review-toolkit:code-reviewer"
+if _has; then _record_pass "(c2) allowlisted type credits (foreground order)"
+else _record_fail "(c2) allowlisted type credits (foreground order)" "no ledger entry"; fi
+
+# ===========================================================================
+# Non-credit paths
+# ===========================================================================
+
+# --- (d) an implementation subagent is never credited, in either order ------
+# The false positive the whole design exists to avoid.
+_reset
+_run_dispatch "im-1" "Task 3: reviewer-evidence writer hook"
+_run_completion "im-1" "Implemented it" >/dev/null
+if _has; then _record_fail "(d1) implementation subagent not credited (bg order)" "ledger entry written"
+else _record_pass "(d1) implementation subagent not credited (bg order)"; fi
+
+_reset
+_run_completion "im-2" "Implemented it" >/dev/null
+_run_dispatch "im-2" "Task 3: reviewer-evidence writer hook"
+if _has; then _record_fail "(d2) implementation subagent not credited (fg order)" "ledger entry written"
+else _record_pass "(d2) implementation subagent not credited (fg order)"; fi
+
+# --- (e) a completion with no dispatch at all is never credited -------------
+# Covers the plugin-skew cold start: a session whose dispatch predates the
+# pairing writer records nothing rather than a fabricated credit.
+_reset
+_run_completion "orphan-1" "Findings: 3" >/dev/null
+if _has; then _record_fail "(e) orphan completion is not credited" "ledger entry written"
+elif [ "${_STATUS}" -ne 0 ]; then _record_fail "(e) orphan completion is not credited" "exit ${_STATUS}"
+else _record_pass "(e) orphan completion is not credited, exit 0"; fi
+
+# --- (f) an empty final message is not a return, in either order ------------
+# A reviewer that emitted nothing (interrupted, crashed) returned no review, so
+# the completion half must not be published — otherwise a later dispatch would
+# join against it and credit a crash.
+_reset
+_run_completion "empty-1" "" >/dev/null
+_run_dispatch "empty-1" "Review the diff for correctness"
+if _has; then _record_fail "(f1) empty final message is not credited (fg order)" "ledger entry written"
+else _record_pass "(f1) empty final message is not credited (fg order)"; fi
+
+_reset
+_run_dispatch "empty-2" "Review the diff for correctness"
+_run_completion "empty-2" "" >/dev/null
+if _has; then _record_fail "(f2) empty final message is not credited (bg order)" "ledger entry written"
+else _record_pass "(f2) empty final message is not credited (bg order)"; fi
+
+# --- (g) a non-SubagentStop event never publishes a completion half ---------
+_reset
+_run_completion "ev-1" "Findings: 1" "$_SID" "Stop" >/dev/null
+_run_dispatch "ev-1" "Review the diff for correctness"
+if _has; then _record_fail "(g) non-SubagentStop event is not credited" "ledger entry written"
+else _record_pass "(g) non-SubagentStop event is not credited"; fi
+
+# ===========================================================================
+# Branch binding — the wrong-target-HIT case
+# ===========================================================================
+
+# --- (h) a reviewer that completes on a DIFFERENT branch is not credited ----
+# branch_ledger_record derives its key from the cwd at CALL time. A backgrounded
+# reviewer finishes while the parent session is free to check out something
+# else, so an unbound credit would land in the ledger of a branch the reviewer
+# never saw — a wrong-target hit, not a miss, into evidence the push gate treats
+# as durable. _REPO2 stands in for "a different branch/repo": a genuinely
+# different ledger key.
+_reset
+_run_dispatch "mv-1" "Review the diff for correctness"        # dispatched in _REPO
+_CWD="$_REPO2"
+_run_completion "mv-1" "Findings: 2" >/dev/null               # completes in _REPO2
+_CWD="$_REPO"
+if _has "$_REPO2"; then
+    _record_fail "(h1) completion on another branch does not credit it" "credited the wrong ledger"
+elif _has "$_REPO"; then
+    _record_fail "(h1) completion on another branch does not credit it" "credited the dispatch ledger from the wrong cwd"
 else
-    _record_fail "(i1) dispatch hook writes the pairing file the reader expects" "no file at $(_pairfile)"
+    _record_pass "(h1) completion on another branch credits neither ledger"
 fi
 
-_run "general-purpose" "$_DISPATCH_ID" "Findings: 1 blocking" "$_SID" >/dev/null
-if _has; then _record_pass "(i2) end-to-end: real dispatch pairing credits the completion"
-else _record_fail "(i2) end-to-end: real dispatch pairing credits the completion" "no ledger entry"; fi
+# The miss must leave a TRACE. A silent miss is how the foreground ordering
+# defect nearly shipped: "no reviewer ran" and "a reviewer ran, join refused"
+# must not look identical from the outside.
+if grep -q '^# branch-mismatch mv-1 ' "$(_complete_file)" 2>/dev/null; then
+    _record_pass "(h2) the refused credit leaves a diagnostic line"
+else
+    _record_fail "(h2) the refused credit leaves a diagnostic line" "no mismatch line recorded"
+fi
 
-# The dispatch hook must keep recording its OWN milestone unchanged — the
-# pairing write is additive, not a replacement.
-if _has_ran; then _record_pass "(i3) dispatch hook still records reviewer-ran"
-else _record_fail "(i3) dispatch hook still records reviewer-ran" "no reviewer-ran entry"; fi
-
-# --- (i4) a NON-reviewer dispatch writes NO pairing entry ------------------
-# The pairing file must carry only agent ids the dispatch predicate accepted;
-# if it recorded every dispatch, the completion hook's general-purpose arm
-# would credit every subagent that ever finished.
+# A diagnostic comment line must never be readable as an agent id.
 _reset
-jq -n --arg sid "$_SID" \
-  '{tool_name:"Agent", session_id:$sid,
-    tool_response:{is_error:false, agentId:"impl-agent-0001"},
-    tool_input:{subagent_type:"general-purpose", description:"Task 3: reviewer-evidence writer hook"}}' \
-  | ( cd "$_REPO" && CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${DISPATCH_HOOK}" ) >/dev/null 2>&1
-_run "general-purpose" "impl-agent-0001" "Implemented it" "$_SID" >/dev/null
-if _has; then _record_fail "(i4) implementation dispatch writes no pairing" "ledger entry written"
-else _record_pass "(i4) implementation dispatch writes no pairing"; fi
+printf '# branch-mismatch cm-1 dispatched=x completed=y\n' > "$(_dispatch_file)"
+_run_completion "#" "Findings: 1" >/dev/null
+if _has; then _record_fail "(h3) a comment line is not a pairing record" "ledger entry written"
+else _record_pass "(h3) a comment line is not a pairing record"; fi
 
-# --- (j) a session_id that is not a single path-safe segment is refused ----
-# The value is harness-supplied, but a recorder must not be the component that
-# turns a surprising value into a read or a write outside ~/.claude.
+# ===========================================================================
+# Lookup exactness
+# ===========================================================================
+
+# --- (i) the lookup is an exact FIELD match --------------------------------
+# `awk '$1==a'` is load-bearing: a prefix or a regex must not join.
 #
-# The traversal is made REACHABLE rather than asserted in the abstract: an
-# earlier version of this cell used a bare "../../escape", which resolves
-# through a non-existent directory and so is refused whether the guard is there
-# or not — it passed with the guard deleted. Here the first path component is
-# made to exist, so without the guard the lookup genuinely escapes to the
-# planted file and credits.
-_reset
-_ESC_DIR="${HOME}/.claude/.skill-reviewer-dispatch-session-x"
-mkdir -p "${_ESC_DIR}"
-_ESC_TARGET="${HOME}/planted-pairing"
-printf '%s\n' "aj" > "${_ESC_TARGET}"
-_run "general-purpose" "aj" "output" "x/../../planted-pairing" >/dev/null
-if [ "${_STATUS}" -ne 0 ]; then
-    _record_fail "(j) unsafe session_id is refused" "non-zero exit ${_STATUS}"
-elif _has; then
-    _record_fail "(j) unsafe session_id is refused" "escaped to the planted file and credited"
-else
-    _record_pass "(j) unsafe session_id is refused, exit 0"
-fi
-rm -rf "${_ESC_DIR}" "${_ESC_TARGET}"
+# The planted record MUST carry the REAL ledger key. An earlier version planted
+# a placeholder, so the branch comparison refused the credit no matter what the
+# lookup did, and both cells passed with the exactness deleted — the mutation
+# was masked by an unrelated correct guard. Isolating one variable means every
+# OTHER gate has to be satisfied.
+_KEYNOW="$(cd "$_REPO" && branch_ledger_key)"
+_reset; printf '%s %s\n' "px-1xyz" "$_KEYNOW" > "$(_dispatch_file)"
+_run_completion "px-1" "output" >/dev/null
+if _has; then _record_fail "(i1) a prefix does not join" "ledger entry written"
+else _record_pass "(i1) a prefix does not join"; fi
 
-# --- (j2) an unsafe session_id must not break the DISPATCH hook -------------
-# The generalisation of the bug (i3) caught: new best-effort code must never be
-# able to suppress the pre-existing milestone, on any input.
+_reset; printf '%s %s\n' "rx-219" "$_KEYNOW" > "$(_dispatch_file)"
+_run_completion "rx-2.9" "output" >/dev/null
+if _has; then _record_fail "(i2) a regex metachar in the agent id does not join" "ledger entry written"
+else _record_pass "(i2) a regex metachar in the agent id does not join"; fi
+
+# (i3) POSITIVE CONTROL for (i1)/(i2). Without it, "did not credit" is
+# indistinguishable from "this harness cannot credit at all" — the exact
+# mistake that made the two cells above vacuous. Same planted-record shape,
+# exact id, must credit.
+_reset; printf '%s %s\n' "px-2" "$_KEYNOW" > "$(_dispatch_file)"
+_run_completion "px-2" "output" >/dev/null
+if _has; then _record_pass "(i3) positive control: an exact planted record DOES join"
+else _record_fail "(i3) positive control: an exact planted record DOES join" "no ledger entry"; fi
+
+# ===========================================================================
+# Contracts and regressions
+# ===========================================================================
+
+# --- (j) recorder contract: nothing on stdout, exit 0, on the CREDIT path ---
 _reset
-jq -n '{tool_name:"Agent", session_id:"../../nope",
-    tool_response:{is_error:false, agentId:"safe-id-1"},
-    tool_input:{subagent_type:"general-purpose", description:"Review the diff"}}' \
-  | ( cd "$_REPO" && CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${DISPATCH_HOOK}" ) >/dev/null 2>&1
-if _has_ran; then _record_pass "(j2) unsafe session_id does not suppress reviewer-ran"
-else _record_fail "(j2) unsafe session_id does not suppress reviewer-ran" "no reviewer-ran entry"; fi
+_run_dispatch "out-1" "Review the diff for correctness"
+_OUT="$(_run_completion "out-1" "Findings: 1")"
+if [ -n "${_OUT}" ]; then _record_fail "(j) recorder writes nothing to stdout" "stdout: ${_OUT}"
+elif [ "${_STATUS}" -ne 0 ]; then _record_fail "(j) recorder exits 0" "exit ${_STATUS}"
+else _record_pass "(j) recorder writes nothing to stdout and exits 0"; fi
+
+# --- (j2) an exhausted completion file must not kill the join --------------
+# `reviewer_pairing_note_complete` returns non-zero when the append does not
+# happen (size ceiling, unwritable HOME). Unguarded under `trap 'exit 0' ERR`
+# that terminates the hook before the join, silently ending every credit for the
+# session. Found by a mutation whose real fault was masked by this early exit.
+_reset
+_run_dispatch "full-1" "Review the diff for correctness"
+# push the completion half past the 64KiB ceiling
+_i=0; : > "$(_complete_file)"
+while [ "$_i" -lt 2000 ]; do
+    printf 'padpadpadpadpadpadpadpadpadpadpadpadpadpad%s\n' "$_i" >> "$(_complete_file)"
+    _i=$(( _i + 1 ))
+done
+_run_completion "full-1" "Findings: 1" >/dev/null
+if _has; then _record_pass "(j2) a full completion file does not stop the join"
+else _record_fail "(j2) a full completion file does not stop the join" "no ledger entry"; fi
 
 # --- (k) malformed / empty input never fails --------------------------------
 _reset
@@ -222,54 +289,99 @@ else
     _record_fail "(k) malformed and empty input exit 0 with no record" "exits ${_S1}/${_S2}"
 fi
 
-# --- (l) registration ------------------------------------------------------
+# --- (l) the dispatch hook still records reviewer-ran -----------------------
+# The regression that actually happened: new best-effort work placed ABOVE the
+# existing ledger write tripped the ERR trap on a redirection failure and
+# silently deleted the pre-existing milestone.
+_reset
+_run_dispatch "ran-1" "Review the diff for correctness"
+if _has_ran; then _record_pass "(l1) dispatch hook still records reviewer-ran"
+else _record_fail "(l1) dispatch hook still records reviewer-ran" "no reviewer-ran entry"; fi
+
+# ...including when the new code's inputs are hostile.
+_reset
+_dispatch_payload "safe-id-1" "Review the diff for correctness" "../../nope" \
+  | ( cd "$_REPO" && CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${DISPATCH_HOOK}" ) >/dev/null 2>&1
+if _has_ran; then _record_pass "(l2) an unsafe session_id does not suppress reviewer-ran"
+else _record_fail "(l2) an unsafe session_id does not suppress reviewer-ran" "no reviewer-ran entry"; fi
+
+# --- (m) an unsafe session_id is refused, and the traversal is REACHABLE ----
+# A bare "../../escape" resolves through a non-existent directory and is refused
+# whether the guard exists or not — an earlier version of this cell was vacuous
+# for exactly that reason. Here the first path component is made to exist, so
+# without the guard the lookup genuinely escapes to the planted file and joins.
+_reset
+mkdir -p "${HOME}/.claude/.skill-reviewer-dispatch-session-x"
+printf '%s %s\n' "esc-1" "$(cd "$_REPO" && branch_ledger_key)" > "${HOME}/planted-dispatch"
+_run_completion "esc-1" "Findings: 1" "x/../../planted-dispatch" >/dev/null
+if [ "${_STATUS}" -ne 0 ]; then
+    _record_fail "(m) unsafe session_id is refused" "exit ${_STATUS}"
+elif _has; then
+    _record_fail "(m) unsafe session_id is refused" "escaped to the planted file and credited"
+else
+    _record_pass "(m) unsafe session_id is refused, exit 0"
+fi
+rm -rf "${HOME}/.claude/.skill-reviewer-dispatch-session-x" "${HOME}/planted-dispatch"
+
+# ===========================================================================
+# Wiring
+# ===========================================================================
+
 if jq -e '[.hooks.SubagentStop[]?.hooks[]?.command]
           | any(test("reviewer-completion-hook\\.sh"))' \
      "${PROJECT_ROOT}/hooks/hooks.json" >/dev/null 2>&1; then
-    _record_pass "(l1) registered on SubagentStop in hooks.json"
+    _record_pass "(n1) registered on SubagentStop in hooks.json"
 else
-    _record_fail "(l1) registered on SubagentStop in hooks.json" "not found"
+    _record_fail "(n1) registered on SubagentStop in hooks.json" "not found"
 fi
 
 # The event name is exact. A typo registers a hook that never fires, and the
-# failure mode is silence, which every other cell here would pass through.
+# failure mode is silence, which every behavioural cell above would sail past.
 if jq -e '.hooks | keys | any(. == "SubagentStop")' \
      "${PROJECT_ROOT}/hooks/hooks.json" >/dev/null 2>&1; then
-    _record_pass "(l2) the event key is spelled SubagentStop"
+    _record_pass "(n2) the event key is spelled SubagentStop"
 else
-    _record_fail "(l2) the event key is spelled SubagentStop" "no such key"
+    _record_fail "(n2) the event key is spelled SubagentStop" "no such key"
 fi
 
-# --- (m) diagnostic-only: never a gate-enforcement component ---------------
+# --- (o) diagnostic-only: never a gate-enforcement component ---------------
 # _GATE_ENFORCE_LIBS drives both the session-start precondition canary and the
-# installed-plugin drift manifest. A diagnostic recorder joining it would make
-# a missing recorder announce as a degraded GATE.
-if grep -q 'reviewer-completion-hook' "${PROJECT_ROOT}/hooks/session-start-hook.sh" 2>/dev/null; then
-    _record_fail "(m) not a gate-enforcement component" "referenced by session-start canary/manifest"
+# installed-plugin drift manifest. A diagnostic recorder joining it would make a
+# missing recorder announce as a degraded GATE.
+_OFF=0
+for _f in reviewer-completion-hook reviewer-pairing; do
+    grep -q "$_f" "${PROJECT_ROOT}/hooks/session-start-hook.sh" 2>/dev/null && _OFF=1
+done
+if [ "$_OFF" -eq 1 ]; then
+    _record_fail "(o1) not a gate-enforcement component" "referenced by session-start canary/manifest"
 else
-    _record_pass "(m) not a gate-enforcement component"
+    _record_pass "(o1) not a gate-enforcement component"
 fi
 
-# It must also never appear in the guard: this change wires no gate.
 if grep -q 'reviewer-returned' "${PROJECT_ROOT}/hooks/openspec-guard.sh" 2>/dev/null; then
-    _record_fail "(m2) no gate reads reviewer-returned in this change" "openspec-guard.sh references it"
+    _record_fail "(o2) no gate reads reviewer-returned in this change" "openspec-guard.sh references it"
 else
-    _record_pass "(m2) no gate reads reviewer-returned in this change"
+    _record_pass "(o2) no gate reads reviewer-returned in this change"
 fi
 
-# --- (n) the pairing file is covered by the state GC ----------------------
-# Behavioural pruning is asserted in tests/test-state-file-cleanup.sh; here we
-# only pin that the name and its current-session exclusion are both present, so
-# adding one without the other cannot pass.
+# --- (p) both pairing families are GC'd, each with its own exclusion --------
+# Behavioural pruning is asserted in tests/test-state-file-cleanup.sh. Here both
+# halves are pinned together, so adding a family's glob without its
+# current-session exclusion (which would prune the LIVE session's pairing and
+# silently break every later join) cannot pass.
 _SS="${PROJECT_ROOT}/hooks/session-start-hook.sh"
-if grep -q "name '\.skill-reviewer-dispatch-\*'" "$_SS" 2>/dev/null \
-   && grep -q '! -name "\.skill-reviewer-dispatch-\${_SESSION_TOKEN}"' "$_SS" 2>/dev/null; then
-    _record_pass "(n) pairing file is GC'd with a current-session exclusion"
+_GCOK=1
+for _k in dispatch complete; do
+    grep -q "name '\.skill-reviewer-${_k}-\*'" "$_SS" 2>/dev/null || _GCOK=0
+    grep -q "! -name \"\.skill-reviewer-${_k}-\${_SESSION_TOKEN}\"" "$_SS" 2>/dev/null || _GCOK=0
+done
+if [ "$_GCOK" -eq 1 ]; then
+    _record_pass "(p) both pairing families are GC'd with current-session exclusions"
 else
-    _record_fail "(n) pairing file is GC'd with a current-session exclusion" "name or exclusion missing"
+    _record_fail "(p) both pairing families are GC'd with current-session exclusions" "a glob or exclusion is missing"
 fi
 
-rm -rf "$_REPO"
+rm -rf "$_REPO" "$_REPO2"
 export HOME="$_OLDHOME"
 print_summary
 exit $?

--- a/tests/test-state-file-cleanup.sh
+++ b/tests/test-state-file-cleanup.sh
@@ -128,23 +128,29 @@ echo "--- C6: reviewer-dispatch pairing GC ---"
 setup_test_env
 mkdir -p "${HOME}/.claude"
 STALE_PAIR="${HOME}/.claude/.skill-reviewer-dispatch-session-deadbeef-old"
-printf 'a1b2c3\n' > "${STALE_PAIR}"
-backdate "${STALE_PAIR}"
+STALE_DONE="${HOME}/.claude/.skill-reviewer-complete-session-deadbeef-old"
+printf 'a1b2c3 deadkey\n' > "${STALE_PAIR}"
+printf 'a1b2c3\n' > "${STALE_DONE}"
+backdate "${STALE_PAIR}"; backdate "${STALE_DONE}"
 run_hook
 TOK="$(cat "${HOME}/.claude/.skill-session-token" 2>/dev/null)"
-if [ -f "${STALE_PAIR}" ]; then
-    _record_fail "C6a: stale dead-token pairing pruned" "still present"
+if [ -f "${STALE_PAIR}" ] || [ -f "${STALE_DONE}" ]; then
+    _record_fail "C6a: stale dead-token pairing halves pruned" "still present"
 else
-    _record_pass "C6a: stale dead-token pairing pruned"
+    _record_pass "C6a: stale dead-token pairing halves pruned"
 fi
+# Both halves must survive: pruning EITHER one mid-session silently breaks
+# every later join, and the join needs both sides present.
 CUR_PAIR="${HOME}/.claude/.skill-reviewer-dispatch-${TOK}"
-printf 'a1b2c3\n' > "${CUR_PAIR}"
-backdate "${CUR_PAIR}"        # stale mtime, but it's the ACTIVE token
+CUR_DONE="${HOME}/.claude/.skill-reviewer-complete-${TOK}"
+printf 'a1b2c3 curkey\n' > "${CUR_PAIR}"
+printf 'a1b2c3\n' > "${CUR_DONE}"
+backdate "${CUR_PAIR}"; backdate "${CUR_DONE}"   # stale mtime, but it's the ACTIVE token
 run_hook
-if [ -f "${CUR_PAIR}" ]; then
-    _record_pass "C6b: current-session pairing preserved despite stale mtime"
+if [ -f "${CUR_PAIR}" ] && [ -f "${CUR_DONE}" ]; then
+    _record_pass "C6b: current-session pairing halves preserved despite stale mtime"
 else
-    _record_fail "C6b: current-session pairing preserved despite stale mtime" "deleted"
+    _record_fail "C6b: current-session pairing halves preserved despite stale mtime" "deleted"
 fi
 teardown_test_env
 

--- a/tests/test-state-file-cleanup.sh
+++ b/tests/test-state-file-cleanup.sh
@@ -118,4 +118,34 @@ else
 fi
 teardown_test_env
 
+# ---------------------------------------------------------------------------
+# C6 — reviewer-dispatch pairing file (openspec/changes/reviewer-completion-
+# evidence/): stale dead-token pairings are pruned with the family; the CURRENT
+# session's pairing is preserved. A pairing GC'd mid-session would silently
+# demote every later general-purpose reviewer completion to "not a reviewer".
+# ---------------------------------------------------------------------------
+echo "--- C6: reviewer-dispatch pairing GC ---"
+setup_test_env
+mkdir -p "${HOME}/.claude"
+STALE_PAIR="${HOME}/.claude/.skill-reviewer-dispatch-session-deadbeef-old"
+printf 'a1b2c3\n' > "${STALE_PAIR}"
+backdate "${STALE_PAIR}"
+run_hook
+TOK="$(cat "${HOME}/.claude/.skill-session-token" 2>/dev/null)"
+if [ -f "${STALE_PAIR}" ]; then
+    _record_fail "C6a: stale dead-token pairing pruned" "still present"
+else
+    _record_pass "C6a: stale dead-token pairing pruned"
+fi
+CUR_PAIR="${HOME}/.claude/.skill-reviewer-dispatch-${TOK}"
+printf 'a1b2c3\n' > "${CUR_PAIR}"
+backdate "${CUR_PAIR}"        # stale mtime, but it's the ACTIVE token
+run_hook
+if [ -f "${CUR_PAIR}" ]; then
+    _record_pass "C6b: current-session pairing preserved despite stale mtime"
+else
+    _record_fail "C6b: current-session pairing preserved despite stale mtime" "deleted"
+fi
+teardown_test_env
+
 print_summary


### PR DESCRIPTION
## Why

The push gate's REVIEW milestone is credited when `Skill(superpowers:requesting-code-review)` returns. That `PostToolUse` `^Skill$` event fires at instruction-**load** time, so the crediting event cannot witness what it attests. Measured previously: 7 of 8 sampled denied-then-merged PRs merged with zero reviews, and those sessions were *satisfying* the gate rather than evading it.

`reviewer-evidence-hook.sh` (#220) improved on that by recording a milestone when a reviewer subagent is **dispatched** — but for a backgrounded dispatch its payload is a launch acknowledgement, so a reviewer that spawns and then crashes, stalls, or returns nothing is recorded identically to one that finished.

`SubagentStop` is a first-class Claude Code event this plugin did not subscribe to.

## What this adds

A `SubagentStop` hook recording a `reviewer-returned` milestone into the per-(repo+branch) branch ledger when a reviewer subagent runs to completion, joined to the dispatch-side classification by `agent_id` and bound to the branch it was dispatched on.

Diagnostic-only, same posture as the existing recorder: nothing on stdout, no `permissionDecision`, exit 0 on every failure path, excluded from `_GATE_ENFORCE_LIBS`. **No gate reads the new milestone** — pinned by a test cell asserting `openspec-guard.sh` does not mention it. The deny-flip is a separate future decision, to be argued as narrowly as the IMPLEMENT leg's.

## What was measured

Live, against Claude Code CLI 2.1.236, in isolated `claude -p --settings` sessions with unrelated hook events registered in the same runs as positive controls.

The payload carries `agent_id`, a verbatim plugin-qualified `agent_type`, the subagent's own transcript path, and its final message. Its `transcript_path` names the parent.

**Hook firing order is not guaranteed, and this killed the first design:**

| dispatch mode | order |
| --- | --- |
| `run_in_background: true` | dispatch fires 1.44s before completion |
| `run_in_background: false` | completion fires ~30ms before dispatch (3 of 3) |

A one-directional "dispatch writes, completion reads" design is therefore a systematic no-op for every foreground dispatch. That version was built and committed; the live probe showed the ledger receiving `reviewer-ran` and no `reviewer-returned`. The join is now symmetric — each hook publishes its own half before reading the other, and whichever runs second records the milestone. It cannot double-miss: each side writes before it reads, so both missing would require `Wd < Rd < Wc < Rc < Wd`.

Also measured, and it forecloses the obvious alternative: at `SubagentStop` time the parent transcript contains **zero** lines mentioning `agent_id`, because the tool result carrying it is written afterwards. The link is not reconstructable after the fact.

## What this does NOT establish

The honest label is **observed completion**, never "reviewed". It shows a reviewer-shaped subagent ran to completion and emitted output. It does not show the output was a real review, that it examined this diff, that any finding was correct, or that anything was acted on. A model can still dispatch a reviewer prompted to rubber-stamp, and the human terminal bypass writes no record at all.

On whether a stricter predicate could do better: no predicate over review *content* survives the same agent having written both the code and the review. Any classifier over what the reviewer said is satisfiable by boilerplate cheaper than a real review the moment the dispatching model wants to unblock. This change is deliberately procedural rather than a quality judgement, and it *lowers* the cost of complying rather than raising a bar.

## Known-open, stated rather than buried

A **same-branch** agent-id collision still credits at spawn time for a reviewer that has produced nothing. The branch binding closes the cross-branch and cross-repo variants, not the ordinary one; no clean ordering constraint exists to close the rest. The residual protection is that ids are 17 random hex characters, which is measured as "8 observed, all distinct", not proven. `design.md` prices this honestly rather than presenting two independent guards.

Pairing-store saturation is recorded as `cannot_check` rather than left to look like `missing` — collapsing those biases every downstream reading in the unsafe direction, which CLAUDE.md is explicit about for the IMPLEMENT leg.

## Review

Four rounds: an adversarial design partner plus three code-review passes. Findings acted on, not summarised.

The design partner predicted the firing-order defect from the measurement before I had seen it. Later rounds found a false-credit path where the dispatch-side join credited on id membership alone — reproduced with a positive control first and a negative control isolating the single variable, then fixed and re-verified with the same instrument. A reviewer also overturned one of my own judgements: a guard I had documented as redundant turned out to fabricate false diagnostics for every ordinary subagent completion.

Three separate test cells were vacuous and were repaired, one of them twice — including a cell whose subject is structurally invisible end-to-end, because a downstream guard refuses the credit anyway and the cell goes green for the wrong reason. It is now a library-level assertion with its own positive control.

## Verification

- 38 cells in `tests/test-reviewer-completion-hook.sh`, mutation-verified 17/17, with every credit path asserted in **both** firing orders.
- Full declared gate (`.verify.yml`, 129 files) green, with a sha-bound clean verdict covering the head commit.
- `openspec validate --strict` passes.

## A note from shipping this

While opening this PR, the gate's REVIEW milestone went green the instant the review skill returned its **instructions** — before the reviewer dispatched from it had read anything. That is the defect this change addresses, reproduced by its own ship process.

Two earlier steps were recorded as explicit attested skips rather than papered over: the design brief arrived fully specified and its one open question was settled by measurement rather than option exploration, and a single-mechanism change had no independent tasks to sequence.
