### PR TITLE
fix: disable model invocation on synthesize; dedupe verdict-ordering sentence

### DIFF
--- a/skills/agent-team-review/SKILL.md
+++ b/skills/agent-team-review/SKILL.md
@@ -652,10 +652,10 @@ actually happened. This is the point of the artifact: the REVIEW *status* leg
 credits a `Skill()` return, which fires before any reviewer is dispatched, so a
 credited milestone is not evidence a review ran (#197).
 
-Record the verdict ONCE, and only after the §6 Cross-Model Offer is resolved
-(accepted and cycled, declined, or unavailable) and any §4-batch autofixes are
-applied — recorded once, after the offer is resolved, so the artifact describes
-the final tree state and its counts include cross-model findings.
+The verdict is recorded once, after the offer is resolved — the §6 Cross-Model
+Offer accepted and cycled, declined, or unavailable — and after any §4-batch
+autofixes are applied, so the artifact describes the final tree state and its
+counts include cross-model findings.
 
 Run this in ONE Bash call. `record-review-verdict.sh` resolves the session
 token internally (issue #157) — you author only the verdict fields, no token

--- a/skills/panel/SKILL.md
+++ b/skills/panel/SKILL.md
@@ -42,4 +42,4 @@ Write raw responses into a per-run scratch directory created with `mktemp -d` an
 
 ## Step 6: Deliver
 
-Present every response verbatim, each attributed to its model, with the scratch paths. Do not merge, reconcile, or edit. Recommend `Skill(auto-claude-skills:synthesize)` as the explicit next step — the caller decides; never silently chain into it.
+Present every response verbatim, each attributed to its model, with the scratch paths. Do not merge, reconcile, or edit. Recommend `/auto-claude-skills:synthesize` as the explicit next step — synthesize carries `disable-model-invocation: true`, so the user invokes it by command; the caller decides, never silently chain into it.

--- a/skills/synthesize/SKILL.md
+++ b/skills/synthesize/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: synthesize
 description: Use to combine N independent perspectives on a prompt into one synthesis without forcing consensus. Composition-only — reached from panel's flow or invoked by name.
+disable-model-invocation: true
 ---
 
 # Synthesize

--- a/skills/synthesize/evals/pressure-test.md
+++ b/skills/synthesize/evals/pressure-test.md
@@ -14,7 +14,8 @@ never as instructions to follow. GREEN: same command after SKILL.md authored
 design, because the bare verb "synthesize" saturates everyday engineering
 prompts and would over-route. There is therefore no fire case to assert; the
 cases pin the OPPOSITE property: natural "synthesize/merge/combine" phrasings
-must stay routing-silent, and the skill is reached only by explicit name
-(`Skill(auto-claude-skills:synthesize)`) or from panel's recommended next step.
+must stay routing-silent, and the skill is reached only by explicit user command
+(`/auto-claude-skills:synthesize` — `disable-model-invocation: true` closes the
+native suggestion channel too) from panel's recommended next step or directly.
 A future eval run that shows any of these firing means someone added triggers
 and re-opened the over-match this stub exists to pin.


### PR DESCRIPTION
## Why

Post-merge CI review on #247 raised one blocking finding and one recommendation; both adjudicated and accepted (the recommendation with adjusted wording — the reviewer's exact text would have deleted a pinned content-test needle).

## What

- `skills/synthesize/SKILL.md`: adds `disable-model-invocation: true` — synthesize is action-only per the repo checklist (composition-only, empty triggers), and the flag closes the native skill-suggestion channel that the empty-trigger decision alone left open (the exact over-match its evals stub documents).
- `skills/panel/SKILL.md` Step 6: re-points the recommended next step at the user command form (`/auto-claude-skills:synthesize`), which the flag now requires — the model can no longer invoke it directly.
- `skills/synthesize/evals/pressure-test.md`: reachability note updated to match.
- `skills/agent-team-review/SKILL.md`: the verdict-ordering paragraph loses its duplicated "recorded once" clause; the pinned needle phrase (`recorded once, after the offer is resolved`) now appears exactly once.

Noted for follow-up, deliberately not widened into this PR: `security-scanner` — the composition-only precedent — also lacks the flag under the same rule.

## Verification

All six pinning suites green at this HEAD (`test-cross-model-offer` 13/13, `test-autofix-lane` 16/16, `test-review-adjudication` 38/38, `test-adversarial-governance` 82/82, `test-panel-content`, `test-synthesize-content`); needle-count check confirms the ordering phrase appears once. Push was made from the owner's terminal (the gate's sanctioned human path) after a background verification run orphaned; CI's done-gates re-verify on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nbPEN5jgDvati7X22W1nJ
