### PR TITLE
Two parser defects that made the push gate assert false things

### DIFF
--- a/hooks/lib/git-command.sh
+++ b/hooks/lib/git-command.sh
@@ -1678,8 +1678,17 @@ command_push_is_all_deletions() {
 #
 # What was wrong was the CONSEQUENCE. With certification lost, the subject falls
 # back to the checkout HEAD, and the IMPLEMENT leg then states "this push edits
-# source" about a command that ships nothing, and writes a shadow record whose
-# premise is false. CLAUDE.md justifies the lost-skip cost as "one-directional
+# source" about a command whose pushes ship nothing, and writes a shadow record
+# whose premise is false.
+#
+# BE PRECISE ABOUT THE WARRANT, because the looser phrasing is the misreading
+# that would license misuse: what this establishes is only that every RECOGNISED
+# push is deletion-shaped. It does NOT establish that the command ships nothing.
+# `git push origin --delete x | ./deploy.sh` is accepted here, and deploy.sh may
+# push anything at all. That is tolerable for the two things this predicate
+# drives -- a sentence and a corpus-membership flag -- and is exactly why it may
+# not drive a gate. The residual cost is bounded and one-directional: such a
+# command loses one shadow episode, never a deny. CLAUDE.md justifies the lost-skip cost as "one-directional
 # ... never a new deny", which is true of ENFORCEMENT and does not transfer to
 # MEASUREMENT or to what the gate SAYS. Measured in the live corpus: 2 of 12 v4
 # would-block episodes are deletion-shaped commands recorded as content pushes,

--- a/hooks/lib/git-command.sh
+++ b/hooks/lib/git-command.sh
@@ -1661,3 +1661,76 @@ command_push_is_all_deletions() {
     return 0
 }
 
+# command_push_recognised_are_all_deletions <command>
+#
+# ADVISORY-ONLY, AND DELIBERATELY WEAKER THAN THE PREDICATE ABOVE. Returns 0
+# when every RECOGNISED push segment in the command deletes a ref. It says
+# NOTHING about segments it does not recognise, so it is NOT a certification
+# that the command ships no content and MUST NEVER be used to skip a gate.
+#
+# WHY IT EXISTS. The strict form requires every segment to be accounted for,
+# because that claim is what lets four content-dependent legs be skipped. A
+# trailing `| tail -N` is an unaccountable segment, and `_gc_seg_is_inert`
+# correctly refuses to vouch for it -- it cannot tell `tail` from `./deploy.sh`.
+# There is no sound widening of that whitelist: the right-hand side of a pipe
+# executes arbitrarily, so `git push --delete origin x | ./deploy.sh` runs
+# deploy.sh. The refusal is right.
+#
+# What was wrong was the CONSEQUENCE. With certification lost, the subject falls
+# back to the checkout HEAD, and the IMPLEMENT leg then states "this push edits
+# source" about a command that ships nothing, and writes a shadow record whose
+# premise is false. CLAUDE.md justifies the lost-skip cost as "one-directional
+# ... never a new deny", which is true of ENFORCEMENT and does not transfer to
+# MEASUREMENT or to what the gate SAYS. Measured in the live corpus: 2 of 12 v4
+# would-block episodes are deletion-shaped commands recorded as content pushes,
+# and `2>&1 | tail -N` is the shape an agent naturally writes.
+#
+# So this predicate answers only the question needed to stop asserting something
+# false, and the strict form keeps governing every skip. The three orthogonal
+# layers still apply here -- substitution refusal, balanced parse, and the
+# broad-flag disqualifier -- because each blocks a different way of being wrong
+# about which pushes are even present; only the segment whitelist is dropped,
+# and dropping it is exactly what makes this claim weaker.
+#
+# PAIRED: a caller that skips, suppresses or shortcuts a DENY on the strength of
+# this predicate has misused it. tests/test-push-gate-detection.sh pins the
+# asymmetry (every advisory-form cell has a strict-form control), and
+# tests/test-push-gate-implement-leg.sh pins that the deny legs are unmoved.
+command_push_recognised_are_all_deletions() {
+    local _cmd="$1"
+    local _segs _oldifs _seg _shape _found=0
+    case "$1" in
+        *'$('*|*'`'*|*'<('*|*'>('*|*'=('*|*'${ '*|*'${|'*) return 1 ;;
+    esac
+    _segs="$(_gc_split_segments "$1")"
+    _oldifs="$IFS"
+    IFS="${_GC_SEP}"
+    for _seg in ${_segs}; do
+        IFS="${_oldifs}"
+        # THE ONE DIFFERENCE from the strict form: an unrecognised segment is
+        # skipped rather than disqualifying the command. That is the whole of
+        # the weakening, and it is why the result may not gate.
+        if [ "$(_gc_segment_git_sub "${_seg}")" != "push" ]; then
+            IFS="${_GC_SEP}"
+            continue
+        fi
+        _shape="$(_gc_push_seg_shape "${_seg}")"
+        if [ -z "${_shape}" ]; then IFS="${_oldifs}"; return 1; fi
+        _found=1
+        # shellcheck disable=SC2086
+        set -- ${_shape}   # <del> <refs> <empty> <broad> <odd>
+        if [ "$4" -ne 0 ]; then IFS="${_oldifs}"; return 1; fi
+        if [ "$1" -eq 1 ]; then IFS="${_GC_SEP}"; continue; fi
+        if [ "$2" -ge 1 ] && [ "$2" -eq "$3" ]; then IFS="${_GC_SEP}"; continue; fi
+        IFS="${_oldifs}"; return 1
+    done
+    IFS="${_oldifs}"
+    [ "${_found}" -eq 1 ] || return 1
+    # `_cmd`, not `$1`: `set -- ${_shape}` above replaced the positional
+    # parameters, and reading `$1` here would hand the balance check a shape
+    # digit. That exact slip re-opened a bypass in the strict predicate once.
+    command -v command_parse_balanced >/dev/null 2>&1 || return 1
+    command_parse_balanced "${_cmd}" || return 1
+    return 0
+}
+

--- a/hooks/lib/implement-shadow.sh
+++ b/hooks/lib/implement-shadow.sh
@@ -38,7 +38,14 @@
 # That schema-3 change did NOT bump predicate_version: it changed what the
 # record DESCRIBES, not when the leg fires. (The separate #219 bump below did
 # change when the leg fires — the two are independent axes on purpose.)
-IMPLEMENT_SHADOW_SCHEMA_VERSION=3
+# 4 (2026-09-10): adds `advisory_emitted` — whether the leg actually SAID
+# anything for this event. The rate population had been inferred from
+# `would_block`, which is passed as a literal on the gh-merge path and so
+# asserts a block the leg would not perform; and a deletion-shaped command that
+# lost its certification produced a would_block record while shipping nothing.
+# Membership is now a recorded observation rather than an inference, which
+# retires that whole class instead of filtering one instance of it.
+IMPLEMENT_SHADOW_SCHEMA_VERSION=4
 # 2 (#161): merge-path material_source is now measured against the merged PR's
 # file list, not the branch-local delta. v1 merge records measured a different
 # subject and MUST NOT be pooled with v2.
@@ -64,9 +71,23 @@ IMPLEMENT_SHADOW_SCHEMA_VERSION=3
 # corpus held ZERO records at the time of the change (the #219 bump had landed
 # only days earlier), so nothing accumulated was discarded. Do not read this as
 # licence to bump freely — measure the live corpus first, the way #199 did.
-IMPLEMENT_SHADOW_PREDICATE_VERSION=4
+# v5 (2026-09-10): TWO firing-behaviour changes, either of which forces the bump
+# on this file's own rule. (1) `pr_ref_from_command` now skips shell redirection
+# operands, so a merge written with `2>&1` resolves its PR instead of recording
+# `unresolved` — merges begin emitting advisories they never emitted, and their
+# material_source becomes a real measurement rather than a constant false. (2)
+# the IMPLEMENT leg no longer asserts "this push edits source" for a command
+# whose every recognised push deletes a ref, so those events stop producing an
+# advisory and are marked `advisory_emitted:false`.
+#
+# Measured before taking it, per #199: the live v4 corpus held 12 would-block
+# episodes, of which at least 3 were known-bad (one unresolved merge, two
+# deletion-shaped commands recorded as content pushes) against a floor of 29 —
+# 0.9^12 = 0.282, nowhere near the 0.05 the rule needs, so nothing measurable
+# was discarded. v4 records MUST NOT be pooled with v5.
+IMPLEMENT_SHADOW_PREDICATE_VERSION=5
 
