### PR TITLE
Deliver the reviewer scope rule, and record review authorship provenance (#245)

### DIFF
--- a/openspec/changes/deliver-reviewer-scope-rule/proposal.md
+++ b/openspec/changes/deliver-reviewer-scope-rule/proposal.md
@@ -1,0 +1,39 @@
+# Deliver the reviewer-facing scope rule to the reviewer
+
+## Why
+
+PR #244 added a two-category do-not-flag table to `agent-team-review` §3,
+introduced as *"scope rules for what a reviewer raises"*. §3 is protocol prose
+that the **lead** reads. A spawned reviewer sees only its own prompt block under
+`## Reviewer Spawn Templates`, and none of the four lens prompts carried the
+rule — so the half that constrains the lead (never demote a delivered finding on
+provenance grounds) was enforced, while the half addressed to reviewers was
+claimed and delivered to nobody. Filed as issue #245 item 1.
+
+The issue offered two options: duplicate the rule into each lens prompt, or
+reword §3 to stop claiming reviewer-facing scope. The second is cheaper but
+retracts a rule that the `adversarial-review` spec already states as a reviewer
+obligation ("A reviewer lens MUST NOT raise…"), which would leave the spec
+demanding behaviour no prompt asks for.
+
+## What Changes
+
+- Every lens prompt gains an identical `## Scope` block carrying the same two
+  categories, their "raise it anyway" exceptions, and the ownership-not-size
+  rule. Duplication is the only delivery mechanism a subagent prompt has — the
+  same reasoning that already duplicates the Delivery Contract into all four.
+- §3 keeps the lead's copy and gains a PAIRED note naming where the reviewer's
+  copy lives and which gates pin the two together.
+- Three mechanical pins, so the copies cannot drift: per-lens needles in the
+  existing `required-clauses.txt` fixture; a block-identity control across the
+  four prompts; and a category-SET equality check between §3's table and the
+  prompt block. The two-category ceiling is asserted separately on the delivered
+  copy in `tests/test-adversarial-governance.sh`, because a third category added
+  to both copies satisfies set equality.
+
+## Impact
+
+- `skills/agent-team-review/SKILL.md` — prose only, no routing or config change.
+- `tests/test-reviewer-dispatch-brief.sh`, `tests/test-adversarial-governance.sh`,
+  `tests/fixtures/agent-team-review/dispatch-brief/required-clauses.txt`.
+- Capability: `adversarial-review`.

--- a/openspec/changes/deliver-reviewer-scope-rule/specs/adversarial-review/spec.md
+++ b/openspec/changes/deliver-reviewer-scope-rule/specs/adversarial-review/spec.md
@@ -14,6 +14,14 @@ the two copies MUST carry the same category set, the reviewer-facing copies MUST
 be identical to one another, and both facts MUST be asserted by a test — a
 comment pairing the copies is not sufficient.
 
+The assertion available here is that each spawn template CARRIES the canonical
+text. It is NOT an assertion that a reviewer receives only these exclusions: a
+contradictory instruction elsewhere in the same prompt, a dispatch path that does
+not use these templates, or a lens defined outside the template section all
+remain outside what any static check can see. That boundary MUST be stated
+wherever the guarantee is claimed, rather than left to be inferred from a passing
+gate.
+
 #### Scenario: A lens prompt omits the scope rule
 
 - **GIVEN** the reviewer spawn templates in `agent-team-review`

--- a/openspec/changes/deliver-reviewer-scope-rule/specs/adversarial-review/spec.md
+++ b/openspec/changes/deliver-reviewer-scope-rule/specs/adversarial-review/spec.md
@@ -1,0 +1,36 @@
+# Spec delta: adversarial-review — deliver the reviewer scope rule
+
+## ADDED Requirements
+
+### Requirement: The reviewer scope rule MUST be delivered in every reviewer prompt
+
+A scope rule addressed to reviewers MUST appear in the spawn template of every
+reviewer lens, not only in the lead-facing protocol prose. A reviewer subagent
+reads only its own prompt, so a rule stated once in protocol text constrains no
+reviewer.
+
+Where the same rule is held in both a lead-facing and a reviewer-facing copy,
+the two copies MUST carry the same category set, the reviewer-facing copies MUST
+be identical to one another, and both facts MUST be asserted by a test — a
+comment pairing the copies is not sufficient.
+
+#### Scenario: A lens prompt omits the scope rule
+
+- **GIVEN** the reviewer spawn templates in `agent-team-review`
+- **WHEN** any lens prompt does not carry the scope block
+- **THEN** the dispatch-brief gate MUST fail
+- **AND** the failure MUST name the lens that is missing it
+
+#### Scenario: The two copies diverge
+
+- **GIVEN** a lead-facing scope table and a reviewer-facing scope block
+- **WHEN** a category is added to or removed from exactly one of them
+- **THEN** the gate MUST fail rather than ship a reviewer scoped by a rule the
+  lead does not hold
+
+#### Scenario: The two-category ceiling holds in the delivered copy
+
+- **GIVEN** the scope block delivered to a reviewer
+- **WHEN** a third provenance category is added to it
+- **THEN** the governance gate MUST fail, whether or not the lead-facing copy
+  gained the same category

--- a/openspec/changes/observed-dispatch-telemetry/specs/pdlc-safety/spec.md
+++ b/openspec/changes/observed-dispatch-telemetry/specs/pdlc-safety/spec.md
@@ -17,7 +17,11 @@ The artifact MUST NOT report `observed` for a value it did not measure. Absence
 of an observation MUST record as "not observed" and MUST NOT be rendered as an
 observed negative.
 
-`schema_version` MUST be incremented to 2. `predicate_version` MUST NOT change:
+`schema_version` MUST be incremented (this change takes it to 2; the current value
+is set by the most recent delta over this artifact — see `review-authorship-provenance`,
+which takes it to 3). Pinning a literal here made this requirement contradict a later
+one over the same field, which strict validation cannot see. `predicate_version` MUST
+NOT change:
 this adds a descriptive field and alters no fire condition, so existing records
 remain poolable and the pre-registered observation horizon is not restarted.
 

--- a/openspec/changes/review-authorship-provenance/proposal.md
+++ b/openspec/changes/review-authorship-provenance/proposal.md
@@ -17,11 +17,16 @@ Provenance is the part that is currently unrecoverable.
 ## What Changes
 
 - `record-review-verdict.sh` gains `--self-authored` and always records an
-  `independence` field: `self-authored`, `dispatch-observed`, or `unknown`. The middle
-  value is named for what was measured: `reviewer-ran` witnesses a DISPATCH, never a
-  return and never that the subagent read this diff, so any reviewer dispatched earlier
-  on the branch sets it. Calling it `independent` would assert of a stale observation
-  exactly what the `unknown` default refuses to assert of an absent one (review finding).
+  `independence` field: `self-authored`, `dispatch-observed`, `pr-review-imported`,
+  or `unknown`. Each value is named for what was measured, never for the conclusion a
+  reader would like to draw. `dispatch-observed` rests on `reviewer-ran`, which witnesses
+  a DISPATCH — never a return, and never that the subagent read this diff — so any
+  reviewer dispatched earlier on the branch sets it; calling it `independent` would
+  assert of a stale observation exactly what the `unknown` default refuses to assert of
+  an absent one. `pr-review-imported` is deliberately NOT folded into it: the import path
+  runs `gh pr view` and observes no dispatch at all, and nothing compares the PR
+  reviewer's identity against the diff's author, so it shows a review EXISTS rather than
+  that it was independent. Both distinctions came from review findings.
 - `schema_version` 2 → 3. `predicate_version` is untouched — this describes a
   record, it does not change any fire condition, so existing shadow records stay
   poolable. The active `observed-dispatch-telemetry` delta pinned the literal value 2,

--- a/openspec/changes/review-authorship-provenance/proposal.md
+++ b/openspec/changes/review-authorship-provenance/proposal.md
@@ -17,11 +17,17 @@ Provenance is the part that is currently unrecoverable.
 ## What Changes
 
 - `record-review-verdict.sh` gains `--self-authored` and always records an
-  `independence` field: `self-authored`, `independent`, or `unknown`.
+  `independence` field: `self-authored`, `dispatch-observed`, or `unknown`. The middle
+  value is named for what was measured: `reviewer-ran` witnesses a DISPATCH, never a
+  return and never that the subagent read this diff, so any reviewer dispatched earlier
+  on the branch sets it. Calling it `independent` would assert of a stale observation
+  exactly what the `unknown` default refuses to assert of an absent one (review finding).
 - `schema_version` 2 → 3. `predicate_version` is untouched — this describes a
   record, it does not change any fire condition, so existing shadow records stay
-  poolable. This supersedes the numeric clause in the active
-  `observed-dispatch-telemetry` delta, which pinned the literal value 2.
+  poolable. The active `observed-dispatch-telemetry` delta pinned the literal value 2,
+  so this change AMENDS that clause in place rather than narrating a supersession the
+  spec corpus does not record — two active deltas asserting different literals for the
+  same field is a contradiction `openspec validate` passes straight over (review finding).
 - The skill's authorship guard and its verdict-recording rules name the flag, so
   the prose and the mechanism are pinned to each other in both directions.
 

--- a/openspec/changes/review-authorship-provenance/proposal.md
+++ b/openspec/changes/review-authorship-provenance/proposal.md
@@ -1,0 +1,56 @@
+# Record review authorship provenance on the verdict artifact
+
+## Why
+
+`agent-team-review`'s authorship guard asks a context that reviewed its own diff
+to withdraw the independence claim, and says plainly that nothing else will
+record it. That was accurate: the declaration existed only as prose in a report,
+so nothing downstream could tell a dispatched review from a self-review. Issue
+#245 item 2, carried over from PR #244.
+
+Live evidence from the session that produced #244: an independent reviewer was
+dispatched, returned a blocking finding that changed the code, and the REVIEW
+milestone was credited 39 minutes later by the `Skill()` return at a different
+sha. Invoking the skill and reading one's own diff produces the same record.
+Provenance is the part that is currently unrecoverable.
+
+## What Changes
+
+- `record-review-verdict.sh` gains `--self-authored` and always records an
+  `independence` field: `self-authored`, `independent`, or `unknown`.
+- `schema_version` 2 → 3. `predicate_version` is untouched — this describes a
+  record, it does not change any fire condition, so existing shadow records stay
+  poolable. This supersedes the numeric clause in the active
+  `observed-dispatch-telemetry` delta, which pinned the literal value 2.
+- The skill's authorship guard and its verdict-recording rules name the flag, so
+  the prose and the mechanism are pinned to each other in both directions.
+
+## Design notes
+
+**Why the artifact and not the branch ledger.** #245 suggested recording
+`independence: false` on the ledger entry. Two reasons not to. The ledger
+record's content is the documented `<sha> <utc-ts>` pair, read by position
+(`branch_ledger_sha` cuts field 1) — #133 chose a sidecar over widening it for
+exactly this. More importantly, an ABSENT sidecar is indistinguishable from "the
+review was independent", so every miss mode `branch-ledger.sh` already documents
+(a review recorded on a task branch and a push made from an integration branch;
+detached HEAD, which re-keys on every commit) would read as an independence
+claim. On the artifact the field is always present, and a record without it is a
+schema-2 record rather than an assertion about the review.
+
+**Why an admission outranks an observation.** `self-authored` wins over an
+observed dispatch. A witnessed spawn proves a subagent ran; it cannot show the
+subagent reviewed *this* diff from a context that did not write it. Ranking the
+telemetry higher would let the one honest declaration the skill asks for be
+overwritten by a signal that does not contradict it.
+
+**Why the default is `unknown`, never `independent`.** An absent signal is not
+evidence of independence. Defaulting the other way would manufacture, for free,
+exactly the claim #197 exists to stop being asserted.
+
+## Impact
+
+- `scripts/record-review-verdict.sh`, `skills/agent-team-review/SKILL.md`.
+- `tests/test-review-verdict.sh`, `tests/test-adversarial-governance.sh`.
+- No hook change; the push gate does not read the field, and a test asserts it.
+- Capability: `pdlc-safety`.

--- a/openspec/changes/review-authorship-provenance/specs/pdlc-safety/spec.md
+++ b/openspec/changes/review-authorship-provenance/specs/pdlc-safety/spec.md
@@ -5,14 +5,17 @@
 ### Requirement: The review verdict MUST record whether the review was independent
 
 The review verdict artifact MUST record an `independence` field with one of
-exactly three values: `self-authored`, `dispatch-observed`, or `unknown`.
+exactly four values: `self-authored`, `dispatch-observed`, `pr-review-imported`,
+or `unknown`.
 
 `self-authored` MUST be recorded when the caller declares that the reviewing
 context authored the diff under review, and MUST take precedence over an
 observed or imported dispatch — a witnessed dispatch cannot refute the
 declaration. `dispatch-observed` MUST be recorded only when a reviewer dispatch
-was observed on this branch or a pull-request review was imported, and no
-self-authorship was declared. Every other case MUST record `unknown`; absence of
+was observed on this branch and no self-authorship was declared.
+`pr-review-imported` MUST be recorded only when a pull-request review was
+resolved and no self-authorship was declared; it MUST NOT be collapsed into
+`dispatch-observed`, because the import path observes no dispatch. Every other case MUST record `unknown`; absence of
 a signal MUST NOT be recorded as a positive claim.
 
 The value MUST be named for what was measured. A dispatch record witnesses that a

--- a/openspec/changes/review-authorship-provenance/specs/pdlc-safety/spec.md
+++ b/openspec/changes/review-authorship-provenance/specs/pdlc-safety/spec.md
@@ -5,20 +5,28 @@
 ### Requirement: The review verdict MUST record whether the review was independent
 
 The review verdict artifact MUST record an `independence` field with one of
-exactly three values: `self-authored`, `independent`, or `unknown`.
+exactly three values: `self-authored`, `dispatch-observed`, or `unknown`.
 
 `self-authored` MUST be recorded when the caller declares that the reviewing
 context authored the diff under review, and MUST take precedence over an
 observed or imported dispatch — a witnessed dispatch cannot refute the
-declaration. `independent` MUST be recorded only when a dispatch was observed
-or a pull-request review was imported and no self-authorship was declared. Every
-other case MUST record `unknown`; absence of a signal MUST NOT be recorded as
-`independent`.
+declaration. `dispatch-observed` MUST be recorded only when a reviewer dispatch
+was observed on this branch or a pull-request review was imported, and no
+self-authorship was declared. Every other case MUST record `unknown`; absence of
+a signal MUST NOT be recorded as a positive claim.
+
+The value MUST be named for what was measured. A dispatch record witnesses that a
+reviewer subagent was dispatched — not that it returned, and not that it read the
+diff under review — so no value of this field MUST assert that a review was
+independent. A reader that needs that conclusion MUST draw it itself.
 
 `independence` MUST remain provenance. It MUST NOT, alone or collapsed with any
 other field, act as a deny predicate.
 
-`schema_version` MUST be incremented to 3. `predicate_version` MUST NOT change:
+`schema_version` MUST be incremented to 3 — the current value for this artifact,
+superseding the literal `2` pinned by `observed-dispatch-telemetry`, whose clause is
+amended in the same change to stop pinning a numeral. `predicate_version` MUST NOT
+change:
 this adds a descriptive field and alters no fire condition, so existing records
 remain poolable and no pre-registered observation horizon is restarted.
 
@@ -29,11 +37,11 @@ remain poolable and no pre-registered observation horizon is restarted.
 - **THEN** `independence` is `self-authored`
 - **AND** it is `self-authored` even when a reviewer dispatch was observed
 
-#### Scenario: An observed dispatch with no declaration is independent
+#### Scenario: An observed dispatch with no declaration records what was measured
 
 - **GIVEN** a reviewer subagent dispatch recorded for this branch
 - **WHEN** the verdict is recorded without the self-authorship flag
-- **THEN** `independence` is `independent`
+- **THEN** `independence` is `dispatch-observed`
 
 #### Scenario: No signal is not an independence claim
 
@@ -45,6 +53,6 @@ remain poolable and no pre-registered observation horizon is restarted.
 #### Scenario: The field never changes a gate decision
 
 - **GIVEN** two otherwise identical clean verdicts covering HEAD
-- **WHEN** one records `independence: "independent"` and the other
+- **WHEN** one records `independence: "dispatch-observed"` and the other
   `independence: "self-authored"`
 - **THEN** the push gate's output MUST be identical for both

--- a/openspec/changes/review-authorship-provenance/specs/pdlc-safety/spec.md
+++ b/openspec/changes/review-authorship-provenance/specs/pdlc-safety/spec.md
@@ -1,0 +1,50 @@
+# Spec delta: pdlc-safety — review authorship provenance
+
+## ADDED Requirements
+
+### Requirement: The review verdict MUST record whether the review was independent
+
+The review verdict artifact MUST record an `independence` field with one of
+exactly three values: `self-authored`, `independent`, or `unknown`.
+
+`self-authored` MUST be recorded when the caller declares that the reviewing
+context authored the diff under review, and MUST take precedence over an
+observed or imported dispatch — a witnessed dispatch cannot refute the
+declaration. `independent` MUST be recorded only when a dispatch was observed
+or a pull-request review was imported and no self-authorship was declared. Every
+other case MUST record `unknown`; absence of a signal MUST NOT be recorded as
+`independent`.
+
+`independence` MUST remain provenance. It MUST NOT, alone or collapsed with any
+other field, act as a deny predicate.
+
+`schema_version` MUST be incremented to 3. `predicate_version` MUST NOT change:
+this adds a descriptive field and alters no fire condition, so existing records
+remain poolable and no pre-registered observation horizon is restarted.
+
+#### Scenario: A declared self-review is recorded as such
+
+- **GIVEN** a context that authored the diff it is reviewing
+- **WHEN** the verdict is recorded with the self-authorship flag
+- **THEN** `independence` is `self-authored`
+- **AND** it is `self-authored` even when a reviewer dispatch was observed
+
+#### Scenario: An observed dispatch with no declaration is independent
+
+- **GIVEN** a reviewer subagent dispatch recorded for this branch
+- **WHEN** the verdict is recorded without the self-authorship flag
+- **THEN** `independence` is `independent`
+
+#### Scenario: No signal is not an independence claim
+
+- **GIVEN** no observed dispatch, no imported pull-request review, and no
+  self-authorship declaration
+- **WHEN** the verdict is recorded
+- **THEN** `independence` is `unknown`
+
+#### Scenario: The field never changes a gate decision
+
+- **GIVEN** two otherwise identical clean verdicts covering HEAD
+- **WHEN** one records `independence: "independent"` and the other
+  `independence: "self-authored"`
+- **THEN** the push gate's output MUST be identical for both

--- a/scripts/record-review-verdict.sh
+++ b/scripts/record-review-verdict.sh
@@ -24,16 +24,22 @@ _PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "${_HERE}/.." && pwd)}"
 
 PROVIDER=""; VERDICT=""; BASE=""; HEAD_ARG=""; FINDINGS=""; UNRESOLVED=""
 FROM_GH=""; DISPATCH_ATTEMPTED="false"; DISPATCH_SUCCEEDED="false"
