### PR TITLE
Record the invariant behind the '&' arm and pin the heredoc seam

### DIFF
--- a/hooks/lib/git-command.sh
+++ b/hooks/lib/git-command.sh
@@ -267,6 +267,39 @@ _gc_split_segments() {
                     # `a\\>` (escaped backslash, then a real operator) also takes
                     # this arm and over-splits. That is the safe direction and is
                     # left deliberately: a merge may never remove a command.
+                    # THE INVARIANT, stated because it is NOT what it looks
+                    # like. A bare terminal `<`/`>` does NOT mean "an operator
+                    # was just appended": this scanner has no escape mode, so
+                    # `a\>` also ends in a bare `>`. Escaped or not, the
+                    # character goes through the SAME arm — the default arm for
+                    # `>` (there is no `'>'` arm), the `'<'` arm's first branch
+                    # for `<` — so nothing upstream distinguishes them. The
+                    # `*'\<'|*'\>'` arm below is the SOLE discriminator, and
+                    # deleting it restores the bypass described above (measured:
+                    # the escaped-operator cells go red).
+                    #
+                    # ON REPLACING THIS WITH A FLAG (recommended in review of
+                    # #242, as "one variable, single writer"). The naive form —
+                    # set on ANY normal-mode `<`/`>` append — is a BYPASS, not a
+                    # cosmetic change: it is set for `a\>` too, so it merges
+                    # `echo a\>&git push origin main`, which real bash executes.
+                    # Detection then fails outright and every gate is skipped,
+                    # including the fail-closed REVIEW/VERIFY gate.
+                    #
+                    # An escape-AWARE flag is, however, perfectly constructible
+                    # (skip the raise when the buffer already ends in `\`), and
+                    # such a variant passes the whole detection suite. So the
+                    # honest objection is NOT "it cannot be done" — an earlier
+                    # draft of this comment claimed that and was wrong. It is
+                    # that the flag moves one correctness obligation, today
+                    # discharged by a single pattern in one place, onto every
+                    # append site in the scanner. The realistic mistake is not
+                    # forgetting the escape: it is raising the flag on the `'<'`
+                    # arm's HEREDOC branch, which merges
+                    # `cat <<EOF&git push origin main` while leaving the
+                    # escaped-operator cells green. That seam is pinned
+                    # separately in tests/test-push-gate-detection.sh (NEW-3),
+                    # because it is the one the rest of the suite does not catch.
                     case "${_seg}" in
                         *'\<'|*'\>') _out="${_out}${_seg}${_GC_SEP}"; _seg="" ;;
                         *'<'|*'>') _seg="${_seg}${_c}" ;;

--- a/tests/test-push-gate-detection.sh
+++ b/tests/test-push-gate-detection.sh
@@ -520,6 +520,53 @@ done
 # "never saw a push".
 _assert_pred "escaped > cannot hide a push behind a deletion" 1 $D 'git push --delete origin foo; cd a\>&git push origin main'
 
+# --- NEW-3: the HEREDOC seam ------------------------------------------------
+#
+#   cat <<EOF&git push origin main
+#   EOF
+#
+# Real bash backgrounds `cat` with the heredoc attached and RUNS THE PUSH
+# (measured with a file-creation oracle and a PATH-shimmed `git`, never with
+# stdout text: bash quotes an offending command back in its syntax-error
+# message, so grepping combined output for a marker reports commands that never
+# ran — that mistake produced a phantom finding while this cell was written).
+#
+# WHY IT EXISTS, stated precisely because the obvious reason is wrong. Review of
+# #242 proposed replacing the `'&')` arm's buffer-tail inspection with a flag
+# raised when the scanner appends `<`/`>`. An escape-aware flag passes the four
+# escaped-operator cells above AND this one, so this cell is NOT "the case a
+# careful flag still gets wrong" — an earlier draft said that and it was
+# measured false. What it pins is a DIFFERENT and likelier error: raising the
+# flag on the `'<'` arm's HEREDOC branch. That variant leaves all five cells
+# above green and merges this command, so before this cell the entire suite
+# passed while detection was bypassed. It is the seam the rest of the suite
+# does not cover, which is the whole of its claim to a place here.
+#
+# THE `EOF` TERMINATOR IS LOAD-BEARING. Without it `_pending` stays non-empty,
+# so `_GC_UNBALANCED=1`, so the guard takes its fail-closed substring path,
+# finds `git push` in the raw text and denies — and the cell passes while the
+# scanner is bypassed. Measured both ways.
+#
+# That prose is not enough on its own, so the precondition is ASSERTED. The
+# terminator is not the only route to an unbalanced parse: anything that stops
+# `cat` classifying as a heredoc data sink (see the sink list in
+# git-command.sh) also sends this payload down the substring path, and the cell
+# would sit green forever. A cell whose non-vacuity rests on a comment pins
+# nothing.
+_assert_pred "NEW-3 payload parses balanced (else the cell below is vacuous)" 0 \
+    command_parse_balanced 'cat <<EOF&git push origin main
+EOF'
+# Asserts the remedy text, not bare "deny", for the M9 reason: it pins WHICH
+# gate denied, so a future change that widens a skip and shifts the deny to
+# VERIFY or routing-governance is caught rather than absorbed. It does NOT
+# distinguish the precise path from the substring fallback — both reach the
+# same message — which is exactly why the balanced-parse assertion above has to
+# carry that half.
+out="$(_run 'cat <<EOF&git push origin main
+EOF')"
+assert_contains "heredoc operator cannot hide a trailing push" \
+    "requesting-code-review has not run" "$out"
+
 # THE DANGEROUS DIRECTION, pinned explicitly. A refspec-less `git push` ships the
 # current branch, so it must NEVER certify as deletion-only — and redirection
 # stripping is exactly the kind of change that could have made it, by removing