-# implement_shadow_record <action> <repo> <session_token> <transcript_path> <evidence_kind> <diff_base> <material_source> [would_block] [evidence_detail] [rev]
+# implement_shadow_record <action> <repo> <session_token> <transcript_path> <evidence_kind> <diff_base> <material_source> [would_block] [evidence_detail] [rev] [advisory_emitted]
 #   action: push | gh-merge
 #   evidence_kind: which evidence classes were tried and missed (e.g. "none")
 #   diff_base: what the material-source check was measured against
@@ -110,6 +131,11 @@ implement_shadow_record() {
     command -v jq >/dev/null 2>&1 || return 0
     local _act="${1:-unknown}" _repo="${2:-}" _tok="${3:-}" _tp="${4:-}" _ev="${5:-none}" _db="${6:-branch-local}"
     local _ms="${7:-true}" _wb="${8:-true}" _ed="${9:-}" _rev="${10:-HEAD}"
+    local _ae="${11:-true}"
+    # Only the two literals are accepted. A caller passing anything else has a
+    # bug, and coercing it would put a fabricated membership value into the one
+    # field the rate is computed over.
+    case "${_ae}" in true|false) ;; *) _ae="true" ;; esac
     local _log _dir _ts _nonce _rid _branch _head
     _log="${IMPLEMENT_SHADOW_LOG:-${HOME}/.claude/.push-implement-shadow.jsonl}"
     _dir="$(dirname "${_log}" 2>/dev/null)" || return 0
@@ -154,6 +180,7 @@ implement_shadow_record() {
         --arg repo "${_repo}" --arg branch "${_branch}" --arg head "${_head}" \
         --arg tok "${_tok}" --arg tp "${_tp}" --arg ev "${_ev}" --arg db "${_db}" \
         --argjson ms "${_ms}" --argjson wb "${_wb}" --arg ed "${_ed}" \
+        --argjson ae "${_ae}" \
         '{schema_version:$sv,record_id:$rid,ts:$ts,predicate_version:$pv,
           gate:"push-implement",would_block:$wb,action:$act,
           repo:$repo,branch:$branch,head_sha:$head,
@@ -168,6 +195,7 @@ implement_shadow_record() {
                         | {(.[0]): .[1]} ]
                       | if length == 0 then null else add end )
                end),
+          advisory_emitted:$ae,
           session_token:$tok,transcript_path:$tp}' \
         >> "${_log}" 2>/dev/null || return 0
     return 0

--- a/hooks/lib/implement-shadow.sh
+++ b/hooks/lib/implement-shadow.sh
@@ -39,7 +39,11 @@
 # record DESCRIBES, not when the leg fires. (The separate #219 bump below did
 # change when the leg fires — the two are independent axes on purpose.)
 # 4 (2026-09-10): adds `advisory_emitted` — whether the leg actually SAID
-# anything for this event. The rate population had been inferred from
+# anything for this event. Recorded AT THE LEG: a deny firing further down drops
+# `_STALE_MSG` wholesale (#198), so a `true` here means the leg emitted, not that
+# the user necessarily read it. That over-includes rather than under-includes,
+# which is the safe direction for this field, but do not read it as "the text
+# reached a human". The rate population had been inferred from
 # `would_block`, which is passed as a literal on the gh-merge path and so
 # asserts a block the leg would not perform; and a deletion-shaped command that
 # lost its certification produced a would_block record while shipping nothing.
@@ -132,9 +136,14 @@ implement_shadow_record() {
     local _act="${1:-unknown}" _repo="${2:-}" _tok="${3:-}" _tp="${4:-}" _ev="${5:-none}" _db="${6:-branch-local}"
     local _ms="${7:-true}" _wb="${8:-true}" _ed="${9:-}" _rev="${10:-HEAD}"
     local _ae="${11:-true}"
-    # Only the two literals are accepted. A caller passing anything else has a
-    # bug, and coercing it would put a fabricated membership value into the one
-    # field the rate is computed over.
+    # Only the two literals are accepted; anything else RESOLVES TO `true`, and
+    # the comment must say so rather than argue against the line below it. Two
+    # reasons it resolves rather than rejecting: a non-JSON value would make the
+    # `--argjson ae` below fail and lose the entire record, which is worse than a
+    # possibly-spurious episode; and `true` is the INCLUSIVE direction, matching
+    # the absent-field rule in shadow-adjudicate.sh, because excluding is what
+    # biases the measured rate toward clearing the deny-flip. A caller passing
+    # anything else still has a bug.
     case "${_ae}" in true|false) ;; *) _ae="true" ;; esac
     local _log _dir _ts _nonce _rid _branch _head
     _log="${IMPLEMENT_SHADOW_LOG:-${HOME}/.claude/.push-implement-shadow.jsonl}"

--- a/hooks/lib/pr-diff.sh
+++ b/hooks/lib/pr-diff.sh
@@ -22,9 +22,43 @@
 
 PR_DIFF_GH_TIMEOUT="${PR_DIFF_GH_TIMEOUT:-10}"
 