+SELF_AUTHORED="false"
 
 _usage() {
     cat >&2 <<'EOF'
 usage: record-review-verdict.sh --provider <p> --verdict <v> [--base SHA --head SHA]
                                 [--findings N] [--unresolved-blocking N]
                                 [--dispatch-attempted] [--dispatch-succeeded]
+                                [--self-authored]
        record-review-verdict.sh --from-github <pr-number> [--provider github-import]
 
   --verdict   clean | findings-open | could-not-review
   --provider  local-agent | human | agent-team-review | github-import
+  --self-authored
+              the reviewing context also AUTHORED the diff. Records
+              independence:"self-authored" — the machine-readable half of the
+              skill's authorship guard. Provenance only; it never gates.
 
 A clean verdict REQUIRES --base and --head (or a resolvable PR); without a
 reviewed subject the verdict is downgraded to could-not-review.
@@ -51,6 +57,7 @@ while [ $# -gt 0 ]; do
         --from-github)          FROM_GH="${2:-}"; shift 2 ;;
         --dispatch-attempted)   DISPATCH_ATTEMPTED="true"; shift ;;
         --dispatch-succeeded)   DISPATCH_SUCCEEDED="true"; shift ;;
+        --self-authored)        SELF_AUTHORED="true"; shift ;;
         -h|--help)              _usage; exit 0 ;;
         *) echo "record-review-verdict: unknown argument '$1'" >&2; _usage; exit 2 ;;
     esac