### PR DESCRIPTION
## Flagged for explicit human review

This branch modifies `hooks/lib/git-command.sh`, one of the files that defines
what "verified" means here, so the verdict clearing this push is partly
self-referential. **That file is the one wanting a human eye** — though its
change is comment-only: nothing deleted, and byte-identical once comments are
stripped (checked three ways, including `declare -f` equality across every
function).

## What this closes

#242 left a section headed "Recommended follow-up, deliberately not done here".
It proposed swapping the `'&')` arm's buffer-tail inspection for a boolean
raised whenever the scanner appends `<`/`>` outside quotes, and parked it as
desirable-but-risky. Measuring it reversed the verdict.

Written that way, the boolean also goes up on the `>` inside `a\>`. Nothing in
this scanner tracks escapes, so both spellings travel the identical path into
the buffer, and the gate loses these two commands:

    echo a\>&git push origin main
    cat <<EOF&git push origin main

bash runs the push in each. Once the push stops being detected, no gate fires at
all — the fail-closed REVIEW/VERIFY gate included.

Which makes `*'\<'|*'\>'` the only thing telling those two spellings apart. It
reads like a belt-and-braces duplicate of the arm beneath it and is nothing of
the kind. That asymmetry is what the new comment exists to record.

## Two claims I made that review destroyed

Both deleted rather than hedged. When the whole deliverable is a warning aimed at
a future engineer, a warning that dies to one counter-example is worse than
silence — it discredits the half that was true.

1. **"Backslash parity is the only way; that means rewriting the scanner."**
   Wrong. The pattern it replaces already peeks exactly one character back, so a
   boolean that skips its raise when the buffer's last character is a backslash
   is equally capable, and it clears the whole detection suite. The real cost is
   custodial: one rule enforced in a single place becomes a rule every append
   site has to remember.
2. **"Over-splitting `a\\>` is free — you only ever orphan an fd number."**
   Wrong, and I reached it by looking at `&2` alone. Whatever trails the `&` is
   what gets orphaned; with `echo a\\>&git push origin main` that orphan is a
   literal push, the guard blocks it, and bash was never going to run git — it
   just writes a file called `git`. A false deny, in other words. The paragraph
   is gone, not rewritten, since a correct version of it already sits three
   lines up.

## The cell, and why it isn't the obvious one

#242's four escaped-operator cells already turn red against the naive boolean —
five, counting NEW-2. An escape-aware boolean sails past all of them *and* past
the new cell, so this is emphatically not "the one a careful implementation still
fumbles". An earlier draft said exactly that; it was false.

The mistake it does catch is a likelier one: raising the boolean inside the `'<'`
arm's heredoc branch. Do that and every cell above stays green while
`cat <<EOF&git push origin main` quietly merges. Measured — one cell in the
entire suite reddens, this one.

## The cell asserts its own precondition

Prose in the cell explained that its `EOF` line matters: drop it and the parse
goes unbalanced, the guard falls back to substring matching, denies on the raw
text, and the cell passes over a bypassed scanner.

Review then found a second road to that same vacuity which the prose hadn't
imagined — anything demoting `cat` out of the heredoc data-sink list routes the
payload down the identical fallback. The cell now calls `command_parse_balanced`
on its own payload and asserts the result. Measured: strip `cat` from the sink
list and the main assertion happily passes while the precondition fails.
Explaining non-vacuity and asserting it are different things.

## Testing

Declared gate fully green, 130/130 files, verdict sha-bound to the head commit.
Every mutation was `cmp`'d to confirm it had actually applied.

Two of my own instruments lied to me first, which seems worth recording:

- Grepping combined output for a marker string "found" a bypass that wasn't
  there. A bash syntax error echoes the offending line back, so the marker
  matched a command that never executed. Oracles need side effects.
- I nearly dismissed the escape-aware boolean, until I noticed my rebuild had
  emitted a pattern matching a pair of backslashes where one was meant.

## Known, deliberately not fixed here

Review flagged the same faulty reasoning in #242's existing block at
`tests/test-push-gate-detection.sh:503-507` — naming the remedy text can't
separate the precise path from the substring fallback, because both arrive at the
same message. Its actual value is identifying *which* gate denied. I corrected my
own copy and left that one alone so this diff only claims what it can defend.
Say the word and it goes in here too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XU27wkcYCVgRMFKQVGecPP