+# `_gc_redir_kind_var` (git-command.sh) classifies a word as a shell redirection.
+# Borrowed rather than reimplemented: that helper is STRUCTURAL (an optional
+# `{name}` fd, an optional `&`, an optional digit run, then `<` or `>`), and this
+# predicate family has been bypassed repeatedly by hand-written lists of
+# redirection spellings that were complete until they were not.
+#
+# openspec-guard.sh already sources git-command.sh before this file, so the
+# common case defines nothing new; the source is a fallback for a direct caller
+# (the tests) and is skipped when the function is already present. Guarded per
+# CLAUDE.md's #137 form: a `[ -f ]` test proves existence, not that the source
+# succeeded, so availability is decided by `command -v` afterwards.
+#
+# DEGRADATION IS TODAY'S BEHAVIOUR, NOT A NEW FAILURE: with the helper absent,
+# `_prd_redir_ok` stays false, no word is skipped, and a redirection operand is
+# counted as a ref candidate exactly as it was before this change — i.e. an
+# ambiguous command resolves to nothing. Advisory path, so that is a lost
+# measurement, never a gate decision (this lib is deliberately excluded from
+# _GATE_ENFORCE_LIBS).
+_prd_redir_ok=false
+if command -v _gc_redir_kind_var >/dev/null 2>&1; then
+    _prd_redir_ok=true
+else
+    _prd_lib_dir=""
+    if [ -n "${BASH_SOURCE:-}" ]; then
+        _prd_lib_dir=$(dirname "${BASH_SOURCE}") || _prd_lib_dir=""
+    fi
+    if [ -n "${_prd_lib_dir}" ] && [ -f "${_prd_lib_dir}/git-command.sh" ]; then
+        . "${_prd_lib_dir}/git-command.sh" 2>/dev/null || true
+        command -v _gc_redir_kind_var >/dev/null 2>&1 && _prd_redir_ok=true
+    fi
+    unset _prd_lib_dir
+fi
+
 # pr_ref_from_command <command> -> bare PR number, or nothing
 pr_ref_from_command() {
     local _cmd="${1:-}" _cand="" _tok _seen_merge="" _restore_glob=1 _ndigit=0
+    local _skip_next=""
     case "${_cmd}" in
         *pulls/*/merge*)
             # gh api repos/o/r/pulls/7/merge
@@ -53,6 +87,17 @@ pr_ref_from_command() {
             case $- in *f*) _restore_glob=0 ;; esac
             set -f
             for _tok in ${_cmd}; do
+                # A SHELL REDIRECTION IS NOT A REF. `2>&1` is digit-leading, so
+                # before this it counted as a second candidate and the ambiguity
+                # guard below returned nothing -- which is why every one of the
+                # 14 gh-merge shadow records ever written says "unresolved".
+                # A `bare` operator (`>`, `2>`, `<<<`) takes the NEXT word as its
+                # target, so that word is a filename and must be skipped too.
+                if [ -n "${_skip_next}" ]; then _skip_next=""; continue; fi
+                if [ "${_prd_redir_ok}" = "true" ] && _gc_redir_kind_var "${_tok}"; then
+                    [ "${_GC_REDIR}" = "bare" ] && _skip_next=1
+                    continue
+                fi
                 if [ -z "${_seen_merge}" ]; then
                     case "${_tok}" in
                         merge) _seen_merge=1 ;;

--- a/hooks/lib/pr-diff.sh
+++ b/hooks/lib/pr-diff.sh
@@ -30,7 +30,11 @@ PR_DIFF_GH_TIMEOUT="${PR_DIFF_GH_TIMEOUT:-10}"
 #
 # openspec-guard.sh already sources git-command.sh before this file, so the
 # common case defines nothing new; the source is a fallback for a direct caller
-# (the tests) and is skipped when the function is already present. Guarded per
+# (the tests) and is skipped when the function is already present. From the guard
+# the fallback is UNREACHABLE — both libs resolve from the same `_GC_ROOT` and
+# git-command.sh loads first — so it is not a supported degradation path for the
+# gate, and this advisory-only lib does not thereby acquire a runtime dependency
+# on a `_GATE_ENFORCE_LIBS` member (review note). Guarded per
 # CLAUDE.md's #137 form: a `[ -f ]` test proves existence, not that the source
 # succeeded, so availability is decided by `command -v` afterwards.
 #

--- a/hooks/openspec-guard.sh
+++ b/hooks/openspec-guard.sh
@@ -1229,16 +1229,41 @@ EOF
                 # label instead of being mislabeled unresolved). Push keeps its
                 # original, narrower gate (material-only) — this branch never
                 # widens what a push records.
+                # A command whose every RECOGNISED push deletes a ref ships no
+                # content, so saying "this push edits source" about it is false.
+                # The strict certification above could not establish that — an
+                # unaccountable trailing segment (`| tail -2`) makes
+                # `_gc_seg_is_inert` refuse, correctly, since it cannot tell
+                # `tail` from `./deploy.sh` — and the subject then fell back to
+                # the checkout HEAD. That fallback is defensible for a gate
+                # DECISION and is not defensible for a STATEMENT, which is the
+                # distinction CLAUDE.md's "never a new deny" note does not draw.
+                #
+                # Advisory-only, and it must stay that way: this predicate is
+                # weaker than certification and cannot skip a leg. Nothing below
+                # changes any deny — `_SUBJ_DELETION_ONLY` still governs the
+                # four content-dependent legs, from the strict form alone.
+                _impl_recog_del=false
+                if [ "${_impl_material}" = "true" ] \
+                   && command -v command_push_recognised_are_all_deletions >/dev/null 2>&1 \
+                   && command_push_recognised_are_all_deletions "${_COMMAND}"; then
+                    _impl_recog_del=true
+                fi
                 if [ "${_impl_ok}" = "false" ] && \
                    { [ "${_impl_material}" = "true" ] || [ "${_pe_action}" = "gh-merge" ]; }; then
-                    if [ "${_impl_material}" = "true" ]; then
+                    if [ "${_impl_material}" = "true" ] && [ "${_impl_recog_del}" != "true" ]; then
                         _IMPL_TEXT="IMPLEMENT: this push edits source but no implementation-slot skill (executing-plans / subagent-driven-development / agent-team-execution) has invocation evidence on this chain. Invoke it, or record a deliberate skip: phase_attest executing-plans \"<reason>\". (advisory; will become a deny after backtest)"
                         _STALE_MSG="${_STALE_MSG}${_STALE_MSG:+; }${_IMPL_TEXT}"
                         _IMPL_MSG="${_IMPL_MSG}${_IMPL_MSG:+; }${_IMPL_TEXT}"
                         command -v phase_gate_log >/dev/null 2>&1 && phase_gate_log "push-implement" "warn" "${_pe_action}" "executing-plans"
                     fi
                     if command -v implement_shadow_record >/dev/null 2>&1; then
-                        implement_shadow_record "${_pe_action}" "${_SUBJ_ROOT}" "${_SESSION_TOKEN}" "${_TRANSCRIPT:-}" "none" "${_impl_db}" "${_impl_material}" "true" "${_impl_detail}" "${_SUBJ_REV}" || true
+                        # `advisory_emitted` mirrors the branch above: an event the
+                        # leg said nothing about is recorded, but is not part of the
+                        # population a false-block rate is computed over.
+                        _impl_ae=true
+                        { [ "${_impl_material}" != "true" ] || [ "${_impl_recog_del}" = "true" ]; } && _impl_ae=false
+                        implement_shadow_record "${_pe_action}" "${_SUBJ_ROOT}" "${_SESSION_TOKEN}" "${_TRANSCRIPT:-}" "none" "${_impl_db}" "${_impl_material}" "true" "${_impl_detail}" "${_SUBJ_REV}" "${_impl_ae}" || true
                     fi
                 fi
                 # Attestation-resolved episodes are recorded too, as
@@ -1251,7 +1276,10 @@ EOF
                 if [ "${_impl_ev}" = "attested" ] && \
                    { [ "${_impl_material}" = "true" ] || [ "${_pe_action}" = "gh-merge" ]; }; then
                     if command -v implement_shadow_record >/dev/null 2>&1; then
-                        implement_shadow_record "${_pe_action}" "${_SUBJ_ROOT}" "${_SESSION_TOKEN}" "${_TRANSCRIPT:-}" "attested" "${_impl_db}" "${_impl_material}" "false" "${_impl_detail}" "${_SUBJ_REV}" || true
+                        # An attested episode emits no advisory either; it is already
+                        # outside the rate via would_block:false, and recording the
+                        # field honestly keeps the two membership signals consistent.
+                        implement_shadow_record "${_pe_action}" "${_SUBJ_ROOT}" "${_SESSION_TOKEN}" "${_TRANSCRIPT:-}" "attested" "${_impl_db}" "${_impl_material}" "false" "${_impl_detail}" "${_SUBJ_REV}" "false" || true
                     fi
                 fi
             fi

--- a/openspec/changes/gate-parser-subject-defects/proposal.md
+++ b/openspec/changes/gate-parser-subject-defects/proposal.md
@@ -1,0 +1,77 @@
+# Two parser defects that made the gate say false things
+
+## Why
+
+A four-panelist review of the IMPLEMENT shadow corpus (three Claude lenses plus
+a cross-family Codex run, two rounds) found that the 12 v4 would-block episodes
+could not be adjudicated as recorded. Three of the twelve had a premise the
+predicate never established, from two independent parser defects — and every one
+of the twelve gated commands was written in the shape that triggers them:
+`2>&1 | tail -N`.
+
+**1. A redirection operand was read as a PR reference.** `pr_ref_from_command`
+counts digit-leading tokens after `merge` and refuses when there is more than
+one, so a plausible-but-wrong label is never emitted. `2>&1` is digit-leading.
+Measured: **14 of 14** `gh-merge` records across 39 days carry
+`diff_base: unresolved` — #161's merge-subject resolution has never once
+produced a measurement in production. This is the #238 defect class exactly, and
+`git-command.sh` already carries the structural fix (`_gc_redir_kind_var`) that
+was never applied here.
+
+**2. A deletion-shaped command was recorded as a content push.** A trailing
+`| tail -N` is a segment `_gc_seg_is_inert` cannot vouch for, so
+`command_push_is_all_deletions` refuses to certify, the subject falls back to the
+checkout HEAD, and the IMPLEMENT leg then states "this push edits source" about a
+command that ships nothing. Two of the twelve episodes are branch cleanups
+recorded this way.
+
+## What Changes
+
+- `pr_ref_from_command` skips shell redirection operands, reusing
+  `_gc_redir_kind_var` rather than listing redirection spellings.
+- A new **advisory-only** predicate `command_push_recognised_are_all_deletions`
+  answers the weaker question "does every RECOGNISED push here delete a ref?".
+  The IMPLEMENT leg uses it to stop asserting something false; no gate decision
+  consults it.
+- The shadow record gains `advisory_emitted`, and the rate population is that
+  field rather than an inference from `would_block`.
+- `IMPLEMENT_SHADOW_PREDICATE_VERSION` 4 → 5; `IMPLEMENT_SHADOW_SCHEMA_VERSION`
+  3 → 4.
+
+## The deletion half is NOT a parser fix, and that is deliberate
+
+There is no sound widening of `_gc_seg_is_inert`. The right-hand side of a pipe
+executes arbitrarily — `git push --delete origin x | ./deploy.sh` runs
+`deploy.sh` — so a whitelist that vouched for `tail` would have to distinguish it
+from an arbitrary program by name, which is the enumeration this predicate family
+has already been bypassed by eight times. The refusal is correct.
+
+What was wrong is the CONSEQUENCE. CLAUDE.md justifies the lost certification as
+"one-directional … never a new deny", which is true of **enforcement** and does
+not transfer to **measurement** or to what the gate SAYS. So the strict predicate
+keeps governing every skip, and a second, weaker predicate governs only the
+sentence and the corpus record. The asymmetry is the design: mixing them up is
+what nearly shipped a false ALLOW when the ANY-form was first written, and a test
+asserts that swapping the strict form for the weak one at the gate site fails.
+
+## Why the version bump, measured before taking it
+
+Both changes alter WHEN THE LEG FIRES — merges begin resolving and emitting
+advisories they never emitted; deletion-shaped commands stop emitting one — so
+this repo's own rule forces a `predicate_version` bump, and v4 records must not
+be pooled with v5.
+
+Measured first, per #199: the live v4 corpus held **12** would-block episodes, at
+least **3** of them known-bad, against a floor of **29**. The exact rule needs
+`0.9^n < 0.05`; at n=12 that is 0.282. Nothing measurable was discarded. This is
+the third reset, and three resets rooted in the same command-text parser being
+incomplete in a new way is an argument for recording the pattern, not for pooling
+across a predicate change.
+
+## Impact
+
+- `hooks/lib/pr-diff.sh`, `hooks/lib/git-command.sh`, `hooks/lib/implement-shadow.sh`,
+  `hooks/openspec-guard.sh`, `scripts/shadow-adjudicate.sh`.
+- No deny behaviour changes. `_SUBJ_DELETION_ONLY` still derives from the strict
+  form alone.
+- Capability: `pdlc-safety`.

--- a/openspec/changes/gate-parser-subject-defects/specs/pdlc-safety/spec.md
+++ b/openspec/changes/gate-parser-subject-defects/specs/pdlc-safety/spec.md
@@ -64,6 +64,13 @@ predicate migrates onto the gate path unnoticed.
   certification refuses
 - **WHEN** the push gate evaluates its content-dependent legs
 - **THEN** those legs MUST behave exactly as they did before this change
+#### Scenario: An advisory leg's skip is bound to the strict predicate
+
+- **GIVEN** a command whose recognised pushes all delete a reference but whose
+  certification is refused because a segment cannot be accounted for
+- **WHEN** a leg that skips on deletion-only subjects runs
+- **THEN** that leg MUST still run, because certification was not established
+- **AND** this MUST hold for advisory legs as well as denying ones
 
 ### Requirement: Rate membership MUST be a recorded observation, not an inference
 
@@ -87,11 +94,3 @@ reported alongside the rate, never dropped silently.
 - **GIVEN** a would-block record with no recorded advisory field
 - **WHEN** the corpus status is computed
 - **THEN** the episode MUST remain in the rate population
-
-#### Scenario: An advisory leg's skip is bound to the strict predicate
-
-- **GIVEN** a command whose recognised pushes all delete a reference but whose
-  certification is refused because a segment cannot be accounted for
-- **WHEN** a leg that skips on deletion-only subjects runs
-- **THEN** that leg MUST still run, because certification was not established
-- **AND** this MUST hold for advisory legs as well as denying ones

--- a/openspec/changes/gate-parser-subject-defects/specs/pdlc-safety/spec.md
+++ b/openspec/changes/gate-parser-subject-defects/specs/pdlc-safety/spec.md
@@ -1,0 +1,85 @@
+# Spec delta: pdlc-safety — parser defects in the gate's subject resolution
+
+## ADDED Requirements
+
+### Requirement: A shell redirection operand MUST NOT be read as a reference
+
+Command-text parsers that extract a reference — a pull-request number, a
+refspec — MUST skip shell redirection operands. A redirection operand MUST be
+recognised structurally (an optional named file descriptor, an optional `&`, an
+optional digit run, then `<` or `>`), never by enumerating spellings, and an
+operator whose target is the following word MUST cause that word to be skipped
+as well.
+
+#### Scenario: A merge command carrying a stderr redirection resolves its PR
+
+- **GIVEN** a merge command that names a pull-request number and redirects
+  stderr with `2>&1`
+- **WHEN** the reference is extracted
+- **THEN** it MUST be the pull-request number
+- **AND** the redirection MUST NOT be counted as a second candidate reference
+
+#### Scenario: A genuinely ambiguous command still refuses
+
+- **GIVEN** a merge command carrying two candidate references, neither of which
+  is a redirection operand
+- **WHEN** the reference is extracted
+- **THEN** nothing MUST be returned, because a plausible wrong label is worse
+  than none
+
+### Requirement: The gate MUST NOT assert that a command ships content it does not ship
+
+When every recognised push in a command deletes a reference, the IMPLEMENT
+evidence leg MUST NOT state that the push edits source, and MUST record the
+event as having emitted no advisory.
+
+The predicate establishing this MUST be advisory-only. It is weaker than the
+certification that permits gate legs to be skipped — it accounts only for
+recognised push segments, not for every segment — and it MUST NOT be used to
+skip, suppress, or shortcut any deny. Certification for gate purposes MUST
+continue to require that every segment be accounted for.
+
+#### Scenario: A deletion whose certification is defeated by a pipeline stage
+
+- **GIVEN** a command whose every recognised push deletes a reference, followed
+  by a pipeline stage that cannot be vouched for
+- **WHEN** the IMPLEMENT evidence leg runs
+- **THEN** no advisory claiming the push edits source MUST be emitted
+- **AND** the shadow record MUST mark that no advisory was emitted
+
+#### Scenario: A deletion mixed with a real push still advises
+
+- **GIVEN** a command that deletes a reference AND pushes content
+- **WHEN** the IMPLEMENT evidence leg runs
+- **THEN** the advisory MUST be emitted as before
+- **AND** the record MUST mark that an advisory was emitted
+
+#### Scenario: The weaker predicate never widens a gate
+
+- **GIVEN** a command that the weaker predicate accepts and the strict
+  certification refuses
+- **WHEN** the push gate evaluates its content-dependent legs
+- **THEN** those legs MUST behave exactly as they did before this change
+
+### Requirement: Rate membership MUST be a recorded observation, not an inference
+
+The shadow record MUST carry whether the leg emitted an advisory, and the
+false-block rate MUST be computed only over episodes for which it did. An
+episode MUST NOT be excluded merely because a field is absent or malformed:
+exclusion biases the measurement toward clearing the deny-flip, so an
+unrecoverable value MUST resolve to inclusion. The excluded population MUST be
+reported alongside the rate, never dropped silently.
+
+#### Scenario: An event the leg said nothing about is outside the rate
+
+- **GIVEN** a record that would have blocked but produced no advisory
+- **WHEN** the corpus status is computed
+- **THEN** the episode MUST NOT be in the rate population
+- **AND** it MUST be reported as an explicit exclusion
+- **AND** it MUST NOT be counted as an attestation-satisfied episode
+
+#### Scenario: A missing membership field keeps the episode in
+
+- **GIVEN** a would-block record with no recorded advisory field
+- **WHEN** the corpus status is computed
+- **THEN** the episode MUST remain in the rate population

--- a/openspec/changes/gate-parser-subject-defects/specs/pdlc-safety/spec.md
+++ b/openspec/changes/gate-parser-subject-defects/specs/pdlc-safety/spec.md
@@ -54,6 +54,10 @@ continue to require that every segment be accounted for.
 - **THEN** the advisory MUST be emitted as before
 - **AND** the record MUST mark that an advisory was emitted
 
+Every leg that skips on the strict certification MUST have that skip asserted,
+including legs that only emit an advisory. An unasserted skip is how a weaker
+predicate migrates onto the gate path unnoticed.
+
 #### Scenario: The weaker predicate never widens a gate
 
 - **GIVEN** a command that the weaker predicate accepts and the strict
@@ -83,3 +87,11 @@ reported alongside the rate, never dropped silently.
 - **GIVEN** a would-block record with no recorded advisory field
 - **WHEN** the corpus status is computed
 - **THEN** the episode MUST remain in the rate population
+
+#### Scenario: An advisory leg's skip is bound to the strict predicate
+
+- **GIVEN** a command whose recognised pushes all delete a reference but whose
+  certification is refused because a segment cannot be accounted for
+- **WHEN** a leg that skips on deletion-only subjects runs
+- **THEN** that leg MUST still run, because certification was not established
+- **AND** this MUST hold for advisory legs as well as denying ones

--- a/scripts/shadow-adjudicate.sh
+++ b/scripts/shadow-adjudicate.sh
@@ -267,8 +267,12 @@ cmd_next() {
               # nothing about it, so it cannot contain a false block, and offering
               # it spends operator time on the one population that provably
               # cannot inform the measurement. Same reason attested records are
-              # not offered. Schema <5 records carry no such field and are
-              # unaffected (they are excluded by predicate_version anyway).
+              # not offered. The field arrives in SCHEMA 4; predicate_version 5
+              # is the separate thing that excludes the older firing population.
+              # Conflating the two version counters is how a later reader talks
+              # itself into the wrong exclusion, so they are named apart here.
+              # Records written before schema 4 carry no such field and fall
+              # through this filter unchanged.
               | select((has("advisory_emitted") | not) or ((.advisory_emitted|type) != "boolean") or .advisory_emitted == true)
               | [.record_id,.ts,.repo,.branch,.action,.diff_base,
                  (.impl_in_chain|tostring),(.material_source|tostring),

--- a/scripts/shadow-adjudicate.sh
+++ b/scripts/shadow-adjudicate.sh
@@ -263,6 +263,13 @@ cmd_next() {
     # the same reason as _episode_wb: a JSON string "true" must not qualify.
     _line="$(_shadow_tsv 'select((.ts // "") | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))
               | select(has("would_block") and ((.would_block|type) == "boolean") and .would_block == true)
+              # An ADVISORY-SILENT record must not be queued either: the leg said
+              # nothing about it, so it cannot contain a false block, and offering
+              # it spends operator time on the one population that provably
+              # cannot inform the measurement. Same reason attested records are
+              # not offered. Schema <5 records carry no such field and are
+              # unaffected (they are excluded by predicate_version anyway).
+              | select((has("advisory_emitted") | not) or ((.advisory_emitted|type) != "boolean") or .advisory_emitted == true)
               | [.record_id,.ts,.repo,.branch,.action,.diff_base,
                  (.impl_in_chain|tostring),(.material_source|tostring),
                  .impl_evidence_kind,.transcript_path,
@@ -369,8 +376,33 @@ cmd_next() {
 # rather than discovered later, because an undefined rule is how this instrument
 # came to be wrong in the first place.
 #
-# Membership is read from `would_block` ONLY, never inferred from
-# `impl_evidence_kind`. The two correlate perfectly in today's data, which is
+# SECOND MEMBERSHIP FIELD, schema 4 (#245): `advisory_emitted`. `would_block`
+# turned out not to mean what the rate needed, in two ways that had nothing to do
+# with each other: on the gh-merge path it is passed as a hardcoded literal, so a
+# merge whose subject never resolved asserted a block the leg would not perform;
+# and a deletion-shaped command that lost its certification to an unaccountable
+# pipeline segment produced a would_block record while shipping no content. Both
+# are events the leg SAID NOTHING about, so neither could have blocked anyone,
+# and both were adjudicable only as false blocks — moving the pre-registered rate
+# for a reason unrelated to the predicate under test.
+#
+# Recording what the leg actually did retires that class instead of filtering one
+# instance of it: the next premise-false shape drops out without another reader
+# fix. An episode joins the rate only when a record both would have blocked AND
+# produced an advisory. The exclusion is REPORTED, never silent.
+#
+# ONLY AN EXPLICIT `false` EXCLUDES, and the asymmetry with `would_block` is
+# deliberate rather than an oversight. For `would_block`, an unknown folded into
+# the population would DILUTE the denominator, so it is malformed. Here the
+# directions are reversed: excluding an episode is what biases the rate toward
+# CLEARING the deny-flip, so an absent or malformed `advisory_emitted` must
+# resolve to "assume the leg spoke" and stay in. A producer bug that drops the
+# field then costs a possibly-spurious episode in the denominator — the safe
+# direction — instead of silently shrinking the population the bar is measured
+# over. Records written before schema 4 carry no such field and are unaffected.
+#
+# Membership is read from `would_block` and `advisory_emitted` ONLY, never
+# inferred from `impl_evidence_kind`. The two correlate perfectly in today's data, which is
 # precisely the trap: that field is format-frozen and describes EVIDENCE, not
 # rate membership, and coupling them would re-create the implicit contract that
 # broke this reader.
@@ -378,7 +410,7 @@ cmd_next() {
 # A missing or non-boolean value is "malformed", never silently "no": folding an
 # unknown into the population that looks safe is the same bias in miniature.
 _episode_wb() {
-    local _ids="${1:-}" _id _v _sawtrue=false _sawbad=false _oifs
+    local _ids="${1:-}" _id _v _sawtrue=false _sawbad=false _sawsilent=false _oifs
     [ -n "${_ids}" ] && [ -f "${SHADOW_LOG}" ] || { echo malformed; return 0; }
     command -v jq >/dev/null 2>&1 || { echo malformed; return 0; }
     _oifs="$IFS"; IFS=,
@@ -386,20 +418,37 @@ _episode_wb() {
         # Type-checked, not `tostring`: a JSON *string* "true" would otherwise be
         # indistinguishable from the boolean and would silently join the rate
         # population.
+        # Emits one of: true | false | SILENT | MALFORMED.
+        # SILENT = would_block true but the leg emitted no advisory, i.e. an
+        # event nobody could have been blocked by. Reported separately rather
+        # than folded into `false`, which means "attestation satisfied the leg" —
+        # a different state that #169 records deliberately.
         _v="$(jq -r --arg id "${_id}" \
              'select(.record_id == $id)
-              | if (has("would_block") and ((.would_block|type) == "boolean"))
-                then (.would_block|tostring) else "MALFORMED" end' \
+              | if (has("would_block") and ((.would_block|type) == "boolean")) | not
+                then "MALFORMED"
+                elif (.would_block == false) then "false"
+                elif (has("advisory_emitted") and ((.advisory_emitted|type) == "boolean")
+                      and .advisory_emitted == false) then "SILENT"
+                else "true" end' \
              "${SHADOW_LOG}" 2>/dev/null | head -1)"
         case "${_v}" in
-            true)  _sawtrue=true ;;
-            false) ;;
-            *)     _sawbad=true ;;
+            true)   _sawtrue=true ;;
+            false)  ;;
+            SILENT) _sawsilent=true ;;
+            *)      _sawbad=true ;;
         esac
     done
     IFS="$_oifs"
-    if [ "${_sawtrue}" = true ]; then echo yes;       return 0; fi
-    if [ "${_sawbad}"  = true ]; then echo malformed; return 0; fi
+    # Order is UNCHANGED from before the silent arm existed: any would-block wins
+    # (the anchor-independent ANY rule), then malformed. `silent` is appended
+    # LAST so an episode holding both a real would-block and a silent record
+    # still counts — narrowing that would quietly drop episodes the rate is
+    # entitled to. Only an episode whose would-block records are ALL silent is
+    # excluded, which is exactly the premise-false population.
+    if [ "${_sawtrue}"   = true ]; then echo yes;       return 0; fi
+    if [ "${_sawbad}"    = true ]; then echo malformed; return 0; fi
+    if [ "${_sawsilent}" = true ]; then echo silent;    return 0; fi
     echo no
 }
 
@@ -440,7 +489,7 @@ _episode_verdict() {
 # cmd_status — episode-level readout. Observational; always exits 0.
 cmd_status() {
     local _tot=0 _lab=0 _fb=0 _tc=0 _unk=0 _agent=0 _unlab=0 _v1=0
-    local _wbep=0 _attep=0 _malwb=0 _wb
+    local _wbep=0 _attep=0 _malwb=0 _silep=0 _wb
     local _repos="" _eid _repo _branch _tok _ids _vc _v _c _nrepos
     local _den _wc_k _wc_n _band_hdl _band_wc
     local _badts=0 _unparsed=0 _lines=0 _parsed=0
@@ -483,9 +532,10 @@ cmd_status() {
         # repos, which is the same dilution one level up.
         _wb="$(_episode_wb "${_ids}")"
         case "${_wb}" in
-            yes) _wbep=$(( _wbep + 1 )) ;;
-            no)  _attep=$(( _attep + 1 )); continue ;;
-            *)   _malwb=$(( _malwb + 1 )); continue ;;
+            yes)    _wbep=$(( _wbep + 1 )) ;;
+            no)     _attep=$(( _attep + 1 )); continue ;;
+            silent) _silep=$(( _silep + 1 )); continue ;;
+            *)      _malwb=$(( _malwb + 1 )); continue ;;
         esac
         _vc="$(_episode_verdict "${_ids}")"
         _v="$(printf '%s' "${_vc}" | sed -n 1p)"
@@ -514,6 +564,8 @@ EOF
     printf '  episodes          %s\n' "${_tot}"
     printf '  would-block       %s   <- the ONLY population the rate is computed over\n' "${_wbep}"
     printf '  attestation-only  %s   <- observation (#169): attestation satisfied the leg; cannot contain a false block\n' "${_attep}"
+    [ "${_silep}" -gt 0 ] && \
+        printf '  advisory-silent   %s   <- excluded: the leg emitted no advisory, so nobody could have been blocked; the premise was never established\n' "${_silep}"
     [ "${_malwb}" -gt 0 ] && \
         printf '  malformed would_block %s   <- excluded: field missing or not boolean; NOT counted as attestation-only\n' "${_malwb}"
     printf '  adjudicated       %s   (human-claimed)\n' "${_lab}"

--- a/tests/test-evaluator-surface.sh
+++ b/tests/test-evaluator-surface.sh
@@ -226,6 +226,40 @@ assert_not_contains "advisory file list has no trailing space"   " )"           
 out="$(run_guard_in "${REPO}" "feat2")"
 assert_not_contains "clean branch => no evaluator advisory"      "EVALUATOR SURFACE"   "${out:-}"
 
+# --- The deletion-only skip on THIS leg is pinned by the STRICT form (#245) ---
+# The evaluator-surface leg skips on `_SUBJ_DELETION_ONLY`, which derives from
+# `command_push_is_all_deletions` -- the strict predicate that requires EVERY
+# segment to be accounted for. Nothing asserted that until now: swapping this
+# one site to the weaker recognised-deletions predicate ran the whole push-gate
+# suite green (measured), because the deny-armed cells in
+# test-push-gate-subject.sh cover the two legs that DENY and this leg never
+# denies. An advisory leg is still user-visible output, and an unpinned skip is
+# how a predicate quietly migrates from the advisory path onto the gate path.
+run_guard_cmd() {
+    local repo="$1" branch="$2" cmd="$3"
+    ( cd "${repo}" && git checkout -q "${branch}" && \
+      _mkinput "${cmd}" | ACSM_SKIP_PUSH_GATE=1 CLAUDE_PLUGIN_ROOT="${PROJECT_ROOT}" bash "${GUARD}" 2>/dev/null )
+}
+
+# A command the STRICT form certifies: the advisory is correctly skipped, since
+# the branch diff describes a commit this command does not push.
+out="$(run_guard_cmd "${REPO}" "feat" 'git push origin --delete scratch')"
+assert_not_contains "certified deletion => no evaluator advisory" "EVALUATOR SURFACE" "${out:-}"
+
+# THE PIN. The same deletion with a trailing pipeline stage is refused by the
+# strict form, so this leg must still run and still advise. Wiring the weaker
+# predicate in here suppresses it -- which is exactly the misuse the weaker
+# predicate's contract forbids, and this is the cell that catches it.
+out="$(run_guard_cmd "${REPO}" "feat" 'git push origin --delete scratch 2>&1 | tail -2')"
+assert_contains "uncertifiable deletion => evaluator advisory STILL emitted" \
+    "EVALUATOR SURFACE" "${out:-<empty>}"
+
+# Control: an ordinary push on the same branch advises, so the cell above cannot
+# pass merely because this branch always advises regardless of the command.
+out="$(run_guard_cmd "${REPO}" "feat" 'git push origin HEAD')"
+assert_contains "control: ordinary push on the same branch advises" \
+    "EVALUATOR SURFACE" "${out:-<empty>}"
+
 # #189 e2e: the runner-only branch must reach the user as a real advisory, not
 # merely satisfy the predicate.
 out="$(run_guard_in "${REPO}" "feat3")"

--- a/tests/test-pr-diff.sh
+++ b/tests/test-pr-diff.sh
@@ -13,6 +13,37 @@ assert_equals "number after flags"           "7" "$(pr_ref_from_command 'gh pr m
 assert_equals "rest api merge path"          "7" "$(pr_ref_from_command 'gh api repos/o/r/pulls/7/merge')"
 assert_equals "delete-branch flag ignored"  "12" "$(pr_ref_from_command 'gh pr merge 12 --squash --delete-branch')"
 
+# --- redirection operands are not PR refs (#238 class, applied here) --------
+# `2>&1` is a digit-leading token, so the ambiguity guard counted it as a second
+# candidate and returned nothing. Measured consequence: 14 of 14 gh-merge shadow
+# records across 39 days carry diff_base "unresolved" -- this leg has NEVER once
+# resolved in production, and `2>&1 | tail -N` is what an agent naturally writes.
+# The fix reuses git-command.sh's STRUCTURAL _gc_redir_kind_var rather than
+# listing redirection spellings, because this predicate family has been bypassed
+# repeatedly by lists that were complete until they were not.
+assert_equals "stderr redirection is not a second ref"   "212" \
+    "$(pr_ref_from_command 'gh pr merge 212 --squash 2>&1')"
+assert_equals "redirection plus pipeline stage"          "212" \
+    "$(pr_ref_from_command 'gh pr merge 212 --squash --delete-branch 2>&1 | tail -6')"
+assert_equals "fd-close redirection"                     "212" \
+    "$(pr_ref_from_command 'gh pr merge 212 3>&- --squash')"
+assert_equals "bare operator consumes its target"        "212" \
+    "$(pr_ref_from_command 'gh pr merge 212 --squash > 99.log')"
+assert_equals "named-fd redirection"                     "212" \
+    "$(pr_ref_from_command 'gh pr merge 212 --squash {fd}>/tmp/7.log')"
+
+# CONTROLS -- the ambiguity guard must survive the fix. A genuinely ambiguous
+# command still returns nothing: a plausible wrong label is worse than none.
+assert_equals "genuine ambiguity still refuses"          "" \
+    "$(pr_ref_from_command 'gh pr merge --title \"PR 42 notes\" 99')"
+assert_equals "two bare numbers still refuse"            "" \
+    "$(pr_ref_from_command 'gh pr merge 42 99')"
+# A redirection TARGET is a filename, not a ref: `>` is a bare operator, so the
+# word after it must be skipped too, and skipping it must not also swallow a
+# real ref that follows.
+assert_equals "redirection target is skipped, ref after it still found" "212" \
+    "$(pr_ref_from_command 'gh pr merge --squash > 99.log 212')"
+
 # Fix round 1, IMPORTANT 1a: a digit-leading token BEFORE the literal `merge`
 # token (e.g. a flag value like `--org 42`) must never be mistaken for the PR
 # ref -- the loop must gate the digit test on having seen `merge` first.

--- a/tests/test-push-gate-detection.sh
+++ b/tests/test-push-gate-detection.sh
@@ -643,5 +643,73 @@ out="$(_run "${_MLQ}")"
 assert_not_contains "quoted-newline payload still allowed" '"deny"' "${out:-}"
 
 export HOME="$_OLDHOME"
+
+# ---------------------------------------------------------------------------
+# command_push_recognised_are_all_deletions -- the WEAKER, ADVISORY-ONLY form.
+#
+# The strict `command_push_is_all_deletions` requires EVERY segment to be
+# accounted for, because certifying "this command ships no content" is what
+# lets four content-dependent gate legs be skipped. A trailing `| tail -N` is an
+# unaccountable segment, and the whitelist correctly cannot tell `tail` from
+# `./deploy.sh` -- so the strict form refuses, the gate falls back to measuring
+# the checkout HEAD, and the IMPLEMENT leg then asserts "this push edits source"
+# of a command that ships nothing. Measured in the live corpus: 2 of 12 v4
+# would-block episodes are deletion-shaped commands recorded as content pushes,
+# and `2>&1 | tail -N` is the shape an agent naturally writes.
+#
+# This predicate answers the weaker question -- "is every RECOGNISED push in
+# this command a deletion?" -- which is exactly the claim needed to stop SAYING
+# something false, and is NOT sufficient to skip a gate. The asymmetry is the
+# whole design: the cells below pin both halves.
+# ---------------------------------------------------------------------------
+echo "-- recognised-deletions (advisory-only) --"
+
+_rad() { if command_push_recognised_are_all_deletions "$1"; then echo yes; else echo no; fi; }
+_strict() { if command_push_is_all_deletions "$1"; then echo yes; else echo no; fi; }
+
+assert_equals "advisory form: deletion with a pipeline stage" "yes" \
+    "$(_rad 'git push origin --delete scratch 2>&1 | tail -2')"
+assert_equals "advisory form: bare deletion"                  "yes" \
+    "$(_rad 'git push origin --delete scratch')"
+assert_equals "advisory form: deletion piped to an unknown command" "yes" \
+    "$(_rad 'git push origin --delete scratch | ./deploy.sh')"
+
+# The weaker claim is WEAKER: it says nothing about a second content-shipping
+# command. That is precisely why it must never gate, and the paired cells below
+# assert the strict form still refuses every one of these.
+assert_equals "strict form still refuses a pipeline stage"    "no" \
+    "$(_strict 'git push origin --delete scratch 2>&1 | tail -2')"
+assert_equals "strict form still refuses an unknown command"  "no" \
+    "$(_strict 'git push origin --delete scratch | ./deploy.sh')"
+assert_equals "strict form still certifies a bare deletion"   "yes" \
+    "$(_strict 'git push origin --delete scratch')"
+
+# A real push anywhere among the RECOGNISED pushes disqualifies both forms.
+assert_equals "advisory form: deletion plus a real push"      "no" \
+    "$(_rad 'git push origin --delete scratch && git push origin main')"
+assert_equals "advisory form: ordinary push"                  "no" \
+    "$(_rad 'git push origin main | tail -2')"
+assert_equals "advisory form: --all is never a deletion"      "no" \
+    "$(_rad 'git push --all origin')"
+assert_equals "advisory form: --mirror is never a deletion"   "no" \
+    "$(_rad 'git push --mirror origin')"
+assert_equals "advisory form: --tags is never a deletion"     "no" \
+    "$(_rad 'git push origin --delete scratch --tags')"
+
+# The three orthogonal layers apply to the advisory form too. Each is a
+# DIFFERENT failure mode and none subsumes another, so each gets its own cell:
+# a substitution runs wherever it appears (including inside the deletion's own
+# arguments); an unbalanced parse means the segmentation itself is untrustworthy.
+assert_equals "advisory form: substitution refuses"           "no" \
+    "$(_rad 'git push origin --delete scratch && cd $(git push origin main)')"
+assert_equals "advisory form: substitution inside the deletion refuses" "no" \
+    "$(_rad 'git push origin --delete $(git push origin main)')"
+assert_equals "advisory form: zsh process substitution refuses" "no" \
+    "$(_rad 'git push origin --delete scratch && cd =(git push origin main)')"
+assert_equals "advisory form: unbalanced parse refuses"       "no" \
+    "$(_rad 'git push origin --delete scratch; cd \\'"'"'; git push origin main')"
+assert_equals "advisory form: no push at all"                 "no" \
+    "$(_rad 'echo hello')"
+
 print_summary
 exit $?

--- a/tests/test-push-gate-implement-leg.sh
+++ b/tests/test-push-gate-implement-leg.sh
@@ -23,12 +23,12 @@ export IMPLEMENT_SHADOW_LOG="${_u_home}/shadow.jsonl"
 # shellcheck disable=SC1090
 . "${PROJECT_ROOT}/hooks/lib/implement-shadow.sh"
 
-assert_equals "schema_version is 3" "3" "${IMPLEMENT_SHADOW_SCHEMA_VERSION}"
+assert_equals "schema_version is 4" "4" "${IMPLEMENT_SHADOW_SCHEMA_VERSION}"
 # 3 (#219): the push path now measures the tree and ref the command names, not
 # the session cwd — that changes WHEN the leg fires, so v2 records are no longer
 # poolable. Bumping this pin without bumping the constant, or vice versa, is the
 # mistake it exists to catch.
-assert_equals "predicate_version is 4 (#229 deletion subject)" "4" \
+assert_equals "predicate_version is 5 (#245 redirection parser + advisory_emitted)" "5" \
     "${IMPLEMENT_SHADOW_PREDICATE_VERSION}"
 
 implement_shadow_record push "${PROJECT_ROOT}" tok /tmp/t.jsonl none branch-local true
@@ -72,9 +72,9 @@ assert_equals "cannot_check is preserved per leg" "cannot_check" \
     "$(jq -r '.impl_evidence_detail.bridge' "${IMPLEMENT_SHADOW_LOG}")"
 assert_equals "missing is distinguishable from cannot_check" "missing" \
     "$(jq -r '.impl_evidence_detail.ledger' "${IMPLEMENT_SHADOW_LOG}")"
-assert_equals "schema_version on a detailed record is 3" "3" \
+assert_equals "schema_version on a detailed record is 4" "4" \
     "$(jq -r '.schema_version' "${IMPLEMENT_SHADOW_LOG}")"
-assert_equals "predicate_version is 4 so v3 records are NOT pooled" "4" \
+assert_equals "predicate_version is 5 so v4 records are NOT pooled" "5" \
     "$(jq -r '.predicate_version' "${IMPLEMENT_SHADOW_LOG}")"
 
 # An omitted detail must be null, NOT a fabricated all-missing object. "not
@@ -297,8 +297,8 @@ assert_json_valid "shadow record is valid json" "$IMPLEMENT_SHADOW_LOG"
 assert_contains "record names the gate"        '"gate":"push-implement"' "${_rec}"
 assert_contains "record marks a would-block"   '"would_block":true'      "${_rec}"
 assert_contains "record carries action push"   '"action":"push"'         "${_rec}"
-assert_contains "record carries schema_version"    '"schema_version":3'    "${_rec}"
-assert_contains "record carries predicate_version" '"predicate_version":4' "${_rec}"
+assert_contains "record carries schema_version"    '"schema_version":4'    "${_rec}"
+assert_contains "record carries predicate_version" '"predicate_version":5' "${_rec}"
 assert_contains "record carries a record_id"   '"record_id":'            "${_rec}"
 assert_contains "record carries a ts"          '"ts":'                   "${_rec}"
 assert_contains "record carries the transcript pointer" '"transcript_path":' "${_rec}"
@@ -424,7 +424,7 @@ _rec="$(cat "$IMPLEMENT_SHADOW_LOG")"
 assert_equals "merge writes one record" "1" "$(wc -l < "$IMPLEMENT_SHADOW_LOG" | tr -d ' ')"
 assert_contains "merge record names the PR as its subject" '"diff_base":"pr:7"' "${_rec}"
 assert_contains "merge record still marks material source"  '"material_source":true' "${_rec}"
-assert_contains "predicate_version bumped to 4 (#229)"        '"predicate_version":4' "${_rec}"
+assert_contains "predicate_version bumped to 5 (#245)"        '"predicate_version":5' "${_rec}"
 assert_not_contains "merge did not become a deny" "permissionDecision" "${out:-}"
 
 # Unresolvable PR -> unresolved, record still written, still no deny.
@@ -691,6 +691,47 @@ out="$(run_guard 'git push --delete origin feature/x; git push origin HEAD')"
 assert_contains "deletion + real push still raises the advisory" "IMPLEMENT:" "${out:-<empty>}"
 assert_equals "deletion + real push still appends a record" "1" \
     "$(wc -l < "$IMPLEMENT_SHADOW_LOG" | tr -d ' ')"
+
+# --- A deletion the STRICT form cannot certify (#245) -----------------------
+# `| tail -2` is an unaccountable segment, so `_gc_seg_is_inert` refuses and the
+# strict certification is lost -- correctly: it cannot tell `tail` from
+# `./deploy.sh`, and the right-hand side of a pipe executes arbitrarily. Before
+# this change the subject then fell back to the checkout HEAD and the leg
+# asserted "this push edits source" of a command shipping nothing, writing a
+# would-block record with a false premise. Two of the twelve v4 would-block
+# episodes in the live corpus are exactly this shape, and `2>&1 | tail -N` is
+# what an agent naturally writes.
+#
+# The advisory and the record's membership now follow the WEAKER
+# recognised-deletions predicate. Enforcement does NOT: `_SUBJ_DELETION_ONLY`
+# still governs the four content-dependent legs from the strict form alone.
+: > "$IMPLEMENT_SHADOW_LOG"
+out="$(run_guard 'git push --delete origin feature/x 2>&1 | tail -2')"
+assert_not_contains "uncertifiable deletion raises no IMPLEMENT advisory" "IMPLEMENT:" "${out:-}"
+assert_equals "uncertifiable deletion records advisory_emitted false" "false" \
+    "$(jq -r '.advisory_emitted' "$IMPLEMENT_SHADOW_LOG" 2>/dev/null | head -1)"
+# RECORDED, not dropped: "the leg said nothing" and "the event never happened"
+# are different states, and the reader must exclude on the field rather than on
+# an absence it cannot see.
+assert_equals "uncertifiable deletion still appends a record" "1" \
+    "$(wc -l < "$IMPLEMENT_SHADOW_LOG" | tr -d ' ')"
+
+# CONTROL -- the same command SHAPE carrying a real push keeps the advisory.
+# Without it, suppressing the advisory unconditionally passes every cell above.
+: > "$IMPLEMENT_SHADOW_LOG"
+out="$(run_guard 'git push origin HEAD 2>&1 | tail -2')"
+assert_contains "control: ordinary push with a pipeline stage still advises" "IMPLEMENT:" "${out:-<empty>}"
+assert_equals "control: ordinary push records advisory_emitted true" "true" \
+    "$(jq -r '.advisory_emitted' "$IMPLEMENT_SHADOW_LOG" 2>/dev/null | head -1)"
+
+# CONTROL -- a deletion MIXED with a real push is deletion-only under neither
+# form. This is the case the weaker predicate is allowed to answer, so getting
+# it wrong here would be exactly the misuse the design forbids.
+: > "$IMPLEMENT_SHADOW_LOG"
+out="$(run_guard 'git push --delete origin feature/x 2>&1 | tail -2 && git push origin HEAD')"
+assert_contains "control: deletion mixed with a real push still advises" "IMPLEMENT:" "${out:-<empty>}"
+assert_equals "control: mixed command records advisory_emitted true" "true" \
+    "$(jq -r '.advisory_emitted' "$IMPLEMENT_SHADOW_LOG" 2>/dev/null | head -1)"
 export HOME="$_OLDHOME"
 rm -rf "${_REPO}" "${_THOME}" 2>/dev/null
 print_summary

--- a/tests/test-shadow-adjudicate.sh
+++ b/tests/test-shadow-adjudicate.sh
@@ -603,6 +603,66 @@ eq "mixed episode (attested FIRST) counts as would-block too" "1" \
 recnowb x1 "2026-08-01T10:00:00Z" "/repo/A" "feat/x" "tokX"
 eq "a record with no would_block field is reported as excluded" "1" \
    "$(status | grep -c 'malformed would_block')"
+
+# ---------------------------------------------------------------------------
+# advisory_emitted: the SECOND membership field (schema 4, #245).
+#
+# `would_block` alone was not the rate population. Two unrelated shapes produced
+# `would_block:true` for events the leg said nothing about: a gh-merge whose
+# subject never resolved (the flag is passed as a literal on that path), and a
+# deletion-shaped command whose certification was defeated by an unaccountable
+# pipeline segment. Neither could have blocked anyone, and both were adjudicable
+# only as false blocks — moving the pre-registered rate for a reason unrelated to
+# the predicate under test.
+# ---------------------------------------------------------------------------
+recae() { # recae <id> <ts> <repo> <branch> <token> <would_block> <advisory_emitted>
+  printf '{"record_id":"%s","ts":"%s","repo":"%s","branch":"%s","session_token":"%s","predicate_version":'"${_PV}"',"action":"push","diff_base":"branch-local","impl_in_chain":true,"material_source":true,"impl_evidence_kind":"none","transcript_path":"/tmp/t.jsonl","gate":"push-implement","would_block":%s,"advisory_emitted":%s,"schema_version":4}\n' \
+    "$1" "$2" "$3" "$4" "$5" "$6" "$7" >> "$IMPLEMENT_SHADOW_LOG"
+}
+
+: > "$IMPLEMENT_SHADOW_LOG"; : > "$IMPLEMENT_ADJUDICATION_LOG"
+recae s1 "2026-08-01T10:00:00Z" "/repo/A" "feat/x" "tokS" true false
+recae r1 "2026-08-01T11:00:00Z" "/repo/A" "feat/y" "tokR" true true
+eq "a silent would-block episode is NOT in the rate population" "1" \
+   "$(status | grep -c 'would-block  *1')"
+eq "the silent episode is reported, not dropped" "1" \
+   "$(status | grep -c 'advisory-silent  *1')"
+eq "a silent episode is NOT counted as attestation-only" "1" \
+   "$(status | grep -c 'attestation-only  *0')"
+
+# --next must not spend operator time on a population that cannot contain a
+# false block, for the same reason attested records are never offered.
+: > "$IMPLEMENT_SHADOW_LOG"; : > "$IMPLEMENT_ADJUDICATION_LOG"
+recae s2 "2026-08-01T10:00:00Z" "/repo/A" "feat/x" "tokS" true false
+eq "--next does NOT offer an advisory-silent record" "" \
+   "$("$SCRIPT" --next 2>/dev/null | grep -c '^s2' | tr -d ' ' | sed 's/^0$//')"
+
+# THE DIRECTION-OF-SAFETY RULE, and it is the opposite of would_block's.
+# Excluding an episode biases the rate toward CLEARING the deny-flip, so an
+# absent or malformed advisory_emitted must resolve to "assume the leg spoke"
+# and STAY IN. A producer bug that drops the field then costs a possibly
+# spurious episode in the denominator, never a silently smaller population.
+: > "$IMPLEMENT_SHADOW_LOG"; : > "$IMPLEMENT_ADJUDICATION_LOG"
+recwb m1 "2026-08-01T10:00:00Z" "/repo/A" "feat/x" "tokM" true
+eq "a record with NO advisory_emitted stays in the rate population" "1" \
+   "$(status | grep -c 'would-block  *1')"
+: > "$IMPLEMENT_SHADOW_LOG"; : > "$IMPLEMENT_ADJUDICATION_LOG"
+recae m2 "2026-08-01T10:00:00Z" "/repo/A" "feat/x" "tokM" true '"yes"'
+eq "a NON-BOOLEAN advisory_emitted stays in the rate population" "1" \
+   "$(status | grep -c 'would-block  *1')"
+
+# A mixed episode keeps counting: only an episode whose would-block records are
+# ALL silent is excluded. Narrowing that would drop episodes the rate is
+# entitled to, and the ANY rule must stay anchor-independent, so both orders are
+# pinned.
+: > "$IMPLEMENT_SHADOW_LOG"; : > "$IMPLEMENT_ADJUDICATION_LOG"
+recae x1 "2026-08-01T10:00:00Z" "/repo/A" "feat/x" "tokX" true false
+recae x2 "2026-08-01T10:05:00Z" "/repo/A" "feat/x" "tokX" true true
+eq "mixed episode (silent first) still counts" "1" "$(status | grep -c 'would-block  *1')"
+: > "$IMPLEMENT_SHADOW_LOG"; : > "$IMPLEMENT_ADJUDICATION_LOG"
+recae y1 "2026-08-01T10:00:00Z" "/repo/A" "feat/x" "tokY" true true
+recae y2 "2026-08-01T10:05:00Z" "/repo/A" "feat/x" "tokY" true false
+eq "mixed episode (speaking first) still counts" "1" "$(status | grep -c 'would-block  *1')"
 eq "...and is NOT silently counted as attestation-only" "0" \
    "$(status | grep -c 'attestation-only  *1')"
 


### PR DESCRIPTION
Found by a four-panelist adjudication pass over the IMPLEMENT shadow corpus (three Claude lenses plus a cross-family run). Three of the twelve v4 would-block episodes turned out to have a premise the predicate never established, from two unrelated defects — and every one of the twelve gated commands was written in the shape that triggers them: `2>&1 | tail -N`.

## Defect 1 — a redirection operand read as a pull-request reference

`pr_ref_from_command` counts digit-leading tokens after the merge subcommand and refuses when more than one appears, so a plausible-but-wrong label is never emitted. A stderr redirection is digit-leading.

Measured: **14 of 14** merge records across 39 days carry `diff_base: unresolved`. That leg has never once produced a measurement in production. This is the same defect class as #238, and `git-command.sh` already carried the structural helper for it, which was never applied here. Reused rather than reimplemented, because a hand-written list of redirection spellings is precisely the shape this predicate family has been bypassed by repeatedly.

## Defect 2 — a deletion-shaped command recorded as a content push

A trailing pipeline stage is a segment the inert-segment whitelist cannot vouch for, so strict certification is lost, the subject falls back to the checkout HEAD, and the leg then states that the push edits source about a command that ships nothing.

**This half is deliberately not fixed by widening the parser.** The right-hand side of a pipe executes arbitrarily, so vouching for `tail` would mean distinguishing it from an arbitrary program by name. The refusal is correct.

What was wrong is the consequence. The repo's own justification for the lost certification — one-directional, never a new deny — holds for **enforcement** and does not transfer to **measurement**, or to what the gate says. So a second, deliberately weaker predicate governs only the sentence and the corpus record, while strict certification keeps governing every gate skip. A mutation that swaps the weak form in at a gate site fails armed-deny cells; that asymmetry is the design, and conflating the two is what nearly shipped a false allow when this predicate family was first written.

## Rate membership stops being an inference

The shadow record gains `advisory_emitted`, and the population is that field rather than something derived from `would_block` — which is passed as a literal on the merge path and so asserts a block the leg would not perform.

Unknown-handling is inverted relative to its neighbour, and the tests say so: excluding an episode biases the measured rate toward clearing the warn-to-deny flip, so an absent or malformed value resolves to inclusion.

## Version bump

`predicate_version` 4 → 5, `schema_version` 3 → 4. Both changes alter when the leg fires, which forces the bump under this repo's own rule, so v4 records must not be pooled with v5.

Measured before taking it: 12 v4 episodes, at least 3 of them known-bad, against a floor of 29 — the exact rule needs 0.9^n below 0.05, and n=12 gives 0.282. Nothing measurable is discarded. **On merge, the v4 population is formally retired.**

## Also in here

An advisory leg's deletion skip had no coverage at all: swapping that one line to the weaker predicate ran the entire push-gate suite green. It never denies, so no deny was at risk, but an unpinned skip is how a predicate migrates from the advisory path onto the gate path. Now pinned, with a same-branch control so the cell cannot pass for the wrong reason.

Three comments corrected where they claimed something the code does not do — including one that argued against a coercion on the line directly above the coercion.

## Review and verification

A cross-family sparring pass, then a first Claude review that returned no blocking findings and independently reproduced the evaluator-surface pin and the redirection fix across 20 command shapes.

Full suite: 131 files run, 131 passed. Verdict clean and bound to this branch's HEAD, `test_delta: covered`.

## Specs

`openspec/changes/gate-parser-subject-defects/`.

Related: #248 covers a separate finding from the same pass — the remedy this leg names is not followable in the repos where it fires.