@@ -147,6 +154,35 @@ else
     fi
 fi
 
+# ---- authorship provenance (#245) ------------------------------------------
+# agent-team-review's authorship guard asks a context that reviewed its own diff
+# to withdraw the independence CLAIM, and states plainly that nothing else will.
+# This is that "nothing else", in a field a reader can act on.
+#
+# Three values, and the ordering is deliberate:
+#   self-authored  the caller says the reviewing context wrote the diff. An
+#                  ADMISSION AGAINST INTEREST, so it outranks an observed
+#                  dispatch — a witnessed spawn cannot refute it (the dispatch
+#                  may have been for something else entirely), and treating the
+#                  observation as the stronger signal would let the one honest
+#                  declaration the skill asks for be overwritten by telemetry.
+#   independent    a dispatch was OBSERVED (or a real PR review imported) and no
+#                  self-authorship was declared.
+#   unknown        neither. Never "independent" by default: an absent signal is
+#                  not evidence of independence, and defaulting the other way
+#                  would manufacture the exact claim #197 exists to stop being
+#                  asserted for free.
+#
+# NOT a gate, alone or collapsed (#197's spec forbids it), and NOT written to
+# the branch ledger: that file's content is the documented `<sha> <utc-ts>` pair
+# read by position, and an absent sidecar there would be indistinguishable from
+# an independence claim under the miss modes branch-ledger.sh already documents.
+INDEPENDENCE="unknown"
+case "${DISPATCH_EVIDENCE}" in
+    observed|imported) INDEPENDENCE="independent" ;;
+esac
+[ "${SELF_AUTHORED}" = "true" ] && INDEPENDENCE="self-authored"
+
 # ---- resolve + validate the reviewed subject -------------------------------
 [ -n "${HEAD_ARG}" ] || HEAD_ARG="$(git -C "${_ROOT:-.}" rev-parse HEAD 2>/dev/null)" || HEAD_ARG=""
 _resolve() { git -C "${_ROOT:-.}" rev-parse --verify "${1}^{commit}" 2>/dev/null; }
@@ -195,14 +231,16 @@ jq -nc \
     --argjson da "${DISPATCH_ATTEMPTED}" \
     --argjson ds "${DISPATCH_SUCCEEDED}" \
     --arg de "${DISPATCH_EVIDENCE}" \
-    '{schema_version:2, provider:$provider,
+    --arg ind "${INDEPENDENCE}" \
+    '{schema_version:3, provider:$provider,
       reviewed_base_sha:$base, reviewed_head_sha:$head,
       changed_file_digest:$digest, changed_file_count:$fc,
       findings_total:$ft, unresolved_blocking:$ub, verdict:$verdict,
       dispatch_attempted:$da, dispatch_succeeded:$ds, dispatch_evidence:$de,
+      independence:$ind,
       ts:$ts, writer:"record-review-verdict.sh"}' > "${TMP}" 2>/dev/null \
   || { rm -f "${TMP}"; echo "record-review-verdict: failed to build the record" >&2; exit 2; }
 
 mv -f "${TMP}" "${OUT}" 2>/dev/null || { rm -f "${TMP}"; exit 2; }
 echo "review verdict written: ${OUT}"
-jq -c '{provider,verdict,reviewed_head_sha,changed_file_count,unresolved_blocking}' "${OUT}" 2>/dev/null
+jq -c '{provider,verdict,reviewed_head_sha,changed_file_count,unresolved_blocking,independence}' "${OUT}" 2>/dev/null

--- a/scripts/record-review-verdict.sh
+++ b/scripts/record-review-verdict.sh
@@ -166,8 +166,15 @@ fi
 #                  may have been for something else entirely), and treating the
 #                  observation as the stronger signal would let the one honest
 #                  declaration the skill asks for be overwritten by telemetry.
-#   independent    a dispatch was OBSERVED (or a real PR review imported) and no
-#                  self-authorship was declared.
+#   dispatch-observed
+#                  a reviewer dispatch was OBSERVED on this branch (or a real PR
+#                  review was imported) and no self-authorship was declared. It is
+#                  named for WHAT WAS MEASURED, not for the conclusion someone would
+#                  like to draw: `reviewer-ran` witnesses a DISPATCH, never a return
+#                  and never that the subagent read THIS diff. Any reviewer dispatched
+#                  earlier on the branch sets it, so calling it `independent` would
+#                  assert of a stale observation exactly what the paragraph below
+#                  refuses to assert of an absent one.
 #   unknown        neither. Never "independent" by default: an absent signal is
 #                  not evidence of independence, and defaulting the other way
 #                  would manufacture the exact claim #197 exists to stop being
@@ -179,7 +186,7 @@ fi
 # an independence claim under the miss modes branch-ledger.sh already documents.
 INDEPENDENCE="unknown"
 case "${DISPATCH_EVIDENCE}" in
-    observed|imported) INDEPENDENCE="independent" ;;
+    observed|imported) INDEPENDENCE="dispatch-observed" ;;
 esac
 [ "${SELF_AUTHORED}" = "true" ] && INDEPENDENCE="self-authored"
 

--- a/scripts/record-review-verdict.sh
+++ b/scripts/record-review-verdict.sh
@@ -166,9 +166,18 @@ fi
 #                  may have been for something else entirely), and treating the
 #                  observation as the stronger signal would let the one honest
 #                  declaration the skill asks for be overwritten by telemetry.
+#   pr-review-imported
+#                  a real pull-request review was RESOLVED from GitHub. Kept
+#                  separate from the value below because collapsing them was a
+#                  factual error: the import path runs `gh pr view` and observes
+#                  no dispatch at all, so labelling it `dispatch-observed` named
+#                  a measurement that never happened. It is also not
+#                  `independent`: nothing here compares the PR reviewer's
+#                  identity against the diff's author, so the import shows a
+#                  review EXISTS, not that it was independent of the author.
 #   dispatch-observed
-#                  a reviewer dispatch was OBSERVED on this branch (or a real PR
-#                  review was imported) and no self-authorship was declared. It is
+#                  a reviewer dispatch was OBSERVED on this branch and no
+#                  self-authorship was declared. It is
 #                  named for WHAT WAS MEASURED, not for the conclusion someone would
 #                  like to draw: `reviewer-ran` witnesses a DISPATCH, never a return
 #                  and never that the subagent read THIS diff. Any reviewer dispatched
@@ -180,13 +189,23 @@ fi
 #                  would manufacture the exact claim #197 exists to stop being
 #                  asserted for free.
 #
+# PRECEDENCE, and why nothing is lost. `--self-authored` still wins over an
+# import. The two are genuinely separate facts — the flag describes the context
+# RECORDING the verdict, the import describes a review by someone else — so
+# neither refutes the other, and a single field has to choose. It chooses the
+# value that does not flatter the verdict, on the same admission-against-interest
+# reasoning as above. No information is destroyed by that choice: the import
+# stays visible in `dispatch_evidence: "imported"`, so a reader sees both facts
+# in the two fields that measured them.
+#
 # NOT a gate, alone or collapsed (#197's spec forbids it), and NOT written to
 # the branch ledger: that file's content is the documented `<sha> <utc-ts>` pair
 # read by position, and an absent sidecar there would be indistinguishable from
 # an independence claim under the miss modes branch-ledger.sh already documents.
 INDEPENDENCE="unknown"
 case "${DISPATCH_EVIDENCE}" in
-    observed|imported) INDEPENDENCE="dispatch-observed" ;;
+    observed) INDEPENDENCE="dispatch-observed" ;;
+    imported) INDEPENDENCE="pr-review-imported" ;;
 esac
 [ "${SELF_AUTHORED}" = "true" ] && INDEPENDENCE="self-authored"
 

--- a/scripts/record-review-verdict.sh
+++ b/scripts/record-review-verdict.sh
@@ -159,7 +159,7 @@ fi
 # to withdraw the independence CLAIM, and states plainly that nothing else will.
 # This is that "nothing else", in a field a reader can act on.
 #
-# Three values, and the ordering is deliberate:
+# Four values, and the ordering is deliberate:
 #   self-authored  the caller says the reviewing context wrote the diff. An
 #                  ADMISSION AGAINST INTEREST, so it outranks an observed
 #                  dispatch — a witnessed spawn cannot refute it (the dispatch

--- a/skills/agent-team-review/SKILL.md
+++ b/skills/agent-team-review/SKILL.md
@@ -74,6 +74,16 @@ The list stops at two entries deliberately. Broader provenance categories — no
 that §4 and the Evidence rule protect, which is the hole those rules exist to close. Do
 not extend this table without re-reading both.
 
+**PAIRED — this table is the LEAD's copy; the reviewer's copy ships in the spawn
+template.** A reviewer sees only its own prompt, so a scope rule stated only here
+constrains nobody: it was claimed as reviewer scope and delivered to no reviewer
+until #245. The same two categories are carried verbatim in every lens prompt's
+`## Scope` block. `tests/test-reviewer-dispatch-brief.sh` asserts each lens carries
+them, that the four copies are byte-identical, and that the category SET here and
+in the prompts is the same; `tests/test-adversarial-governance.sh` asserts the
+delivered copy still stops at two. Editing one copy fails the gate — fix that by
+editing the other, never by deleting the assertion.
+
 **Trivial is not the same as droppable.** A finding small enough to fix in one line is
 still reported; these two categories are about *ownership*, not size.
 
@@ -315,6 +325,17 @@ Task tool (general-purpose):
     Diff: {diff}
     Files changed: {files}
 
+    ## Scope: two categories not to raise
+    - Do not raise `pre-existing` — a defect on the merge base that appears in no
+      changed hunk. Raise it anyway when the diff changes its blast radius, or makes
+      it newly reachable.
+    - Do not raise `tool-owned` — lint, formatting, type errors, test failures, SAST
+      results. Raise it anyway when the gate did not run: then the finding is *that
+      the gate did not run*, not the individual violation.
+    - Nothing else is out of scope. These two categories are about OWNERSHIP, not size
+      — a one-line fix is still reported — and no other provenance label, "speculative"
+      included, is grounds for withholding a finding.
+
     ## Rules
     - Read-only in the shared tree: do NOT modify any files there.
     - Own worktree for anything that executes or mutates. If your lens needs to run
@@ -381,6 +402,17 @@ Task tool (general-purpose):
     Diff: {diff}
     Files changed: {files}
 
+    ## Scope: two categories not to raise
+    - Do not raise `pre-existing` — a defect on the merge base that appears in no
+      changed hunk. Raise it anyway when the diff changes its blast radius, or makes
+      it newly reachable.
+    - Do not raise `tool-owned` — lint, formatting, type errors, test failures, SAST
+      results. Raise it anyway when the gate did not run: then the finding is *that
+      the gate did not run*, not the individual violation.
+    - Nothing else is out of scope. These two categories are about OWNERSHIP, not size
+      — a one-line fix is still reported — and no other provenance label, "speculative"
+      included, is grounds for withholding a finding.
+
     ## Rules
     - Read-only in the shared tree: do NOT modify any files there.
     - Own worktree for anything that executes or mutates. If your lens needs to run
@@ -442,6 +474,17 @@ Task tool (general-purpose):
     Diff: {diff}
     Files changed: {files}
 
+    ## Scope: two categories not to raise
+    - Do not raise `pre-existing` — a defect on the merge base that appears in no
+      changed hunk. Raise it anyway when the diff changes its blast radius, or makes
+      it newly reachable.
+    - Do not raise `tool-owned` — lint, formatting, type errors, test failures, SAST
+      results. Raise it anyway when the gate did not run: then the finding is *that
+      the gate did not run*, not the individual violation.
+    - Nothing else is out of scope. These two categories are about OWNERSHIP, not size
+      — a one-line fix is still reported — and no other provenance label, "speculative"
+      included, is grounds for withholding a finding.
+
     ## Rules
     - Read-only in the shared tree: do NOT modify any files there.
     - Own worktree for anything that executes or mutates. If your lens needs to run
@@ -502,6 +545,17 @@ Task tool (general-purpose):
     Design doc: {design_doc}
     Diff: {diff}
     Files changed: {files}
+
+    ## Scope: two categories not to raise
+    - Do not raise `pre-existing` — a defect on the merge base that appears in no
+      changed hunk. Raise it anyway when the diff changes its blast radius, or makes
+      it newly reachable.
+    - Do not raise `tool-owned` — lint, formatting, type errors, test failures, SAST
+      results. Raise it anyway when the gate did not run: then the finding is *that
+      the gate did not run*, not the individual violation.
+    - Nothing else is out of scope. These two categories are about OWNERSHIP, not size
+      — a one-line fix is still reported — and no other provenance label, "speculative"
+      included, is grounds for withholding a finding.
 
     ## Rules
     - Read-only in the shared tree: do NOT modify any files there.

--- a/skills/agent-team-review/SKILL.md
+++ b/skills/agent-team-review/SKILL.md
@@ -94,11 +94,13 @@ weak arm in the evidence for review fan-out is same-context self-assessment, and
 independence claim is what fails, not the findings. Withdraw the claim; keep every
 finding at the severity its evidence earns.
 
-Say it explicitly because nothing else will. The push gate's STATUS layer credits a
-Skill return, not a review that happened, and observed dispatch is recorded only as
-advisory evidence — so a self-review reaches SHIP with a green gate and no signal that
-the independence was never there. Context isolation is the mechanism doing the work; this
-paragraph is the only place that records when it was absent.
+Say it explicitly, and record it: `record-review-verdict.sh --self-authored` writes
+`independence: "self-authored"` onto the verdict artifact. Prose alone reaches only whoever
+reads the report — the push gate's STATUS layer credits a Skill return, not a review that
+happened, so without the flag a self-review reaches SHIP with a green gate and no durable
+signal that the independence was never there. The flag is provenance, not a gate: it denies
+nothing, and it never downgrades a finding. Context isolation is still the mechanism doing
+the work; the declaration only records when it was absent.
 
 **Collect the reports — they do not arrive on their own.** A background reviewer in this
 harness signals idle with no findings attached, because its final text is a return value,
@@ -620,6 +622,13 @@ Do not pass `--dispatch-attempted`/`--dispatch-succeeded` here: when a
 reviewer subagent actually ran, the script observes it from the branch ledger
 regardless of these flags, so passing them adds nothing; when one did not
 run, passing them would falsely assert a `true` dispatch that never happened.
+
+DO pass `--self-authored` when this context authored the diff it just reviewed — the
+Authorship guard above. It is the one provenance flag the script cannot observe for
+itself: an observed dispatch proves a subagent ran, never that it reviewed *this* diff
+in a context that did not write it. Because it is an admission against interest it
+outranks an observation, so the artifact records `self-authored` even where a dispatch
+was witnessed.
 
 Do not resolve the token by reading `~/.claude/.skill-session-token`
 directly. It is a shared last-writer-wins singleton that under concurrent sessions

--- a/tests/fixtures/agent-team-review/dispatch-brief/required-clauses.txt
+++ b/tests/fixtures/agent-team-review/dispatch-brief/required-clauses.txt
@@ -56,3 +56,10 @@ Do not raise `pre-existing`
 Do not raise `tool-owned`
 Nothing else is out of scope
 about OWNERSHIP, not size
+
+# --- Clause 6 (#245 review): the "raise it anyway" exceptions are the safety-bearing
+# half of the scope rule. Deleting them from all four copies satisfies Control 4
+# (byte-identity across lenses) and every Clause-5 needle, because those pin only the
+# prohibitions. Measured: with all 16 exception lines stripped, both suites ran green.
+Raise it anyway when the diff changes its blast radius
+Raise it anyway when the gate did not run

--- a/tests/fixtures/agent-team-review/dispatch-brief/required-clauses.txt
+++ b/tests/fixtures/agent-team-review/dispatch-brief/required-clauses.txt
@@ -46,3 +46,13 @@ Read-only in the shared tree
 do NOT modify any files
 do not manufacture findings
 VERIFIED by running from what you INFERRED by reading
+
+# --- Clause 5 (#245): the reviewer-facing scope rule must REACH the reviewer ---
+# Protocol §3 carries the lead's copy of the two-category do-not-flag table, but
+# §3 is prose the LEAD reads. A spawned reviewer sees only its own prompt, so the
+# reviewer-facing half was claimed and never delivered. These needles pin the
+# delivered copy; Control 4 in the test pins the four copies byte-identical.
+Do not raise `pre-existing`
+Do not raise `tool-owned`
+Nothing else is out of scope
+about OWNERSHIP, not size

--- a/tests/fixtures/agent-team-review/dispatch-brief/scope-block.txt
+++ b/tests/fixtures/agent-team-review/dispatch-brief/scope-block.txt
@@ -1,0 +1,9 @@
+    - Do not raise `pre-existing` — a defect on the merge base that appears in no
+      changed hunk. Raise it anyway when the diff changes its blast radius, or makes
+      it newly reachable.
+    - Do not raise `tool-owned` — lint, formatting, type errors, test failures, SAST
+      results. Raise it anyway when the gate did not run: then the finding is *that
+      the gate did not run*, not the individual violation.
+    - Nothing else is out of scope. These two categories are about OWNERSHIP, not size
+      — a one-line fix is still reported — and no other provenance label, "speculative"
+      included, is grounds for withholding a finding.

--- a/tests/test-adversarial-governance.sh
+++ b/tests/test-adversarial-governance.sh
@@ -171,6 +171,39 @@ assert_contains "do-not-flag row: tool-owned"              '| `tool-owned`'     
 
 # (b) The forbidden shapes, asserted as ABSENT rather than inferred from prose.
 assert_not_contains "no speculative do-not-raise row"      '| `speculative`'                    "${atr}"
+
+# (a2) #245 — the SAME invariant on the copy that actually reaches a reviewer.
+#      §3 is prose the lead reads; a spawned reviewer sees only its own prompt,
+#      so the two-category ceiling has to hold in the delivered text as well, or
+#      a third category can be added where the lead-side assertion cannot see it.
+#      Counted per lens, not whole-file: a whole-file count cannot tell "two
+#      categories in each of four prompts" from "eight in one".
+while IFS= read -r _lens; do
+    [ -n "${_lens}" ] || continue
+    _scope="$(awk -v lens="${_lens}" '
+        $0 ~ "^[[:space:]]*name: \"" lens "\"" { f=1; next }
+        f && /^[[:space:]]*name: "/ { exit }
+        f && /^## / { exit }
+        f && /^[[:space:]]*## Scope/ { s=1; next }
+        s && /^[[:space:]]*## / { exit }
+        s
+    ' "${ATR}")"
+    _cats="$(printf '%s\n' "${_scope}" | grep -c 'Do not raise `[a-z-]*`')"
+    assert_equals "${_lens}: reviewer scope block stops at two categories" "2" "${_cats}"
+    assert_not_contains "${_lens}: no speculative category in the delivered copy" \
+        'Do not raise `speculative`' "${_scope}"
+done <<'LENS_EOF'
+security-reviewer
+quality-reviewer
+spec-reviewer
+adversarial-reviewer
+LENS_EOF
+
+# (a3) The lead-side table must SAY where the reviewer copy lives, so the next
+#      editor changes both. Without this the two copies drift silently, which is
+#      the #166 shape this pairing note exists to prevent.
+assert_contains "do-not-flag table names its paired reviewer copy" \
+    "the reviewer's copy ships in the spawn" "${atr}"
 assert_not_contains "no synthesis-side provenance filter"  "Provenance filter"                  "${atr}"
 assert_not_contains "no category-based drop at synthesis"  "drop any finding whose category"    "${atr}"
 

--- a/tests/test-adversarial-governance.sh
+++ b/tests/test-adversarial-governance.sh
@@ -188,9 +188,20 @@ while IFS= read -r _lens; do
         s && /^[[:space:]]*## / { exit }
         s
     ' "${ATR}")"
+    # Counted as LIST ITEMS, not by matching one verb. A reviewer added a third
+    # category worded "Do not report `speculative` findings" to all four blocks and
+    # ran both suites green: a `Do not raise` grep, its literal-`speculative` absence
+    # assertion, and the lead/reviewer category-set pairing all match on the verb, so
+    # a different verb evades every one of them. The block is exactly three bullets:
+    # two prohibitions and the closing "Nothing else is out of scope" line.
+    _items="$(printf '%s\n' "${_scope}" | grep -c '^[[:space:]]*- ')"
+    assert_equals "${_lens}: reviewer scope block is exactly three bullets" "3" "${_items}"
     _cats="$(printf '%s\n' "${_scope}" | grep -c 'Do not raise `[a-z-]*`')"
     assert_equals "${_lens}: reviewer scope block stops at two categories" "2" "${_cats}"
+    # Verb-agnostic: any bullet that withholds a finding by naming `speculative`.
     assert_not_contains "${_lens}: no speculative category in the delivered copy" \
+        'speculative` findings' "${_scope}"
+    assert_not_contains "${_lens}: no speculative prohibition in the delivered copy" \
         'Do not raise `speculative`' "${_scope}"
 done <<'LENS_EOF'
 security-reviewer
@@ -240,7 +251,16 @@ else
         "no --self-authored) arm in ${_rrv} — the skill instructs an argument the script rejects"
 fi
 # Provenance, never a gate (#197). The guard must not branch on the field.
-if grep -q 'independence' "${PROJECT_ROOT}/hooks/openspec-guard.sh" 2>/dev/null; then
+# Comment lines are excluded: #197 forbids gating, not describing, and a total ban on
+# the literal would forbid the guard ever explaining WHY it does not read the field.
+# An absence grep must first prove it is reading the right file: `grep -q` exits 2 on a
+# missing path, so a renamed or moved guard would turn this into a permanent silent
+# green (verified). Require a known-present needle to match before trusting the absence.
+_guard="${PROJECT_ROOT}/hooks/openspec-guard.sh"
+if ! grep -q 'review_verdict_is_clean' "${_guard}" 2>/dev/null; then
+    _record_fail "push-gate absence check is reading the real guard" \
+        "no 'review_verdict_is_clean' in ${_guard} — moved, renamed, or unreadable, so the absence assertion below proves nothing"
+elif grep -v '^[[:space:]]*#' "${_guard}" 2>/dev/null | grep -q 'independence'; then
     _record_fail "independence is not read by the push gate" \
         "openspec-guard.sh references 'independence' — #197 forbids provenance from gating"
 else

--- a/tests/test-adversarial-governance.sh
+++ b/tests/test-adversarial-governance.sh
@@ -225,6 +225,28 @@ assert_not_contains "authorship guard does not demote per level" "demote each"  
 assert_not_contains "authorship guard does not demote by level"  "one severity level"           "${atr}"
 assert_not_contains "authorship guard does not downgrade findings" "downgrade the finding"      "${atr}"
 
+# (e) #245 — the guard's "nothing else will" is now false: the verdict artifact
+#     carries the declaration. Pin the prose to the MECHANISM in both
+#     directions, so neither can be removed while the other keeps claiming it.
+#     The second assertion reads the real producer rather than a copy of the
+#     flag name, which is the only way a renamed flag fails here instead of
+#     shipping a skill that instructs an unknown argument.
+assert_contains "authorship guard names the recording flag" "--self-authored" "${atr}"
+_rrv="${PROJECT_ROOT}/scripts/record-review-verdict.sh"
+if grep -q -- '--self-authored)' "${_rrv}" 2>/dev/null; then
+    _record_pass "record-review-verdict.sh accepts the flag the skill instructs"
+else
+    _record_fail "record-review-verdict.sh accepts the flag the skill instructs" \
+        "no --self-authored) arm in ${_rrv} — the skill instructs an argument the script rejects"
+fi
+# Provenance, never a gate (#197). The guard must not branch on the field.
+if grep -q 'independence' "${PROJECT_ROOT}/hooks/openspec-guard.sh" 2>/dev/null; then
+    _record_fail "independence is not read by the push gate" \
+        "openspec-guard.sh references 'independence' — #197 forbids provenance from gating"
+else
+    _record_pass "independence is not read by the push gate"
+fi
+
 # Summary
 echo ""
 echo "=============================="

--- a/tests/test-review-verdict.sh
+++ b/tests/test-review-verdict.sh
@@ -554,8 +554,11 @@ if [ "$(_probe_gh "${_FAKEGH}")" = "yes" ]; then
     # The `imported` arm of the independence rule, which cells (e)-(i) never reach:
     # without this, collapsing `observed|imported` to `observed` in the case arm
     # passes the whole suite while a real PR-review import records `unknown`.
-    assert_equals "an imported PR review also records dispatch-observed" \
-        "dispatch-observed" "$(_odt_field independence)"
+    # NOT `dispatch-observed`: the import path runs `gh pr view` and observes no
+    # dispatch, so collapsing the two named a measurement that never happened
+    # (cross-family review finding). Each value names what was actually measured.
+    assert_equals "an imported PR review records pr-review-imported, not a dispatch" \
+        "pr-review-imported" "$(_odt_field independence)"
 else
     _record_fail "could build a resolvable-gh PATH for the precedence test" \
         "gh not resolvable on the fake PATH"

--- a/tests/test-review-verdict.sh
+++ b/tests/test-review-verdict.sh
@@ -249,13 +249,18 @@ assert_not_contains "clean verdict at HEAD => no review advisory" "REVIEW VERDIC
 _write_verdict clean "${_NEWHEAD}"
 jq -c '. + {independence:"dispatch-observed"}' "${_ART}" > "${_ART}.tmp" && mv "${_ART}.tmp" "${_ART}"
 _indep_out="$(_run_guard)"
+# Every value of the field must be inert, not just the two the first cut compared.
+# A newly-added value is exactly where a future gate would be wired in, so the
+# rotation covers the whole value set (review finding).
+jq -c '. + {independence:"pr-review-imported"}' "${_ART}" > "${_ART}.tmp" && mv "${_ART}.tmp" "${_ART}"
+_imported_out="$(_run_guard)"
 jq -c '. + {independence:"self-authored"}' "${_ART}" > "${_ART}.tmp" && mv "${_ART}.tmp" "${_ART}"
 _self_out="$(_run_guard)"
-if [ "${_indep_out}" = "${_self_out}" ]; then
-    _record_pass "independence is never a deny predicate (guard output identical)"
+if [ "${_indep_out}" = "${_self_out}" ] && [ "${_indep_out}" = "${_imported_out}" ]; then
+    _record_pass "independence is never a deny predicate (guard output identical across every value)"
 else
-    _record_fail "independence is never a deny predicate (guard output identical)" \
-        "self-authored changed the guard's output: [${_self_out}] vs [${_indep_out}]"
+    _record_fail "independence is never a deny predicate (guard output identical across every value)" \
+        "a value changed the guard's output: dispatch-observed=[${_indep_out}] self-authored=[${_self_out}] pr-review-imported=[${_imported_out}]"
 fi
 assert_not_contains "self-authored verdict never denies" '"deny"' "${_self_out:-}"
 
@@ -559,6 +564,22 @@ if [ "$(_probe_gh "${_FAKEGH}")" = "yes" ]; then
     # (cross-family review finding). Each value names what was actually measured.
     assert_equals "an imported PR review records pr-review-imported, not a dispatch" \
         "pr-review-imported" "$(_odt_field independence)"
+
+    # THE PRECEDENCE ARGUMENT'S LOAD-BEARING HALF (review finding). The script
+    # argues that `--self-authored` may outrank an import because nothing is
+    # destroyed: the import stays readable in `dispatch_evidence`. That claim was
+    # argued in a comment and asserted nowhere -- mutating the writer to clear
+    # `DISPATCH_EVIDENCE` whenever `SELF_AUTHORED=true` would destroy exactly the
+    # information the argument rests on, with the suite still green. Both fields
+    # are asserted here because the argument is about the PAIR, not either one.
+    rm -f "${_ART}"
+    ( cd "$_ODT_REPO" && SKILL_SESSION_TOKEN="$_TOK" CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" \
+        PATH="${_FAKEGH}" bash "${PROJECT_ROOT}/scripts/record-review-verdict.sh" \
+        --from-github 1 --self-authored ) >/dev/null 2>&1
+    assert_equals "a declared self-review outranks an import" \
+        "self-authored" "$(_odt_field independence)"
+    assert_equals "...and the import is NOT destroyed by that precedence" \
+        "imported" "$(_odt_field dispatch_evidence)"
 else
     _record_fail "could build a resolvable-gh PATH for the precedence test" \
         "gh not resolvable on the fake PATH"

--- a/tests/test-review-verdict.sh
+++ b/tests/test-review-verdict.sh
@@ -184,7 +184,7 @@ if [ -f "${WRITER}" ]; then
         assert_equals "writer output is clean per the reader" "0" "$(_bool review_verdict_is_clean "${_TOK}")"
         assert_equals "writer records the provider" "local-agent" \
             "$(review_verdict_field "${_TOK}" provider 2>/dev/null)"
-        assert_equals "writer records schema_version" "2" \
+        assert_equals "writer records schema_version" "3" \
             "$(review_verdict_field "${_TOK}" schema_version 2>/dev/null)"
     else
         _record_fail "writer produced an artifact" "no file at ${_ART} after invoking ${WRITER}"
@@ -238,6 +238,23 @@ assert_not_contains "review advisory never denies"            '"deny"'         "
 _write_verdict clean "${_NEWHEAD}"
 out="$(_run_guard)"
 assert_not_contains "clean verdict at HEAD => no review advisory" "REVIEW VERDICT" "${out:-}"
+
+# (j) #245: `independence` is provenance, NEVER a predicate. Same rule #197
+#     set for dispatch_evidence, asserted the same way: the guard's output must
+#     be BYTE-IDENTICAL across the two values, so the field cannot be gating
+#     even indirectly (an advisory that mentioned it would differ here).
+_write_verdict clean "${_NEWHEAD}"
+jq -c '. + {independence:"independent"}' "${_ART}" > "${_ART}.tmp" && mv "${_ART}.tmp" "${_ART}"
+_indep_out="$(_run_guard)"
+jq -c '. + {independence:"self-authored"}' "${_ART}" > "${_ART}.tmp" && mv "${_ART}.tmp" "${_ART}"
+_self_out="$(_run_guard)"
+if [ "${_indep_out}" = "${_self_out}" ]; then
+    _record_pass "independence is never a deny predicate (guard output identical)"
+else
+    _record_fail "independence is never a deny predicate (guard output identical)" \
+        "self-authored changed the guard's output: [${_self_out}] vs [${_indep_out}]"
+fi
+assert_not_contains "self-authored verdict never denies" '"deny"' "${_self_out:-}"
 
 # ---------------------------------------------------------------------------
 # 7. Fail-open: with the reader lib ABSENT the gate must not deny and must not
@@ -387,7 +404,49 @@ assert_equals "absent dispatch is not observed"  "asserted" "$(_odt_field dispat
 assert_equals "absent dispatch is false"         "false"    "$(_odt_field dispatch_attempted)"
 
 # (d) the schema version is bumped
-assert_equals "writer records schema_version 2" "2" "$(_odt_field schema_version)"
+assert_equals "writer records schema_version 3" "3" "$(_odt_field schema_version)"
+
+# ---------------------------------------------------------------------------
+# (I3) Authorship provenance (#245 item 2). The skill's authorship guard asks a
+# self-reviewing context to withdraw the independence CLAIM, and says plainly
+# that nothing else will — the artifact had no field for it, so the declaration
+# lived only in prose a reader never sees.
+#
+# `independence` is recorded on the ARTIFACT, not as a branch-ledger record.
+# Two reasons, and the second is the one that matters: the ledger's content is
+# the documented two-field `<sha> <utc-ts>` line that `branch_ledger_sha` cuts
+# by position (#133 chose a sidecar over widening it for exactly this), and an
+# ABSENT ledger sidecar is indistinguishable from "a reviewer was independent",
+# so the miss modes that lib already documents (branch divergence, detached
+# HEAD) would each read as a clean independence claim. On the artifact the
+# field is always present, and its absence is a schema-2 record rather than an
+# assertion about the review.
+#
+# It is provenance, never a predicate: #197's spec forbids a dispatch field
+# from gating alone or collapsed, and cell (j) pins that for this field too.
+# ---------------------------------------------------------------------------
+find "$HOME/.claude" -maxdepth 1 -type d -name '.skill-branch-ledger-*' -exec rm -rf {} + 2>/dev/null
+_odt_record
+assert_equals "(e) no observation, no claim => unknown" "unknown" "$(_odt_field independence)"
+
+branch_ledger_record "reviewer-ran" "$_ODT_REPO"
+_odt_record
+assert_equals "(f) an observed reviewer is independent" "independent" "$(_odt_field independence)"
+
+# An admission against interest outranks the observation: the caller is saying
+# the context that wrote the diff also reviewed it, which an observed DISPATCH
+# cannot refute (the dispatch may have been for something else entirely).
+_odt_record --self-authored
+assert_equals "(g) a self-authorship claim outranks an observation" \
+    "self-authored" "$(_odt_field independence)"
+
+find "$HOME/.claude" -maxdepth 1 -type d -name '.skill-branch-ledger-*' -exec rm -rf {} + 2>/dev/null
+_odt_record --self-authored
+assert_equals "(h) self-authored with no observation" "self-authored" "$(_odt_field independence)"
+
+# (i) the flag must not disturb the dispatch telemetry it sits beside
+assert_equals "(i) --self-authored leaves dispatch_evidence alone" \
+    "asserted" "$(_odt_field dispatch_evidence)"
 
 # ---------------------------------------------------------------------------
 # (I2) `imported` MUST require a RESOLVABLE PR, not just the flag. The old

--- a/tests/test-review-verdict.sh
+++ b/tests/test-review-verdict.sh
@@ -87,17 +87,20 @@ _ART="$HOME/.claude/.skill-review-verdict-${_TOK}"
 _bool() { if "$@" >/dev/null 2>&1; then echo 0; else echo 1; fi; }
 
 _write_verdict() { # <verdict> <head_sha> [unresolved_blocking]
-    # schema_version:2 + dispatch_evidence, matching the real writer's shape
-    # (issue: an all-schema-1, no-dispatch_evidence fixture here meant the
-    # guard e2e below was never driven with a dispatch field present, so
-    # "dispatch_evidence is never a deny predicate" was an untested claim).
+    # MUST match the real writer's CURRENT shape — schema 3, every provenance field
+    # present. The previous version of this comment claimed that and had gone stale:
+    # it was written because an all-schema-1 fixture meant the guard e2e was never
+    # driven with `dispatch_evidence` at all, making "dispatch_evidence is never a
+    # deny predicate" an untested claim — and then the writer moved to schema 3 with
+    # `independence` while the fixture stayed at 2, reintroducing the same hole for
+    # the new field. Keep this in step with record-review-verdict.sh's jq object.
     jq -nc --arg v "$1" --arg h "$2" --arg b "${BASE_SHA}" \
            --argjson ub "${3:-0}" \
-        '{schema_version:2,provider:"local-agent",reviewed_base_sha:$b,
+        '{schema_version:3,provider:"local-agent",reviewed_base_sha:$b,
           reviewed_head_sha:$h,changed_file_digest:"deadbeefcafe",
           changed_file_count:1,findings_total:0,unresolved_blocking:$ub,
           verdict:$v,dispatch_attempted:true,dispatch_succeeded:true,
-          dispatch_evidence:"observed",
+          dispatch_evidence:"observed",independence:"dispatch-observed",
           ts:"2026-08-25T00:00:00Z",writer:"test"}' > "${_ART}"
 }
 
@@ -244,7 +247,7 @@ assert_not_contains "clean verdict at HEAD => no review advisory" "REVIEW VERDIC
 #     be BYTE-IDENTICAL across the two values, so the field cannot be gating
 #     even indirectly (an advisory that mentioned it would differ here).
 _write_verdict clean "${_NEWHEAD}"
-jq -c '. + {independence:"independent"}' "${_ART}" > "${_ART}.tmp" && mv "${_ART}.tmp" "${_ART}"
+jq -c '. + {independence:"dispatch-observed"}' "${_ART}" > "${_ART}.tmp" && mv "${_ART}.tmp" "${_ART}"
 _indep_out="$(_run_guard)"
 jq -c '. + {independence:"self-authored"}' "${_ART}" > "${_ART}.tmp" && mv "${_ART}.tmp" "${_ART}"
 _self_out="$(_run_guard)"
@@ -431,7 +434,8 @@ assert_equals "(e) no observation, no claim => unknown" "unknown" "$(_odt_field 
 
 branch_ledger_record "reviewer-ran" "$_ODT_REPO"
 _odt_record
-assert_equals "(f) an observed reviewer is independent" "independent" "$(_odt_field independence)"
+assert_equals "(f) an observed reviewer records what was measured" \
+    "dispatch-observed" "$(_odt_field independence)"
 
 # An admission against interest outranks the observation: the caller is saying
 # the context that wrote the diff also reviewed it, which an observed DISPATCH
@@ -439,14 +443,50 @@ assert_equals "(f) an observed reviewer is independent" "independent" "$(_odt_fi
 _odt_record --self-authored
 assert_equals "(g) a self-authorship claim outranks an observation" \
     "self-authored" "$(_odt_field independence)"
+# The flag must not disturb the telemetry it sits beside, asserted HERE because this
+# is the only configuration in which the claim is testable: the ledger is present, so
+# `observed` is the value a clobber would destroy. Asserting it after the ledger has
+# been deleted (cell (i) below) is satisfied by the fallback path — `asserted` is the
+# answer whatever the flag does, and the exact clobber the cell is named for ran green.
+assert_equals "(g) --self-authored does not clobber an OBSERVED dispatch" \
+    "observed" "$(_odt_field dispatch_evidence)"
 
 find "$HOME/.claude" -maxdepth 1 -type d -name '.skill-branch-ledger-*' -exec rm -rf {} + 2>/dev/null
 _odt_record --self-authored
 assert_equals "(h) self-authored with no observation" "self-authored" "$(_odt_field independence)"
 
-# (i) the flag must not disturb the dispatch telemetry it sits beside
-assert_equals "(i) --self-authored leaves dispatch_evidence alone" \
+# (i) with no ledger, the flag still leaves the telemetry at its honest default.
+# Weak by construction (see (g)): `asserted` is the no-ledger answer regardless.
+assert_equals "(i) --self-authored with no ledger leaves dispatch_evidence asserted" \
     "asserted" "$(_odt_field dispatch_evidence)"
+
+# (k) The guard-e2e fixture must carry the SAME FIELD SET the real writer produces.
+# Derived from the producer, never from this file's idea of the format: the writer has
+# just run above, so its artifact is the authority. This exists because the fixture had
+# already drifted once — it sat at schema 1 while the writer emitted `dispatch_evidence`,
+# which left "dispatch_evidence is never a deny predicate" untested in the guard e2e —
+# and then drifted again the same way when the writer moved to schema 3. Reverting the
+# fixture to schema 2 was measured to fail NOTHING before this cell existed.
+# ORDER MATTERS: `_write_verdict` writes to the SAME artifact path the writer just
+# produced, so the writer's shape must be captured BEFORE the fixture is generated.
+# Reading it afterwards compares the fixture with itself and passes unconditionally.
+_WRITER_ART="$(review_verdict_artifact_path "${_TOK}" 2>/dev/null)"
+_writer_keys="$(jq -S -c 'keys' "${_WRITER_ART}" 2>/dev/null)"
+_writer_schema="$(jq -r '.schema_version' "${_WRITER_ART}" 2>/dev/null)"
+_write_verdict clean "${BASE_SHA}"
+_fixture_keys="$(jq -S -c 'keys' "${_ART}" 2>/dev/null)"
+_fixture_schema="$(jq -r '.schema_version' "${_ART}" 2>/dev/null)"
+if [ -z "${_writer_keys}" ] || [ -z "${_fixture_keys}" ]; then
+    _record_fail "guard-e2e fixture matches the writer's field set" \
+        "could not read one of the two artifacts (writer=[${_writer_keys}] fixture=[${_fixture_keys}]) — this assertion proves nothing"
+elif [ "${_writer_keys}" = "${_fixture_keys}" ]; then
+    _record_pass "guard-e2e fixture carries the writer's exact field set"
+else
+    _record_fail "guard-e2e fixture carries the writer's exact field set" \
+        "writer=${_writer_keys} fixture=${_fixture_keys} — _write_verdict has drifted from record-review-verdict.sh"
+fi
+assert_equals "guard-e2e fixture carries the writer's schema_version" \
+    "${_writer_schema}" "${_fixture_schema}"
 
 # ---------------------------------------------------------------------------
 # (I2) `imported` MUST require a RESOLVABLE PR, not just the flag. The old
@@ -511,6 +551,11 @@ if [ "$(_probe_gh "${_FAKEGH}")" = "yes" ]; then
         PATH="${_FAKEGH}" bash "${PROJECT_ROOT}/scripts/record-review-verdict.sh" \
         --from-github 1 ) >/dev/null 2>&1
     assert_equals "imported outranks a real observation" "imported" "$(_odt_field dispatch_evidence)"
+    # The `imported` arm of the independence rule, which cells (e)-(i) never reach:
+    # without this, collapsing `observed|imported` to `observed` in the case arm
+    # passes the whole suite while a real PR-review import records `unknown`.
+    assert_equals "an imported PR review also records dispatch-observed" \
+        "dispatch-observed" "$(_odt_field independence)"
 else
     _record_fail "could build a resolvable-gh PATH for the precedence test" \
         "gh not resolvable on the fake PATH"

--- a/tests/test-reviewer-dispatch-brief.sh
+++ b/tests/test-reviewer-dispatch-brief.sh
@@ -107,6 +107,12 @@ _require_needle "Do not raise \`pre-existing\`"
 _require_needle "Do not raise \`tool-owned\`"
 _require_needle "Nothing else is out of scope"
 _require_needle "about OWNERSHIP, not size"
+# The exceptions, added after a reviewer deleted all 16 of their lines from the four
+# delivered blocks and ran both suites green. They are the safety-bearing half: they
+# are what stops a reviewer suppressing a pre-existing defect the diff made newly
+# reachable, and what makes "the gate did not run" itself reportable.
+_require_needle "Raise it anyway when the diff changes its blast radius"
+_require_needle "Raise it anyway when the gate did not run"
 
 # --- Control 2: non-vacuity floor ------------------------------------------
 # Secondary to Control 1 (which a shrinking fixture trips first), but it also
@@ -116,11 +122,11 @@ _require_needle "about OWNERSHIP, not size"
 # headroom between them is a set of needles that can be deleted without tripping
 # either control — which is exactly how the second leak opened. Raise both together
 # when adding a needle.
-if [ "${CLAUSE_COUNT}" -ge 18 ]; then
+if [ "${CLAUSE_COUNT}" -ge 20 ]; then
     _record_pass "clause fixture non-vacuous (${CLAUSE_COUNT} needles)"
 else
     _record_fail "clause fixture non-vacuous" \
-        "expected >= 18 needles, got ${CLAUSE_COUNT} — assertions below prove nothing"
+        "expected >= 20 needles, got ${CLAUSE_COUNT} — assertions below prove nothing"
 fi
 
 # --- Discover the lens population -------------------------------------------
@@ -170,7 +176,19 @@ _block_has() {
 }
 
 CONTRACT_REF=""
+# The canonical delivered Scope block. Hand-authored and committed, NEVER generated
+# from SKILL.md — a fixture derived from the subject only ever agrees with itself.
+SCOPE_FIXTURE="${FIXTURE_DIR}/scope-block.txt"
 SCOPE_REF=""
+if [ -f "${SCOPE_FIXTURE}" ]; then
+    SCOPE_REF="$(cat "${SCOPE_FIXTURE}")"
+fi
+if [ -n "${SCOPE_REF}" ]; then
+    _record_pass "committed scope-block fixture present"
+else
+    _record_fail "committed scope-block fixture present" \
+        "no readable ${SCOPE_FIXTURE} — the per-lens scope assertions below prove nothing"
+fi
 while IFS= read -r lens; do
     [ -n "${lens}" ] || continue
     BLOCK="$(_lens_block "${lens}")"
@@ -225,17 +243,24 @@ EOF
         f && /^[[:space:]]*## / { exit }
         f
     ')"
+    #
+    # Compared against a COMMITTED fixture, not against the first lens. Lens-to-lens
+    # identity is satisfied by mutating all four the same way, and a reviewer used
+    # exactly that: deleting both "Raise it anyway" exceptions from all four blocks,
+    # and separately adding a third category worded "Do not report ...", each ran the
+    # whole suite green. Byte-equality against a fixture fails on ANY edit — deletion,
+    # addition, or rewording — in one or in all four.
     if [ -z "${SCOPE}" ]; then
         _record_fail "${lens}: Scope block extracted" \
             "empty — §3's reviewer-facing scope rule is not delivered to this lens"
     elif [ -z "${SCOPE_REF}" ]; then
-        SCOPE_REF="${SCOPE}"
-        _record_pass "${lens}: Scope block extracted (reference copy)"
+        _record_fail "${lens}: Scope block matches the committed fixture" \
+            "fixture ${SCOPE_FIXTURE} is missing or empty — this assertion proves nothing"
     elif [ "${SCOPE}" = "${SCOPE_REF}" ]; then
-        _record_pass "${lens}: Scope block identical to the other lenses"
+        _record_pass "${lens}: Scope block matches the committed fixture byte-for-byte"
     else
-        _record_fail "${lens}: Scope block identical to the other lenses" \
-            "this lens's scope rule has drifted from the reference copy"
+        _record_fail "${lens}: Scope block matches the committed fixture byte-for-byte" \
+            "this lens's scope rule differs from tests/fixtures/agent-team-review/dispatch-brief/scope-block.txt"
     fi
 done <<EOF
 ${LENSES}

--- a/tests/test-reviewer-dispatch-brief.sh
+++ b/tests/test-reviewer-dispatch-brief.sh
@@ -100,6 +100,13 @@ _require_needle "VERIFIED by running from what you INFERRED by reading"
 _require_needle "mktemp -d"
 _require_needle "Confirm your worktree matches the subject"
 _require_needle "Review range: {base_sha}..{head_sha}"
+# #245: the reviewer-facing half of Protocol §3's do-not-flag table. Anchored
+# here for the same reason as every needle above — a needle deleted from the
+# fixture silently deletes its own per-lens assertion.
+_require_needle "Do not raise \`pre-existing\`"
+_require_needle "Do not raise \`tool-owned\`"
+_require_needle "Nothing else is out of scope"
+_require_needle "about OWNERSHIP, not size"
 
 # --- Control 2: non-vacuity floor ------------------------------------------
 # Secondary to Control 1 (which a shrinking fixture trips first), but it also
@@ -109,11 +116,11 @@ _require_needle "Review range: {base_sha}..{head_sha}"
 # headroom between them is a set of needles that can be deleted without tripping
 # either control — which is exactly how the second leak opened. Raise both together
 # when adding a needle.
-if [ "${CLAUSE_COUNT}" -ge 14 ]; then
+if [ "${CLAUSE_COUNT}" -ge 18 ]; then
     _record_pass "clause fixture non-vacuous (${CLAUSE_COUNT} needles)"
 else
     _record_fail "clause fixture non-vacuous" \
-        "expected >= 14 needles, got ${CLAUSE_COUNT} — assertions below prove nothing"
+        "expected >= 18 needles, got ${CLAUSE_COUNT} — assertions below prove nothing"
 fi
 
 # --- Discover the lens population -------------------------------------------
@@ -163,6 +170,7 @@ _block_has() {
 }
 
 CONTRACT_REF=""
+SCOPE_REF=""
 while IFS= read -r lens; do
     [ -n "${lens}" ] || continue
     BLOCK="$(_lens_block "${lens}")"
@@ -205,9 +213,52 @@ EOF
         _record_fail "${lens}: Delivery Contract identical to the other lenses" \
             "this lens's contract has drifted from the reference copy"
     fi
+    # --- Control 4 (#245): the four Scope blocks must be IDENTICAL ----------
+    # Protocol §3 keeps the lead's copy of the same two categories, so this rule
+    # now lives in five places by design. Duplication is the only delivery
+    # mechanism a subagent prompt has (Control 3, same reasoning), and its one
+    # cost is drift: without this, a lens whose scope block grew a third category
+    # or lost the "raise it anyway" exceptions still passes as long as the four
+    # needles survive somewhere in the block.
+    SCOPE="$(printf '%s\n' "${BLOCK}" | awk '
+        /^[[:space:]]*## Scope/ { f=1; next }
+        f && /^[[:space:]]*## / { exit }
+        f
+    ')"
+    if [ -z "${SCOPE}" ]; then
+        _record_fail "${lens}: Scope block extracted" \
+            "empty — §3's reviewer-facing scope rule is not delivered to this lens"
+    elif [ -z "${SCOPE_REF}" ]; then
+        SCOPE_REF="${SCOPE}"
+        _record_pass "${lens}: Scope block extracted (reference copy)"
+    elif [ "${SCOPE}" = "${SCOPE_REF}" ]; then
+        _record_pass "${lens}: Scope block identical to the other lenses"
+    else
+        _record_fail "${lens}: Scope block identical to the other lenses" \
+            "this lens's scope rule has drifted from the reference copy"
+    fi
 done <<EOF
 ${LENSES}
 EOF
+
+# --- Control 5 (#245): the lead's copy and the reviewers' copy must agree ----
+# The two copies carry the SAME two ownership categories. §3 is a markdown table
+# (`| \`pre-existing\` |`), the prompt is a bullet (``Do not raise \`pre-existing\```),
+# so neither text can be derived from the other by grep — the pairing is asserted
+# on the CATEGORY SET, which is what must not diverge. A category added to one
+# copy and not the other fails here rather than shipping a reviewer that scopes
+# itself by a rule the lead does not hold.
+LEAD_CATS="$(awk '/^\*\*Do not flag/{f=1} f&&match($0, /^\| `[a-z-]+`/){c=substr($0, RSTART+3, RLENGTH-4); print c} f&&/^The list stops at two/{exit}' "${SKILL}" | sort)"
+REV_CATS="$(printf '%s\n' "${SCOPE_REF}" | awk 'match($0, /Do not raise `[a-z-]+`/){c=substr($0, RSTART+14, RLENGTH-15); print c}' | sort)"
+if [ -z "${LEAD_CATS}" ] || [ -z "${REV_CATS}" ]; then
+    _record_fail "lead and reviewer scope categories both extracted" \
+        "one side is empty (lead=[${LEAD_CATS}] reviewer=[${REV_CATS}]) — the pairing assertion below proves nothing"
+elif [ "${LEAD_CATS}" = "${REV_CATS}" ]; then
+    _record_pass "lead §3 table and reviewer Scope block carry the same categories"
+else
+    _record_fail "lead §3 table and reviewer Scope block carry the same categories" \
+        "lead=[${LEAD_CATS}] reviewer=[${REV_CATS}] — the two copies have diverged"
+fi
 
 # --- Lead-side collection protocol -----------------------------------------
 # The Verification section already asserted the OUTCOME ("every spawned reviewer

--- a/tests/test-reviewer-dispatch-brief.sh
+++ b/tests/test-reviewer-dispatch-brief.sh
@@ -249,7 +249,8 @@ EOF
     # the stronger "every reviewer that actually runs receives and follows only
     # these two exclusions". A line added elsewhere in the same prompt — under
     # `## Rules`, say, "ignore the Scope section for low-confidence findings" —
-    # leaves byte-equality perfect and the bullet count at three while handing
+    # leaves byte-equality perfect -- and the three-bullet count in
+    # test-adversarial-governance.sh equally so -- while handing
     # the reviewer a contradictory instruction. So do a lead instruction to
     # abbreviate Scope when spawning, a dispatch path that does not use these
     # templates, and a fifth lens defined outside the discovered `name:`

--- a/tests/test-reviewer-dispatch-brief.sh
+++ b/tests/test-reviewer-dispatch-brief.sh
@@ -244,6 +244,21 @@ EOF
         f
     ')"
     #
+    # WHAT THIS DOES NOT COVER, stated rather than implied. The invariant pinned
+    # here is "each static Scope block contains exactly the canonical text", NOT
+    # the stronger "every reviewer that actually runs receives and follows only
+    # these two exclusions". A line added elsewhere in the same prompt — under
+    # `## Rules`, say, "ignore the Scope section for low-confidence findings" —
+    # leaves byte-equality perfect and the bullet count at three while handing
+    # the reviewer a contradictory instruction. So do a lead instruction to
+    # abbreviate Scope when spawning, a dispatch path that does not use these
+    # templates, and a fifth lens defined outside the discovered `name:`
+    # population. A keyword blocklist for "contradictory" phrasing was
+    # considered and rejected: it is the fitted-heuristic shape this repo has
+    # been bitten by, and it would buy false comfort rather than coverage.
+    # (Cross-family review finding; the boundary is real and is documented here
+    # instead of being papered over.)
+    #
     # Compared against a COMMITTED fixture, not against the first lens. Lens-to-lens
     # identity is satisfied by mutating all four the same way, and a reviewer used
     # exactly that: deleting both "Raise it anyway" exceptions from all four blocks,


### PR DESCRIPTION
Closes #245.

## Item 1 — the scope rule now reaches the reviewer

§3's two-category do-not-flag table was introduced as scope rules for reviewers, but §3 is protocol prose the lead reads. A spawned reviewer sees only its own prompt block, and none of the four lens templates carried the rule — so the half addressed to reviewers was claimed and delivered to nobody, while the `adversarial-review` spec already stated it as a reviewer obligation.

All four lens prompts now carry an identical `## Scope` block. Duplication is the only delivery mechanism a subagent prompt has, which is the same reasoning that already duplicates the Delivery Contract into all four, so the copies are pinned rather than trusted:

- per-lens needles in the existing `required-clauses.txt` fixture (floor 14 → 20)
- each block compared byte-for-byte against a committed fixture, hand-authored rather than generated from `SKILL.md`
- §3's table and the prompt block must carry the same category set
- the two-category ceiling asserted per lens on the delivered copy, counted as list items rather than by matching one verb

## Item 2 — authorship provenance on the verdict artifact

The authorship guard asked a self-reviewing context to withdraw its independence claim and noted that nothing else would record it. That was accurate. `record-review-verdict.sh` gains `--self-authored` and always writes an `independence` field with four values: `self-authored`, `dispatch-observed`, `pr-review-imported`, `unknown`.

Each value names what was measured. `dispatch-observed` rests on a record that witnesses a subagent being dispatched — not that it returned, not that it read this diff — so it is not called `independent`. `pr-review-imported` is separate because the import path queries GitHub and observes no dispatch at all. The default is `unknown`, never a positive claim, because an absent signal is not evidence.

It is provenance and never a gate: #197 forbids that. A cell asserts the guard's output is byte-identical across every value of the field, and another asserts the guard does not reference it in code at all.

`schema_version` 2 → 3; `predicate_version` untouched, since this describes a record rather than changing any firing condition.

## Review

Three reviewer lenses, a cross-family pass, and a delta review of the response to that pass. Nine findings across two rounds, all fixed, each fix re-run against its own mutation.

Two of them broke controls I had called mutation-verified: the "raise it anyway" exceptions could be stripped from all four scope blocks with every suite green, and a third category worded with a different verb reached every reviewer the same way. Both are fixed and both mutations now fail. The cause was picking mutations by inverting my own assertions instead of asking how the rule could be violated.

Two more were documentation the previous commit had broken — an enumeration still reading "three values" above four, and a proposal still listing a superseded set while the spec beside it said otherwise.

## Verification

Full suite: 131 files run, 131 passed. Verdict recorded clean and bound to this branch's HEAD, `test_delta: covered`, gate-gaming clean.

## Specs

`openspec/changes/deliver-reviewer-scope-rule/` and `openspec/changes/review-authorship-provenance/`. The latter also amends a clause in the active `observed-dispatch-telemetry` delta that pinned a literal schema version, because two active deltas asserting different literals for one field is a contradiction that structural validation passes straight over.
